### PR TITLE
Use HTTPS links where possible

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,7 +11,7 @@
   </head>
 
   <body class="container">
-    <a href="//github.com/rust-lang/rust">
+    <a href="https://github.com/rust-lang/rust">
       <img class="ribbon" style="display: none" src="/logos/forkme.png" alt="Fork me on GitHub" width="298" height="298">
     </a>
 
@@ -46,13 +46,13 @@
       <li class="col-xs-4 col-md-2"><h2>Community</h2>
         <ul>
           <li>
-            <a href="http://github.com/rust-lang/rust">GitHub</a>
+            <a href="https://github.com/rust-lang/rust">GitHub</a>
           </li>
           <li>
             <a href="https://mail.mozilla.org/listinfo/rust-dev">Mailing List</a>
           </li>
           <li>
-            <a href="http://chat.mibbit.com/?server=irc.mozilla.org&amp;channel=%23rust">IRC</a>
+            <a href="https://chat.mibbit.com/?server=irc.mozilla.org&amp;channel=%23rust">IRC</a>
           </li>
           <li>
             <a href="http://blog.rust-lang.org">Blog</a>
@@ -62,13 +62,13 @@
       <li class="col-xs-4 col-md-2"><h2>&nbsp;</h2>
         <ul>
           <li>
-            <a href="http://reddit.com/r/rust">Reddit</a>
+            <a href="https://reddit.com/r/rust">Reddit</a>
           </li>
           <li>
-	    <a href="http://twitter.com/rustlang">Twitter</a>
+	    <a href="https://twitter.com/rustlang">Twitter</a>
           </li>
           <li>
-            <a href="http://stackoverflow.com/questions/tagged/rust">Stack Overflow</a>
+            <a href="https://stackoverflow.com/questions/tagged/rust">Stack Overflow</a>
           </li>
           <li>
             <a href="https://www.google.com/calendar/embed?src=apd9vmbc22egenmtu5l6c5jbfc%40group.calendar.google.com">Calendar</a>


### PR DESCRIPTION
This commit changes the hyper-links in `_layouts/default.html` to use
HTTPS rather than HTTP, where the referent Web-sites support HTTPS.
