### PR TITLE
Move <script> into <body>

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -78,7 +78,6 @@
     </ul>
   </header>
       {{ content }}
-  </body>
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -89,4 +88,5 @@
       ga('send', 'pageview');
 
     </script>
+  </body>
 </html>


### PR DESCRIPTION
\<script\> elements aren't allowed to live outside \<body\> or \<head\>. As a result, this will also make the front page valid HTML