### PR TITLE
Update install.html

### DIFF
--- a/install.html
+++ b/install.html
@@ -42,6 +42,13 @@ title: Install &middot; The Rust Programming Language
         </div>
       </div>
 
+      <div class="row">
+        <div class="col-md-offset-1 col-md-10">
+          <p>The easiest way to install the nightly binaries for your platform is to run this in your shell:</p>
+          <pre><code>$ curl -s http://www.rust-lang.org/rustup.sh | sudo sh</code></pre>
+        </div>
+      </div>
+
       <hr/>
 
       <div class="row">


### PR DESCRIPTION
I've found myself wanting to figure out where rustup.sh is, and unable to find it anyway on www.rust-lang.com. It seems to me that this should be listed on the downloads page, preferably near the nightly binaries.

I'm guessing other folks who are interested but not on the Rust reddit channel nor the rust developer listserve might not even know about this script.
