### PR TITLE
Add link to nightly builds on homepage under "Downloads"

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,9 @@
 					<li>
 						<a href="https://github.com/mozilla/rust/wiki/Doc-releases">Previous releases</a>
 					</li>
+					<li>
+						<a href="https://github.com/mozilla/rust/wiki/Doc-packages,-editors,-and-other-tools">Nightly builds</a>
+					</li>
 				</ul>
 			</li>
 			<li class="col-xs-2 col-md-2"><h2>Community</h2>


### PR DESCRIPTION
I think this is more important than linking to the unsupported 0.8 release.
