### PR TITLE
Move infobox headers from left to above

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -27,18 +27,14 @@ ul.menu li>ul {
 	line-height: 1.5em;
 }
 
-.col-md-3 h2 {
+.boxhead h2 {
 	font-weight: bold;
 	font-size: 1.1em;
 	line-height: 24px;
 	margin-left: 10px;
 	margin-right: 10px;
 }
-@media (min-width: 992px) {
-	.col-md-3 h2 {
-		text-align: right;
-	}
-}
+
 .table-features {
 	width: 100%;
 	margin-bottom: 18px;

--- a/index.html
+++ b/index.html
@@ -85,10 +85,12 @@
 			</p>
 
 			<div class="row">
-				<div class="col-md-3">
+				<div class="col-md-12 boxhead">
 					<h2>A short summary of features</h2>
 				</div>
-				<div class="col-md-9">
+      </div>
+      <div class="row">
+				<div class="col-md-12">
 					<table class="table-features table-hover"><tbody>
 						<tr><td>Type system</td><td>static, nominal, linear, algebraic, locally inferred</td></tr>
 						<tr><td>Memory safety</td><td>no null or dangling pointers, no buffer overflows</td></tr>
@@ -102,10 +104,12 @@
 				</div>
 			</div>
 			<div class="row">
-				<div class="col-md-3">
+				<div class="col-md-12 boxhead">
 					<h2>A very small taste of what it looks like</h2>
 				</div>
-				<div class="col-md-9">
+      </div>
+      <div class="row">
+				<div class="col-md-12">
 <pre class="cm-s-default">
 <span class="cm-keyword">fn</span> <span class="cm-def">main</span>() {
     <span class="cm-keyword">let</span> <span class="cm-def">nums</span> = [<span class="cm-number">1</span>, <span class="cm-number">2</span>];


### PR DESCRIPTION
On my display, the code is long enough that it wraps, which is ugly.
We could just make the code shorter, but there's a better solution.
The low-resolution responsive view puts the infobox headers _above_,
rather than to the left, which not only wastes less space but also
just plain looks better. So let's just do that on the high-res view.
