### PR TITLE
Changed "Other docs" to "All docs". Changed "docs" link to "all docs"

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,14 +27,14 @@
 				<ul>
 					<li>
 						<a href="http://doc.rust-lang.org/doc/master/std/index.html">std</a> |
-						<a href="http://static.rust-lang.org/doc/master/index.html">docs</a> (master)
+						<a href="http://static.rust-lang.org/doc/master/index.html">all docs</a> (master)
 					</li>
 					<li>
 						<a href="http://doc.rust-lang.org/doc/0.9/std/index.html">std</a> |
 						<a href="http://doc.rust-lang.org/doc/0.9/extra/index.html">extra</a> (0.9)
 					</li>
 					<li>
-						<a href="http://static.rust-lang.org/doc/0.9/index.html">Other docs</a> (0.9)
+						<a href="http://static.rust-lang.org/doc/0.9/index.html">All docs</a> (0.9)
 					</li>
 				</ul>
 			</li>


### PR DESCRIPTION
Downside: "all docs" seems to cause "(master)" to wrap to the next line when the browser window is set to half the width of a 1920x1080 monitor.
