### PR TITLE
Update for upstream changes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -56,61 +56,15 @@ ul.menu li>ul {
 	}
 }
 
+pre { background-color: #FDFDFD; }
+
 /* Code highlighting */
-.cm-s-default span.cm-keyword {
-	color: #803C8D;
-}
-.cm-s-default span.cm-atom {
-	color: #221199;
-}
-.cm-s-default span.cm-number {
-	color: #2AA198;
-}
-.cm-s-default span.cm-def {
-	color: #256EB8;
-}
-.cm-s-default span.cm-variable {
-	color: black;
-}
-.cm-s-default span.cm-variable-2 {
-	color: #817E61;
-}
-.cm-s-default span.cm-variable-3 {
-	color: #008855;
-}
-.cm-s-default span.cm-property {
-	color: black;
-}
-.cm-s-default span.cm-operator {
-	color: black;
-}
-.cm-s-default span.cm-comment {
-	color: #A82323;
-}
-.cm-s-default span.cm-string {
-	color: #866544;
-}
-.cm-s-default span.cm-string-2 {
-	color: #FF5500;
-}
-.cm-s-default span.cm-meta {
-	color: #555555;
-}
-.cm-s-default span.cm-error {
-	color: #FF0000;
-}
-.cm-s-default span.cm-qualifier {
-	color: #555555;
-}
-.cm-s-default span.cm-builtin {
-	color: #3300AA;
-}
-.cm-s-default span.cm-bracket {
-	color: #999977;
-}
-.cm-s-default span.cm-tag {
-	color: #117700;
-}
-.cm-s-default span.cm-attribute {
-	color: #0000CC;
-}
+pre.rust .kw { color: #8959A8; }
+pre.rust .kw-2, pre.rust .prelude-ty { color: #4271AE; }
+pre.rust .number, pre.rust .string { color: #718C00; }
+pre.rust .self, pre.rust .boolval, pre.rust .prelude-val,
+pre.rust .attribute, pre.rust .attribute .ident { color: #C82829; }
+pre.rust .comment { color: #8E908C; }
+pre.rust .doccomment { color: #4D4D4C; }
+pre.rust .macro, pre.rust .macro-nonterminal { color: #3E999F; }
+pre.rust .lifetime { color: #B76514; }

--- a/index.html
+++ b/index.html
@@ -27,14 +27,11 @@
 				<ul>
 					<li>
 						<a href="http://doc.rust-lang.org/doc/master/std/index.html">std</a> |
-						<a href="http://doc.rust-lang.org/doc/master/extra/index.html">extra</a> (master)
+						<a href="http://static.rust-lang.org/doc/master/index.html">docs</a> (master)
 					</li>
 					<li>
 						<a href="http://doc.rust-lang.org/doc/0.9/std/index.html">std</a> |
 						<a href="http://doc.rust-lang.org/doc/0.9/extra/index.html">extra</a> (0.9)
-					</li>
-					<li>
-						<a href="http://static.rust-lang.org/doc/master/index.html">Other docs</a> (master)
 					</li>
 					<li>
 						<a href="http://static.rust-lang.org/doc/0.9/index.html">Other docs</a> (0.9)
@@ -115,17 +112,17 @@
 					<h2>A very small taste of what it looks like</h2>
 				</div>
 				<div class="col-md-10">
-<pre class="cm-s-default">
-<span class="cm-keyword">fn</span> <span class="cm-def">main</span>() {
-    <span class="cm-keyword">let</span> <span class="cm-def">nums</span> = [<span class="cm-number">1</span>, <span class="cm-number">2</span>];
-    <span class="cm-keyword">let</span> <span class="cm-def">noms</span> = [<span class="cm-string">"Tim"</span>, <span class="cm-string">"Eston"</span>, <span class="cm-string">"Aaron"</span>, <span class="cm-string">"Ben"</span>];
-&nbsp;
-    <span class="cm-keyword">let</span> <span class="cm-def">mut</span> <span class="cm-def">odds</span> = <span class="cm-variable">nums</span>.<span class="cm-variable">iter</span>().<span class="cm-variable">map</span>(|&amp;<span class="cm-variable">x</span>| <span class="cm-variable">x</span> * <span class="cm-number">2</span> - <span class="cm-number">1</span>);
-&nbsp;
-    <span class="cm-keyword">for</span> <span class="cm-def">num</span> <span class="cm-keyword">in</span> <span class="cm-variable">odds</span> {
-        <span class="cm-keyword">do</span> <span class="cm-variable">spawn</span> {
-            <span class="cm-variable">println</span>!(<span class="cm-string">"{:s} says hello from a lightweight thread!"</span>, <span class="cm-variable">noms</span>[<span class="cm-variable">num</span>]);
-        }
+<pre class='rust'>
+<span class='kw'>fn</span> <span class='ident'>main</span>() {
+    <span class='kw'>let</span> <span class='ident'>nums</span> <span class='op'>=</span> [<span class='number'>1</span>, <span class='number'>2</span>];
+    <span class='kw'>let</span> <span class='ident'>noms</span> <span class='op'>=</span> [<span class='string'>&quot;Tim&quot;</span>, <span class='string'>&quot;Eston&quot;</span>, <span class='string'>&quot;Aaron&quot;</span>, <span class='string'>&quot;Ben&quot;</span>];
+
+    <span class='kw'>let</span> <span class='kw-2'>mut</span> <span class='ident'>odds</span> <span class='op'>=</span> <span class='ident'>nums</span>.<span class='ident'>iter</span>().<span class='ident'>map</span>(<span class='op'>|</span><span class='kw-2'>&amp;</span><span class='ident'>x</span><span class='op'>|</span> <span class='ident'>x</span> <span class='op'>*</span> <span class='number'>2</span> <span class='op'>-</span> <span class='number'>1</span>);
+
+    <span class='kw'>for</span> <span class='ident'>num</span> <span class='kw'>in</span> <span class='ident'>odds</span> {
+        <span class='ident'>spawn</span>(<span class='kw'>proc</span>() {
+            <span class='macro'>println</span><span class='macro'>!</span>(<span class='string'>&quot;{:s} says hello from a lightweight thread!&quot;</span>, <span class='ident'>noms</span>[<span class='ident'>num</span>]);
+        });
     }
 }
 </pre>


### PR DESCRIPTION
- remove `libextra` URL
- merge in new highlighting syntax, forward-port the code sample and pass it through rustdoc

r? @brson
