### PR TITLE
Draw tab guides every two column instead of four

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -30,6 +30,7 @@ var editor = ace.edit("editor");
 var Range = ace.require('ace/range').Range;
 editor.setTheme("ace/theme/chrome");
 editor.getSession().setMode("ace/mode/rust");
+editor.getSession().setTabSize(2);
 editor.setShowPrintMargin(false);
 editor.renderer.setShowGutter(false);
 


### PR DESCRIPTION
This is completely untested. I have no idea what I’m doing.
