### PR TITLE
Change "Show me more!" to link to nightly intro

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@ title: The Rust Programming Language
           prevents almost all crashes<span class="asterisk">*</span>,
           and eliminates data races.
           <br/>
-          <a href="http://doc.rust-lang.org/master/intro.html">Show me more!</a>
+          <a href="http://doc.rust-lang.org/nightly/intro.html">Show me more!</a>
         </p>
       </div>
       <div class="col-md-4 install-box">


### PR DESCRIPTION
The "Show me more!" link on the home page currently links to http://doc.rust-lang.org/master/intro.html, which 301 redirects to http://doc.rust-lang.org/nightly/intro.html; we can probably just link directly to the nightly intro.