### PR TITLE
"use" statement in homepage unneeded

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,8 +127,6 @@
 	  <div class="span10">
 
 <pre class="cm-s-default">
-<span class="cm-keyword">use</span> <span class="cm-variable-2">core</span>::*;
-
 <span class="cm-keyword">fn</span> <span class="cm-def">main</span>() {
     <span class="cm-keyword">for</span> [<span class="cm-string">"Alice"</span>, <span class="cm-string">"Bob"</span>, <span class="cm-string">"Carol"</span>].<span class="cm-variable">each</span> |&amp;<span class="cm-variable">name</span>| {
         <span class="cm-keyword">do</span> <span class="cm-variable-2">task::</span><span class="cm-variable">spawn</span> {


### PR DESCRIPTION
Seems silly to have "dead" code on the homepage example.
