### PR TITLE
Core/Std -> Standard/Extra

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,8 +32,8 @@
                 <ul class="docs">
                   <li><a href="http://doc.rust-lang.org/doc/tutorial.html">Tutorial</a></li>
                   <li><a href="http://doc.rust-lang.org/doc/rust.html">Manual</a></li>
-                  <li><a href="http://doc.rust-lang.org/doc/core/index.html">Core</a> |
-                      <a href="http://doc.rust-lang.org/doc/std/index.html">Standard</a></li>
+                  <li><a href="http://doc.rust-lang.org/doc/std/index.html">Standard</a> |
+                      <a href="http://doc.rust-lang.org/doc/extra/index.html">Extra</a></li>
                 </ul>
               </li>
               <li><div class="doc-rev">0.6</div>


### PR DESCRIPTION
This commit re-aligns the link to the Trunk docs with what actually exists today.
