### PR TITLE
Fix warning about unknown or unused feature

### DIFF
--- a/_includes/example.rs
+++ b/_includes/example.rs
@@ -1,5 +1,3 @@
-#![feature(core)]
-
 // This code is editable and runnable!
 fn main() {
     // A simple integer calculator:


### PR DESCRIPTION
Currently the sample on rust-lang.org compiles with a warning.