### PR TITLE
Updates for Rust 1.0

### DIFF
--- a/_includes/set_platform.js
+++ b/_includes/set_platform.js
@@ -21,9 +21,9 @@ function detect_platform() {
   "use strict";
   var platform = detect_platform();
 
-  var rec_package_name = "1.0.0-beta.5";
+  var rec_package_name = "1.0.0";
   var rec_version_type = "source";
-  var rec_download_file = "rustc-1.0.0-beta.5-src.tar.gz";
+  var rec_download_file = "rustc-1.0.0-src.tar.gz";
 
   if (platform == "x86_64-unknown-linux-gnu") {
     rec_version_type = "Linux binary";

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -23,13 +23,13 @@
           <img class="img-responsive" src="logos/rust-logo-blk.svg" onerror="this.src='logos/rust-logo-256x256-blk.png'" height="128" width="128" alt="Rust logo" />
         </a>
       </li>
-      <li class="col-xs-4 col-md-2"><h2>Docs (Beta)</h2>
+      <li class="col-xs-4 col-md-2"><h2>Docs (1.0.0)</h2>
         <ul>
-          <li><a href="http://doc.rust-lang.org/1.0.0-beta.5/book/">Book</a></li>
-          <li><a href="http://doc.rust-lang.org/1.0.0-beta.5/reference.html">Reference</a></li>
+          <li><a href="http://doc.rust-lang.org/stable/book/">Book</a></li>
+          <li><a href="http://doc.rust-lang.org/stable/reference.html">Reference</a></li>
           <li>
-            <a href="http://doc.rust-lang.org/1.0.0-beta.5/std/">API docs</a></li>
-            <li><a href="http://doc.rust-lang.org/1.0.0-beta.5/">All docs</a>
+            <a href="http://doc.rust-lang.org/stable/std/">API docs</a></li>
+            <li><a href="http://doc.rust-lang.org/stable/">All docs</a>
           </li>
         </ul>
       </li>

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@ title: The Rust Programming Language
           never segfaults,
           and guarantees thread safety.
           <br/>
-          <a href="http://doc.rust-lang.org/nightly/book/README.html">Show me more!</a>
+          <a href="http://doc.rust-lang.org/nightly/book/README.html">Show me!</a>
         </p>
       </div>
       <div class="col-md-4 install-box">

--- a/index.html
+++ b/index.html
@@ -8,8 +8,8 @@ title: The Rust Programming Language
         <p class="pitch">
           <b>Rust</b> is a systems programming language
           that runs blazingly fast,
-          prevents almost all crashes,
-          and eliminates data races.
+          never segfaults,
+          and guarantees thread safety.
           <br/>
           <a href="http://doc.rust-lang.org/nightly/book/README.html">Show me more!</a>
         </p>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@ title: The Rust Programming Language
         <p class="pitch">
           <b>Rust</b> is a systems programming language
           that runs blazingly fast,
-          prevents almost all crashes<span class="asterisk">*</span>,
+          prevents almost all crashes,
           and eliminates data races.
           <br/>
           <a href="http://doc.rust-lang.org/nightly/book/README.html">Show me more!</a>
@@ -57,11 +57,6 @@ title: The Rust Programming Language
         </div>
       </div>
     </div>
-
-    <p class="footnote">
-      <span class="asterisk">*</span>
-      In theory. Rust is a work-in-progress and may do anything it likes up to and including eating your laundry.
-    </p>
 
   <script type="text/javascript">
     {% include include.js %}

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@ title: The Rust Programming Language
         <p class="pitch">
           <b>Rust</b> is a systems programming language
           that runs blazingly fast,
-          never segfaults,
+          prevents nearly all segfaults,
           and guarantees thread safety.
           <br/>
           <a href="http://doc.rust-lang.org/nightly/book/README.html">Show me!</a>

--- a/index.html
+++ b/index.html
@@ -18,12 +18,12 @@ title: The Rust Programming Language
         <span class="version-rec-box-inner">
           Recommended Version:<br>
           <span id="install-version">
-            1.0.0-beta.5
+            1.0.0
             (<span>source</span>)
           </span>
         </span>
         <a class="btn btn-primary" id="inst-link"
-            href="https://static.rust-lang.org/dist/rustc-1.0.0-beta.5-src.tar.gz">Install</a>
+            href="https://static.rust-lang.org/dist/rustc-1.0.0-src.tar.gz">Install</a>
         <a class="btn btn-default" href="install.html" role="button">Other Downloads</a>
       </div>
     </div>

--- a/install.html
+++ b/install.html
@@ -158,10 +158,12 @@ title: Install &middot; The Rust Programming Language
       </div>
     </div>
 
+    <hr/>
+
     <div class="row">
       <div class="col-md-offset-1 col-md-11">
       <p>
-        <a href="http://static.rust-lang.org/dist/index.html">The archives.</a>
+        Discover other downloads in <a href="http://static.rust-lang.org/dist/index.html">the archives.</a>
       </p>
       </div>
     </div>

--- a/install.html
+++ b/install.html
@@ -29,12 +29,6 @@ title: Install &middot; The Rust Programming Language
           <td><a href="https://static.rust-lang.org/dist/rust-1.0.0-i686-apple-darwin.tar.gz"><div class="inst-button">32-bit</div></a></td>
           </tr>
           <tr>
-          <td class="inst-type">Windows installer (.exe)</td>
-          <td><a href="https://static.rust-lang.org/dist/rust-1.0.0-x86_64-pc-windows-gnu.exe"><div class="inst-button">64-bit</div></a></td>
-          <td><a href="https://static.rust-lang.org/dist/rust-1.0.0-i686-pc-windows-gnu.exe"><div class="inst-button">32-bit</div></a></td>
-          </tr>
-          <tr>
-          <tr>
           <td class="inst-type">Windows installer (.msi)</td>
           <td><a href="https://static.rust-lang.org/dist/rust-1.0.0-x86_64-pc-windows-gnu.msi"><div class="inst-button">64-bit</div></a></td>
           <td><a href="https://static.rust-lang.org/dist/rust-1.0.0-i686-pc-windows-gnu.msi"><div class="inst-button">32-bit</div></a></td>
@@ -80,11 +74,6 @@ title: Install &middot; The Rust Programming Language
           <td class="inst-type">Mac binaries (.tar.gz)</td>
           <td><a href="https://static.rust-lang.org/dist/rust-beta-x86_64-apple-darwin.tar.gz"><div class="inst-button">64-bit</div></a></td>
           <td><a href="https://static.rust-lang.org/dist/rust-beta-i686-apple-darwin.tar.gz"><div class="inst-button">32-bit</div></a></td>
-          </tr>
-          <tr>
-          <td class="inst-type">Windows installer (.exe)</td>
-          <td><a href="https://static.rust-lang.org/dist/rust-beta-x86_64-pc-windows-gnu.exe"><div class="inst-button">64-bit</div></a></td>
-          <td><a href="https://static.rust-lang.org/dist/rust-beta-i686-pc-windows-gnu.exe"><div class="inst-button">32-bit</div></a></td>
           </tr>
           <tr>
           <td class="inst-type">Windows installer (.msi)</td>
@@ -134,11 +123,6 @@ title: Install &middot; The Rust Programming Language
           <td class="inst-type">Mac binaries (.tar.gz)</td>
           <td><a href="https://static.rust-lang.org/dist/rust-nightly-x86_64-apple-darwin.tar.gz"><div class="inst-button">64-bit</div></a></td>
           <td><a href="https://static.rust-lang.org/dist/rust-nightly-i686-apple-darwin.tar.gz"><div class="inst-button">32-bit</div></a></td>
-          </tr>
-          <tr>
-          <td class="inst-type">Windows installer (.exe)</td>
-          <td><a href="https://static.rust-lang.org/dist/rust-nightly-x86_64-pc-windows-gnu.exe"><div class="inst-button">64-bit</div></a></td>
-          <td><a href="https://static.rust-lang.org/dist/rust-nightly-i686-pc-windows-gnu.exe"><div class="inst-button">32-bit</div></a></td>
           </tr>
           <tr>
           <td class="inst-type">Windows installer (.msi)</td>

--- a/install.html
+++ b/install.html
@@ -8,7 +8,7 @@ title: Install &middot; The Rust Programming Language
         <h2>1.0.0</h2>
         <h3>May 15, 2015</h3>
         <p>
-	  The current stable release of Rust, updated every six weeks.
+	  The current stable release of Rust, updated every six weeks and backwards-compatible.
         </p>
       </div>
       <div class="col-md-7">

--- a/install.html
+++ b/install.html
@@ -50,7 +50,7 @@ title: Install &middot; The Rust Programming Language
      <div class="row">
       <div class="col-md-offset-1 col-md-10">
         <p>An easy way to install the beta binaries for Linux and Mac is to run this in your shell:</p>
-        <pre><code>$ curl -s https://static.rust-lang.org/rustup.sh | sh</code></pre>
+        <pre><code>$ curl -sSf https://static.rust-lang.org/rustup.sh | sh</code></pre>
       </div>
     </div>
 
@@ -102,7 +102,7 @@ title: Install &middot; The Rust Programming Language
      <div class="row">
       <div class="col-md-offset-1 col-md-10">
         <p>An easy way to install the beta binaries for Linux and Mac is to run this in your shell:</p>
-        <pre><code>$ curl -s https://static.rust-lang.org/rustup.sh | sh -s -- --channel=beta</code></pre>
+        <pre><code>$ curl -sSf https://static.rust-lang.org/rustup.sh | sh -s -- --channel=beta</code></pre>
       </div>
     </div>
 
@@ -154,7 +154,7 @@ title: Install &middot; The Rust Programming Language
      <div class="row">
       <div class="col-md-offset-1 col-md-10">
         <p>An easy way to install the nightly binaries for Linux and Mac is to run this in your shell:</p>
-        <pre><code>$ curl -s https://static.rust-lang.org/rustup.sh | sh -s -- --channel=nightly</code></pre>
+        <pre><code>$ curl -sSf https://static.rust-lang.org/rustup.sh | sh -s -- --channel=nightly</code></pre>
       </div>
     </div>
 

--- a/install.html
+++ b/install.html
@@ -113,7 +113,9 @@ title: Install &middot; The Rust Programming Language
         <h2>Nightly</h2>
         <p>
         The current development branch.
-	It includes unstable features that are not available in the betas or stable releases.
+	It includes
+	<a href="http://doc.rust-lang.org/book/nightly-rust.html">unstable features</a>
+	that are not available in the betas or stable releases.
         </p>
       </div>
       <div class="col-md-7">

--- a/install.html
+++ b/install.html
@@ -5,43 +5,43 @@ title: Install &middot; The Rust Programming Language
 
     <div class="row install">
       <div class="col-md-offset-1 col-md-3 side-header">
-        <h2>1.0.0-beta.5</h2>
-        <h3>May 11, 2015</h3>
+        <h2>1.0.0</h2>
+        <h3>May 15, 2015</h3>
         <p>
-	  A feature-complete preview of the 1.0.0 release.
+	  The current stable release of Rust, updated every six weeks.
         </p>
       </div>
       <div class="col-md-7">
         <table class="table-features table-installers"><tbody>
           <tr>
           <td class="inst-type">Linux binaries (.tar.gz)</td>
-          <td><a href="https://static.rust-lang.org/dist/rust-1.0.0-beta.5-x86_64-unknown-linux-gnu.tar.gz"><div class="inst-button">64-bit</div></a></td>
-          <td><a href="https://static.rust-lang.org/dist/rust-1.0.0-beta.5-i686-unknown-linux-gnu.tar.gz"><div class="inst-button">32-bit</div></a></td>
+          <td><a href="https://static.rust-lang.org/dist/rust-1.0.0-x86_64-unknown-linux-gnu.tar.gz"><div class="inst-button">64-bit</div></a></td>
+          <td><a href="https://static.rust-lang.org/dist/rust-1.0.0-i686-unknown-linux-gnu.tar.gz"><div class="inst-button">32-bit</div></a></td>
           </tr>
           <tr>
           <td class="inst-type">Mac installer (.pkg)</td>
-          <td><a href="https://static.rust-lang.org/dist/rust-1.0.0-beta.5-x86_64-apple-darwin.pkg"><div class="inst-button">64-bit</div></a></td>
-          <td><a href="https://static.rust-lang.org/dist/rust-1.0.0-beta.5-i686-apple-darwin.pkg"><div class="inst-button">32-bit</div></a></td>
+          <td><a href="https://static.rust-lang.org/dist/rust-1.0.0-x86_64-apple-darwin.pkg"><div class="inst-button">64-bit</div></a></td>
+          <td><a href="https://static.rust-lang.org/dist/rust-1.0.0-i686-apple-darwin.pkg"><div class="inst-button">32-bit</div></a></td>
           </tr>
           <tr>
           <td class="inst-type">Mac binaries (.tar.gz)</td>
-          <td><a href="https://static.rust-lang.org/dist/rust-1.0.0-beta.5-x86_64-apple-darwin.tar.gz"><div class="inst-button">64-bit</div></a></td>
-          <td><a href="https://static.rust-lang.org/dist/rust-1.0.0-beta.5-i686-apple-darwin.tar.gz"><div class="inst-button">32-bit</div></a></td>
+          <td><a href="https://static.rust-lang.org/dist/rust-1.0.0-x86_64-apple-darwin.tar.gz"><div class="inst-button">64-bit</div></a></td>
+          <td><a href="https://static.rust-lang.org/dist/rust-1.0.0-i686-apple-darwin.tar.gz"><div class="inst-button">32-bit</div></a></td>
           </tr>
           <tr>
           <td class="inst-type">Windows installer (.exe)</td>
-          <td><a href="https://static.rust-lang.org/dist/rust-1.0.0-beta.5-x86_64-pc-windows-gnu.exe"><div class="inst-button">64-bit</div></a></td>
-          <td><a href="https://static.rust-lang.org/dist/rust-1.0.0-beta.5-i686-pc-windows-gnu.exe"><div class="inst-button">32-bit</div></a></td>
+          <td><a href="https://static.rust-lang.org/dist/rust-1.0.0-x86_64-pc-windows-gnu.exe"><div class="inst-button">64-bit</div></a></td>
+          <td><a href="https://static.rust-lang.org/dist/rust-1.0.0-i686-pc-windows-gnu.exe"><div class="inst-button">32-bit</div></a></td>
           </tr>
           <tr>
           <tr>
           <td class="inst-type">Windows installer (.msi)</td>
-          <td><a href="https://static.rust-lang.org/dist/rust-1.0.0-beta.5-x86_64-pc-windows-gnu.msi"><div class="inst-button">64-bit</div></a></td>
-          <td><a href="https://static.rust-lang.org/dist/rust-1.0.0-beta.5-i686-pc-windows-gnu.msi"><div class="inst-button">32-bit</div></a></td>
+          <td><a href="https://static.rust-lang.org/dist/rust-1.0.0-x86_64-pc-windows-gnu.msi"><div class="inst-button">64-bit</div></a></td>
+          <td><a href="https://static.rust-lang.org/dist/rust-1.0.0-i686-pc-windows-gnu.msi"><div class="inst-button">32-bit</div></a></td>
           </tr>
           <td class="inst-type">Source</td>
           <td colspan="2"><a
-              href="https://static.rust-lang.org/dist/rustc-1.0.0-beta.5-src.tar.gz"><div class="inst-button">rustc-1.0.0-beta.5-src.tar.gz</div></a></td>
+              href="https://static.rust-lang.org/dist/rustc-1.0.0-src.tar.gz"><div class="inst-button">rustc-1.0.0-src.tar.gz</div></a></td>
           </tr>
         </tbody></table>
       </div>
@@ -58,10 +58,62 @@ title: Install &middot; The Rust Programming Language
 
     <div class="row">
       <div class="col-md-3 col-md-offset-1 side-header">
+        <h2>Beta</h2>
+        <p>
+	A beta of the upcoming stable release, intended for testing by
+	crate authors. Updated as needed.
+        </p>
+      </div>
+      <div class="col-md-7">
+        <table class="table-features table-installers"><tbody>
+          <tr>
+          <td class="inst-type">Linux binaries (.tar.gz)</td>
+          <td><a href="https://static.rust-lang.org/dist/rust-beta-x86_64-unknown-linux-gnu.tar.gz"><div class="inst-button">64-bit</div></a></td>
+          <td><a href="https://static.rust-lang.org/dist/rust-beta-i686-unknown-linux-gnu.tar.gz"><div class="inst-button">32-bit</div></a></td>
+          </tr>
+          <tr>
+          <td class="inst-type">Mac installer (.pkg)</td>
+          <td><a href="https://static.rust-lang.org/dist/rust-beta-x86_64-apple-darwin.pkg"><div class="inst-button">64-bit</div></a></td>
+          <td><a href="https://static.rust-lang.org/dist/rust-beta-i686-apple-darwin.pkg"><div class="inst-button">32-bit</div></a></td>
+          </tr>
+          <tr>
+          <td class="inst-type">Mac binaries (.tar.gz)</td>
+          <td><a href="https://static.rust-lang.org/dist/rust-beta-x86_64-apple-darwin.tar.gz"><div class="inst-button">64-bit</div></a></td>
+          <td><a href="https://static.rust-lang.org/dist/rust-beta-i686-apple-darwin.tar.gz"><div class="inst-button">32-bit</div></a></td>
+          </tr>
+          <tr>
+          <td class="inst-type">Windows installer (.exe)</td>
+          <td><a href="https://static.rust-lang.org/dist/rust-beta-x86_64-pc-windows-gnu.exe"><div class="inst-button">64-bit</div></a></td>
+          <td><a href="https://static.rust-lang.org/dist/rust-beta-i686-pc-windows-gnu.exe"><div class="inst-button">32-bit</div></a></td>
+          </tr>
+          <tr>
+          <td class="inst-type">Windows installer (.msi)</td>
+          <td><a href="https://static.rust-lang.org/dist/rust-beta-x86_64-pc-windows-gnu.msi"><div class="inst-button">64-bit</div></a></td>
+          <td><a href="https://static.rust-lang.org/dist/rust-beta-i686-pc-windows-gnu.msi"><div class="inst-button">32-bit</div></a></td>
+          </tr>
+          <tr>
+          <td class="inst-type">Source</td>
+          <td colspan="2"><a href="https://static.rust-lang.org/dist/rustc-beta-src.tar.gz"><div class="inst-button">rustc-beta-src.tar.gz</div></a></td>
+          </tr>
+        </tbody></table>
+      </div>
+    </div>
+
+     <div class="row">
+      <div class="col-md-offset-1 col-md-10">
+        <p>An easy way to install the beta binaries for Linux and Mac is to run this in your shell:</p>
+        <pre><code>$ curl -s https://static.rust-lang.org/rustup.sh | sh -s -- --channel=beta</code></pre>
+      </div>
+    </div>
+
+    <hr/>
+
+    <div class="row">
+      <div class="col-md-3 col-md-offset-1 side-header">
         <h2>Nightly</h2>
         <p>
-        The current dev branch.
-        This is the most up to date version with the latest bug fixes and features.
+        The current development branch.
+	It includes unstable features that are not available in the betas or stable releases.
         </p>
       </div>
       <div class="col-md-7">


### PR DESCRIPTION
Do not merge yet.

This removes the asterisk about laundry, adds 1.0 links to the header, and a section of stable installers to install.html, adjusts the curl flags, removes .exe in favor of .msi.

One thing to note is that instead of adding additional stable links to the header I replaced beta with stable. It felt a bit overwhelming having a third set of duplicate links, and the beta docs seemed pretty dispensable.

cc @steveklabnik 