### PR TITLE
Changed reference to 'beta binaries' to 'stable binaries'

### DIFF
--- a/install.html
+++ b/install.html
@@ -43,7 +43,7 @@ title: Install &middot; The Rust Programming Language
 
      <div class="row">
       <div class="col-md-offset-1 col-md-10">
-        <p>An easy way to install the beta binaries for Linux and Mac is to run this in your shell:</p>
+        <p>An easy way to install the stable binaries for Linux and Mac is to run this in your shell:</p>
         <pre><code>$ curl -sSf https://static.rust-lang.org/rustup.sh | sh</code></pre>
       </div>
     </div>


### PR DESCRIPTION
The install page refers to "beta binaries" under both the 1.0.0 section and the beta section. I changed the instance of "beta binaries" under the 1.0.0 section to be "stable binaries" instead.