### PR TITLE
Changed URL from playtest to play

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -67,7 +67,7 @@ function runProgram(program, callback) {
   });
 
   // console.log("Sending", data);
-  req.open('POST', "http://playtest.rust-lang.org/evaluate.json", true);
+  req.open('POST', "http://play.rust-lang.org/evaluate.json", true);
   req.onload = function(e) {
     if (req.readyState === 4 && req.status === 200) {
       var result = JSON.parse(req.response).result;


### PR DESCRIPTION
The URL for the playpen is now http://play.rust-lang.org. The XMLHttpRequest has been modified to reflect this.
