### PR TITLE
Add Link to Rust by Example

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -353,3 +353,8 @@ ul.laundry-list {
 #active-code, #editor {
 	background-color: #FAFAFA;
 }
+
+.more-examples {
+	text-align: right;
+	margin: 5px 10px 0 0;
+}

--- a/index.html
+++ b/index.html
@@ -97,6 +97,9 @@ fn main() {
 }
 </pre>
         </div>
+        <div class="more-examples">
+          <a href="http://rustbyexample.com/">More examples</a>
+        </div>
       </div>
     </div>
 


### PR DESCRIPTION
This is adds a link to rustbyexample.com below the code example.

This is basically the code @arthurtw suggested #71 in this [comment](https://github.com/rust-lang/rust-www/issues/71#issuecomment-66502526).
