### PR TITLE
Tweak example for 0.8

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,17 +128,16 @@
 
 	  <div class="span10">
 
-<pre class="cm-s-default"><span class="cm-keyword">fn</span> <span class="cm-def">main</span>() {
-    <span class="cm-keyword">let</span> <span class="cm-def">nums</span> = [<span class="cm-number">0</span>, <span class="cm-number">1</span>, <span class="cm-number">2</span>, <span class="cm-number">3</span>];
-    <span class="cm-keyword">let</span> <span class="cm-def">noms</span> = [<span class="cm-string">&quot;Tim&quot;</span>, <span class="cm-string">&quot;Eston&quot;</span>, <span class="cm-string">&quot;Aaron&quot;</span>, <span class="cm-string">&quot;Ben&quot;</span>];
-
-    <span class="cm-keyword">let</span> <span class="cm-keyword">mut</span> <span class="cm-def">evens</span> = <span class="cm-variable">nums</span>.<span class="cm-variable">iter</span>().<span class="cm-variable">filter</span>(|<span class="cm-variable">x</span>| **<span class="cm-variable">x</span> % <span class="cm-number">2</span> == <span class="cm-number">0</span>);
-
-    <span class="cm-keyword">for</span> &amp;<span class="cm-def">num</span> <span class="cm-keyword">in</span> <span class="cm-def">evens</span> {
+<pre class="cm-s-default">
+<span class="cm-keyword">fn</span> <span class="cm-def">main</span>() {
+    <span class="cm-keyword">let</span> <span class="cm-def">nums</span> = [<span class="cm-number">1</span>, <span class="cm-number">2</span>];
+    <span class="cm-keyword">let</span> <span class="cm-def">noms</span> = [<span class="cm-string">"Tim"</span>, <span class="cm-string">"Eston"</span>, <span class="cm-string">"Aaron"</span>, <span class="cm-string">"Ben"</span>];
+&nbsp;
+    <span class="cm-keyword">let</span> <span class="cm-def">mut</span> <span class="cm-def">odds</span> = <span class="cm-variable">nums</span>.<span class="cm-variable">iter</span>().<span class="cm-variable">map</span>(|&amp;<span class="cm-variable">x</span>| <span class="cm-variable">x</span> * <span class="cm-number">2</span> - <span class="cm-number">1</span>);
+&nbsp;
+    <span class="cm-keyword">for</span> <span class="cm-def">num</span> <span class="cm-keyword">in</span> <span class="cm-variable">odds</span> {
         <span class="cm-keyword">do</span> <span class="cm-variable">spawn</span> {
-            <span class="cm-keyword">let</span> <span class="cm-def">msg</span> = <span class="cm-variable">fmt</span>!(<span class="cm-string">&quot;%s says hello from a lightweight thread!&quot;</span>,
-                           <span class="cm-variable">noms</span>[<span class="cm-variable">num</span>]);
-            <span class="cm-variable">println</span>(<span class="cm-variable">msg</span>);
+            <span class="cm-variable">println</span>!(<span class="cm-string">"{:s} says hello from a lightweight thread!"</span>, <span class="cm-variable">noms</span>[<span class="cm-variable">num</span>]);
         }
     }
 }


### PR DESCRIPTION
Old example was showing off the old `fmt!` macro rather than our new `format!` style.

I also changed the HOF from a filter to a map, since it's less perplexing at first sight to new users.

You can see the new example live at http://seleniac.org/rust-www/
