### PR TITLE
Display the code editor as preformatted text

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -272,6 +272,7 @@ ul.laundry-list {
   min-height: 340px;
   font-size: 13px;
   font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
+  white-space: pre-wrap;
 }
 
 #active-code {


### PR DESCRIPTION
When going to the http://www.rust-lang.org/ with NoScript blocking all foreign assets, here's what my page looked like (since jsdelivr.net was blocked):
![screen shot 2014-12-12 at 23 43 26](https://cloud.githubusercontent.com/assets/632942/5422638/3b57ead2-825b-11e4-88aa-be8b026cea7f.png)

This PR is a one-line CSS fix (again without jsdelivr.net):
![screen shot 2014-12-12 at 23 53 58](https://cloud.githubusercontent.com/assets/632942/5422639/3f1e8dec-825b-11e4-9416-1e18dd3ed4b4.png)
