### PR TITLE
Fix front-page static code integer inference section

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@ fn main() {
     // `*` or `/` means multiply or divide by 2</span>
 
     <span class='kw'>let</span> program = <span class='string'>"+ + * - /"</span>;
-    <span class='kw'>let</span> <span class='kw'>mut</span> accumulator = <span class='number'>0</span>;
+    <span class='kw'>let</span> <span class='kw'>mut</span> accumulator = <span class='number'>0i</span>;
 
     <span class='kw'>for</span> token in program.chars() {
         <span class='kw'>match</span> token {


### PR DESCRIPTION
The site loads the `static-code` section first then the `active-code` section. 
@huonw changed the active-code accumulator section in #41, and here's the corresponding update for the static-code accumulator section.

cc @alexcrichton
