### PR TITLE
Link to the main docs per https://github.com/mozilla/rust/pull/11123

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,38 +17,41 @@
 			</li>
 			<li class="col-xs-2 col-md-2"><h2>Getting Started</h2>
 				<ul>
-					<li><a href="http://doc.rust-lang.org/doc/0.8/tutorial.html">Tutorial</a> (0.8)</li>
-					<li><a href="http://doc.rust-lang.org/doc/0.8/rust.html">Manual</a> (0.8)</li>
 					<li><a href="http://doc.rust-lang.org/doc/master/tutorial.html">Tutorial</a> (master)</li>
 					<li><a href="http://doc.rust-lang.org/doc/master/rust.html">Manual</a> (master)</li>
+					<li><a href="http://doc.rust-lang.org/doc/0.9/tutorial.html">Tutorial</a> (0.9)</li>
+					<li><a href="http://doc.rust-lang.org/doc/0.9/rust.html">Manual</a> (0.9)</li>
 				</ul>
 			</li>
 			<li class="col-xs-2 col-md-2"><h2>Documentation</h2>
 				<ul>
 					<li>
-						<a href="http://doc.rust-lang.org/doc/0.8/std/index.html">std</a> |
-						<a href="http://doc.rust-lang.org/doc/0.8/extra/index.html">extra</a> (0.8)
-					</li>
-					<li>
 						<a href="http://doc.rust-lang.org/doc/master/std/index.html">std</a> |
 						<a href="http://doc.rust-lang.org/doc/master/extra/index.html">extra</a> (master)
 					</li>
 					<li>
-						<a href="http://static.rust-lang.org/doc/master/index.html">Main Docs</a>
+						<a href="http://doc.rust-lang.org/doc/0.9/std/index.html">std</a> |
+						<a href="http://doc.rust-lang.org/doc/0.9/extra/index.html">extra</a> (0.9)
+					</li>
+					<li>
+						<a href="http://static.rust-lang.org/doc/master/index.html">Other docs</a> (master)
+					</li>
+					<li>
+						<a href="http://static.rust-lang.org/doc/0.9/index.html">Other docs</a> (0.9)
 					</li>
 				</ul>
 			</li>
 			<li class="col-xs-2 col-md-2"><h2>Downloads</h2>
 				<ul>
 					<li>
-						0.8 - Sep. 26 2013
+						0.9 - Jan. 9, 2014
 					</li>
 					<li>
-						<a href="http://static.rust-lang.org/dist/rust-0.8.tar.gz">.tar.gz</a> |
-						<a href="http://static.rust-lang.org/dist/rust-0.8-install.exe">.exe</a>
+						<a href="http://static.rust-lang.org/dist/rust-0.9.tar.gz">.tar.gz</a> |
+						<a href="http://static.rust-lang.org/dist/rust-0.9-install.exe">.exe</a>
 					</li>
 					<li>
-						<a href="https://github.com/mozilla/rust/blob/0.8/RELEASES.txt">Release notes</a>
+						<a href="https://github.com/mozilla/rust/blob/0.9/RELEASES.txt">Release notes</a>
 					</li>
 					<li>
 						<a href="https://github.com/mozilla/rust/wiki/Doc-releases">Previous releases</a>


### PR DESCRIPTION
According to this PR https://github.com/mozilla/rust/pull/11123

We're moving away from the wikis and we need to redirect users to this new transcribed internal documentation page.
# NOTE

This new documentation page will link to 0.9, which is not yet released. In case of this PR being ok, we need to deploy right after rust cuts the release to 0.9
