### PR TITLE
remove 'optional gc' from the homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,6 @@ title: The Rust Programming Language
         <li>type inference</li>
         <li>zero-cost abstractions</li>
         <li>guaranteed memory safety</li>
-        <li>optional garbage collection</li>
         <li>concurrency without data races</li>
         <li>minimal runtime</li>
         <li>efficient C bindings</li>


### PR DESCRIPTION
`Gc<T>` is neither real, nor a GC, nor a good idea. We shouldn't be encouraging this idea.
