### PR TITLE
Rename "Reference" → "Lang reference"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+The Rust website ([www.rust-lang.org]())
+
+To preview your changes:
+
+    gem install jekyll
+    sudo yum install nodejs # install a javascript runtime; may not be necessary
+    PATH="$PATH:$HOME/bin" jekyll serve
+    # go to localhost:4000 or similar in a web browser!

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -28,7 +28,7 @@
           <li><a href="http://doc.rust-lang.org/book/">Book</a></li>
           <li><a href="http://doc.rust-lang.org/reference.html">Reference</a></li>
           <li>
-            <a href="http://doc.rust-lang.org/std/index.html">API docs</a></li>
+            <a href="http://doc.rust-lang.org/std/index.html">Library API</a></li>
             <li><a href="http://doc.rust-lang.org/index.html">All docs</a>
           </li>
         </ul>
@@ -38,7 +38,7 @@
           <li><a href="http://doc.rust-lang.org/1.0.0-alpha.2/book/">Book</a></li>
           <li><a href="http://doc.rust-lang.org/1.0.0-alpha.2/reference.html">Reference</a></li>
           <li>
-            <a href="http://doc.rust-lang.org/1.0.0-alpha.2/std/index.html">API docs</a></li>
+            <a href="http://doc.rust-lang.org/1.0.0-alpha.2/std/index.html">Library API</a></li>
             <li><a href="http://doc.rust-lang.org/1.0.0-alpha.2/index.html">All docs</a>
           </li>
         </ul>


### PR DESCRIPTION
because I got fed up clicking "Reference" and not getting to the library reference I wanted!

Note: would have been "Language reference", but I couldn't figure out the CSS magic to make the columns wide enough!