### PR TITLE
Piping curl to sudo bash considered harmful

### DIFF
--- a/install.html
+++ b/install.html
@@ -44,7 +44,8 @@ title: Install &middot; The Rust Programming Language
      <div class="row">
       <div class="col-md-offset-1 col-md-10">
         <p>Presently, the easiest way to install the nightly binaries for Linux and Mac is to run the <a href="https://static.rust-lang.org/rustup.sh">rustup.sh</a> script.</p>
-        <pre><code>$ curl -s https://static.rust-lang.org/rustup.sh | sudo sh</code></pre>
+        <pre><code>$ curl -s -o rustup.sh https://static.rust-lang.org/rustup.sh
+$ sudo sh rustup.sh</code></pre>
         <p>This will also install <a href="http://crates.io">Cargo</a>, Rust's package manager, which the other installers do not.</p>
       </div>
     </div>

--- a/install.html
+++ b/install.html
@@ -43,7 +43,7 @@ title: Install &middot; The Rust Programming Language
 
      <div class="row">
       <div class="col-md-offset-1 col-md-10">
-        <p>Presently, the easiest way to install the nightly binaries for Linux and Mac is to run this in your shell:</p>
+        <p>Presently, the easiest way to install the nightly binaries for Linux and Mac is to run the <a href="https://static.rust-lang.org/rustup.sh">rustup.sh</a> script.</p>
         <pre><code>$ curl -s https://static.rust-lang.org/rustup.sh | sudo sh</code></pre>
         <p>This will also install <a href="http://crates.io">Cargo</a>, Rust's package manager, which the other installers do not.</p>
       </div>


### PR DESCRIPTION
Following a discussion on twitter with @wycats about the safety, security and usability implications of curling a shell script into `sudo sh`, I made a few minor adjustments to the installation instructions.

1. Link to the [rustup.sh](https://static.rust-lang.org/rustup.sh) script so that users who wish to review the script can simply click on a hyper-link instead of manually copying the URL into their address bar.
2. Split the `curl | sudo sh` command into two separate commands. Now the `curl` command will download the `rustup.sh` script to a file. Again, this allows users to review the file before running it under sudo. This also leaves behind a "paper trail" for what and how Rust was installed onto their system.

I believe these changes respect the right of users to inspect how code is installed onto their systems, while being obtrusive to users who just want to install the latest Rust build right this second.