### PR TITLE
Prefer i32 over int

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@ fn main() {
     // `*` or `/` means multiply or divide by 2
 
     let program = "+ + * - /";
-    let mut accumulator = 0i;
+    let mut accumulator = 0_i32;
 
     for token in program.chars() {
         match token {


### PR DESCRIPTION
We should avoid giving a wrong impression that `int` is a "default" type to choose.

`0 as i32` or `0_i32` (or `accumulator: i32`,) which is the best for the first Rust code people see?
