### PR TITLE
Bring back the 'Fork me' ribbon, but only for large displays

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -45,3 +45,13 @@ ul.menu li>ul {
 	padding: 6px 12px;
 	border: none;
 }
+
+@media (min-width: 992px) {
+	img.ribbon {
+		display: inline !important;
+		position: absolute;
+		top: 0;
+		right: 0;
+		border: 0;
+	}
+}

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
 	</head>
 
 	<body class="container">
+		<a href="//github.com/mozilla/rust"><img class="ribbon" style="display: none" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"></a>
 		<ul class="row menu">
 			<li class="col-xs-2 col-md-2">
 				<img class="img-responsive" src="logos/rust-logo-128x128-blk-v2.png" height="128" width="128" alt="Rust logo" />


### PR DESCRIPTION
@brson I see you removed the banner in 498e245d007d0efb92b10733ab970a4daaef27fa, but that one is black and gets enabled only on 992px+ width so I think it looks good. You tell me!
