### PR TITLE
Display team-member's IRC nicks on hover.

### DIFF
--- a/team.md
+++ b/team.md
@@ -101,6 +101,19 @@ teams:
 }
 .lead { font-weight: bold; }
 .lead .name::after { content: " (lead)"; }
+.irc {
+  display: none;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: rgba(0, 0, 0, 0.5);
+  color: white;
+  font-weight: normal;
+}
+.person:hover .irc {
+   display: block;
+}
 
 .headshots {
   text-align: center;
@@ -129,6 +142,7 @@ rosters, in alphabetical order.
   <li class="person {% if team.lead and team.lead == github %}lead{% endif %}">
   <a href="https://github.com/{{ github }}">
     <div class="name">{{ person.name }}</div>
+    <div class="irc">irc: {% if person.irc %}{{ person.irc }}{% else %}{{ github }}{% endif %}</div>
     <img class="headshot" src="http://avatars.githubusercontent.com/{{ github }}">
   </a>
 </li>

--- a/team.md
+++ b/team.md
@@ -1,21 +1,106 @@
 ---
 layout: default
 title: The Rust Team
+
+# map from GH username to name & irc nick (irc nick can be omitted if it
+# matches GH).
+people:
+  aatch:
+    name: James Miller
+  alexcrichton:
+    name: Alex Crichton
+    irc: acrichto
+  aturon:
+    name: Aaron Turon
+  bkoropoff:
+    name: Brian Koropoff
+  brson:
+    name: Brian Anderson
+  BurntSushi:
+    name: Andrew Gallant
+    irc: burntsushi
+  dotdash:
+    name: Björn Steinbrink
+    irc: doener
+  eddyb:
+    name: Eduard Burtescu
+  erickt:
+    name: Erick Tryzelaar
+  Gankro:
+    name: Alexis Beingessner
+  huonw:
+    name: Huon Wilson
+    irc: huon
+  "jakub-":
+    name: Jakub Bukaj
+  Kimundi:
+    name: Marvin Löbel
+    irc: kimundi
+  manishearth:
+    name: Manish Goregaokar
+    irc: Manishearth
+  mbrubeck:
+    name: Matt Brubeck
+  michaelwoerister:
+    name: Michael Woerister
+    irc: mw
+  nikomatsakis:
+    name: Niko Matsakis
+    irc: nmatsakis
+  nrc:
+    name: Nick Cameron
+  pcwalton:
+    name: Patrick Walton
+  pnkfelix:
+    name: Felix Klock
+  sfackler:
+    name: Steven Fackler
+  steveklabnik:
+    name: Steve Klabnik
+  vadimcn:
+    name: Vadim Chugunov
+  wycats:
+    name: Yehuda Katz
+
+# Information about each team. Omit `lead` for teams without leaders.
+teams:
+  - name: Core
+    responsibility: "overall direction of the project, subteam leadership, cross-cutting concerns"
+    members: [brson, alexcrichton, wycats, steveklabnik, nikomatsakis, aturon, pcwalton, huonw]
+  - name: Language design
+    responsibility: "designing new language features"
+    members: [nrc, pnkfelix, nikomatsakis, aturon, huonw]
+    lead: nikomatsakis
+  - name: Library
+    responsibility: "the Rust standard library, rust-lang crates, conventions"
+    members: [brson, Gankro, alexcrichton, sfackler, BurntSushi, Kimundi, aturon, huonw]
+    lead: aturon
+  - name: Compiler
+    responsibility: "compiler internals, optimizations"
+    members: ["jakub-", eddyb, nrc, pnkfelix, bkoropoff, nikomatsakis, aatch, dotdash, michaelwoerister]
+    lead: nikomatsakis
+  - name: Tooling and infrastructure
+    responsibility: "tool support (e.g. Cargo, multirust), CI infrastructure, etc."
+    members: [brson, nrc, alexcrichton, vadimcn, wycats, michaelwoerister]
+    lead: alexcrichton
+  - name: Moderation
+    responsibility: "helping uphold the [code of conduct](http://www.rust-lang.org/conduct.html)"
+    members: [mbrubeck, BurntSushi, manishearth, pnkfelix, erickt]
 ---
 
 <style type="text/css">
 .headshot {
   border: 1px solid #888;
-  margin-bottom: 10px;
   width: 140px;
 }
 
 .person {
   display: inline-block;
+  position: relative;
+  margin-bottom: 20px;
 }
-.lead {
-  font-weight: bold;
-}
+.lead { font-weight: bold; }
+.lead .name::after { content: " (lead)"; }
 
 .headshots {
   text-align: center;
@@ -33,126 +118,21 @@ The Rust project is [governed](https://github.com/rust-lang/rfcs/blob/master/tex
 number of teams, each focused on a specific area of concern. Below are the
 rosters, in alphabetical order.
 
-## Core team
+{% for team in page.teams %}
+## {{ team.name }} team
 
-**Responsibility**: *overall direction of the project, subteam leadership, cross-cutting concerns*
-
-<ul class="headshots">
-  <li class="person"><a href="https://github.com/brson/">Brian Anderson<br/>
-      <img class="headshot" src="https://avatars.githubusercontent.com/brson"></a></li>
-  <li class="person"><a href="https://github.com/alexcrichton/">Alex Crichton<br/>
-      <img class="headshot" src="https://avatars.githubusercontent.com/alexcrichton"></a></li>
-  <li class="person"><a href="https://github.com/wycats/">Yehuda Katz<br/>
-      <img class="headshot" src="https://avatars.githubusercontent.com/wycats"></a></li>
-  <li class="person"><a href="https://github.com/steveklabnik/">Steve Klabnik<br/>
-      <img class="headshot" src="https://avatars.githubusercontent.com/steveklabnik"></a></li>
-  <li class="person"><a href="https://github.com/nikomatsakis/">Niko Matsakis<br/>
-      <img class="headshot" src="https://avatars.githubusercontent.com/nikomatsakis"></a></li>
-  <li class="person"><a href="https://github.com/aturon/">Aaron Turon<br/>
-      <img class="headshot" src="https://avatars.githubusercontent.com/aturon"></a></li>
-  <li class="person"><a href="https://github.com/pcwalton/">Patrick Walton<br/>
-      <img class="headshot" src="https://avatars.githubusercontent.com/pcwalton"></a></li>
-  <li class="person"><a href="https://github.com/huonw/">Huon Wilson<br/>
-      <img class="headshot" src="https://avatars.githubusercontent.com/huonw"></a></li>
-</ul>
-
-## Language design team
-
-**Responsibility**: *designing new language features*
+**Responsibility**: *{{ team.responsibility }}*
 
 <ul class="headshots">
-  <li class="person"><a href="https://github.com/nrc/">Nick Cameron<br/>
-      <img class="headshot" src="https://avatars.githubusercontent.com/nrc"></a></li>
-  <li class="person"><a href="https://github.com/pnkfelix/">Felix Klock<br/>
-      <img class="headshot" src="https://avatars.githubusercontent.com/pnkfelix"></a></li>
-  <li class="person lead"><a href="https://github.com/nikomatsakis/">Niko Matsakis (lead)<br/>
-      <img class="headshot" src="https://avatars.githubusercontent.com/nikomatsakis"></a></li>
-  <li class="person"><a href="https://github.com/aturon/">Aaron Turon<br/>
-      <img class="headshot" src="https://avatars.githubusercontent.com/aturon"></a></li>
-  <li class="person"><a href="https://github.com/huonw/">Huon Wilson<br/>
-      <img class="headshot" src="https://avatars.githubusercontent.com/huonw"></a></li>
+{% for github in team.members %}
+  {% assign person = page.people[github] %}
+  <li class="person {% if team.lead and team.lead == github %}lead{% endif %}">
+  <a href="https://github.com/{{ github }}">
+    <div class="name">{{ person.name }}</div>
+    <img class="headshot" src="http://avatars.githubusercontent.com/{{ github }}">
+  </a>
+</li>
+{% endfor %}
 </ul>
 
-## Library team
-
-**Responsibility**: *the Rust standard library, rust-lang crates, conventions*
-
-<ul class="headshots">
-  <li class="person"><a href="https://github.com/brson/">Brian Anderson<br/>
-      <img class="headshot" src="https://avatars.githubusercontent.com/brson"></a></li>
-  <li class="person"><a href="https://github.com/Gankro/">Alexis Beingessner<br/>
-      <img class="headshot" src="https://avatars.githubusercontent.com/Gankro"></a></li>
-  <li class="person"><a href="https://github.com/alexcrichton/">Alex Crichton<br/>
-      <img class="headshot" src="https://avatars.githubusercontent.com/alexcrichton"></a></li>
-  <li class="person"><a href="https://github.com/sfackler/">Steven Fackler<br/>
-      <img class="headshot" src="https://avatars.githubusercontent.com/sfackler"></a></li>
-  <li class="person"><a href="https://github.com/BurntSushi/">Andrew Gallant<br/>
-      <img class="headshot" src="https://avatars.githubusercontent.com/BurntSushi"></a></li>
-  <li class="person"><a href="https://github.com/Kimundi/">Marvin Löbel<br/>
-      <img class="headshot" src="https://avatars.githubusercontent.com/Kimundi"></a></li>
-  <li class="person lead"><a href="https://github.com/aturon/">Aaron Turon (lead)<br/>
-      <img class="headshot" src="https://avatars.githubusercontent.com/aturon"></a></li>
-  <li class="person"><a href="https://github.com/huonw/">Huon Wilson<br/>
-      <img class="headshot" src="https://avatars.githubusercontent.com/huonw"></a></li>
-</ul>
-
-## Compiler team
-
-**Responsibility**: *compiler internals, optimizations*
-
-<ul class="headshots">
-  <li class="person"><a href="https://github.com/jakub-/">Jakub Bukaj<br/>
-      <img class="headshot" src="https://avatars.githubusercontent.com/jakub-"></a></li>
-  <li class="person"><a href="https://github.com/eddyb/">Eduard Burtescu<br/>
-      <img class="headshot" src="https://avatars.githubusercontent.com/eddyb"></a></li>
-  <li class="person"><a href="https://github.com/nrc/">Nick Cameron<br/>
-      <img class="headshot" src="https://avatars.githubusercontent.com/nrc"></a></li>
-  <li class="person"><a href="https://github.com/pnkfelix/">Felix Klock<br/>
-      <img class="headshot" src="https://avatars.githubusercontent.com/pnkfelix"></a></li>
-  <li class="person"><a href="https://github.com/bkoropoff/">Brian Koropoff<br/>
-      <img class="headshot" src="https://avatars.githubusercontent.com/bkoropoff"></a></li>
-  <li class="person lead"><a href="https://github.com/nikomatsakis/">Niko Matsakis (lead)<br/>
-      <img class="headshot" src="https://avatars.githubusercontent.com/nikomatsakis"></a></li>
-  <li class="person"><a href="https://github.com/aatch/">James Miller<br/>
-      <img class="headshot" src="https://avatars.githubusercontent.com/aatch"></a></li>
-  <li class="person"><a href="https://github.com/dotdash/">Björn Steinbrink<br/>
-      <img class="headshot" src="https://avatars.githubusercontent.com/dotdash"></a></li>
-  <li class="person"><a href="https://github.com/michaelwoerister/">Michael Woerister<br/>
-      <img class="headshot" src="https://avatars.githubusercontent.com/michaelwoerister"></a></li>
-</ul>
-
-## Tooling and infrastructure team
-
-**Responsiblity**: *tool support (e.g. Cargo, multirust), CI infrastructure, etc.*
-
-<ul class="headshots">
-  <li class="person"><a href="https://github.com/brson/">Brian Anderson<br/>
-      <img class="headshot" src="https://avatars.githubusercontent.com/brson"></a></li>
-  <li class="person"><a href="https://github.com/nrc/">Nick Cameron<br/>
-      <img class="headshot" src="https://avatars.githubusercontent.com/nrc"></a></li>
-  <li class="person lead"><a href="https://github.com/alexcrichton/">Alex Crichton (lead)<br/>
-      <img class="headshot" src="https://avatars.githubusercontent.com/alexcrichton"></a></li>
-  <li class="person"><a href="https://github.com/vadimcn/">Vadim Chugunov<br/>
-      <img class="headshot" src="https://avatars.githubusercontent.com/vadimcn"></a></li>
-  <li class="person"><a href="https://github.com/wycats/">Yehuda Katz<br/>
-      <img class="headshot" src="https://avatars.githubusercontent.com/wycats"></a></li>
-  <li class="person"><a href="https://github.com/michaelwoerister/">Michael Woerister<br/>
-      <img class="headshot" src="https://avatars.githubusercontent.com/michaelwoerister"></a></li>
-</ul>
-
-## Moderation team
-
-**Responsibility**: *helping uphold the [code of conduct](http://www.rust-lang.org/conduct.html)*
-
-<ul class="headshots">
-  <li class="person"><a href="https://github.com/mbrubeck/">Matt Brubeck<br/>
-      <img class="headshot" src="https://avatars.githubusercontent.com/mbrubeck"></a></li>
-  <li class="person"><a href="https://github.com/BurntSushi/">Andrew Gallant<br/>
-      <img class="headshot" src="https://avatars.githubusercontent.com/BurntSushi"></a></li>
-  <li class="person"><a href="https://github.com/manishearth/">Manish Goregaokar<br/>
-      <img class="headshot" src="https://avatars.githubusercontent.com/manishearth"></a></li>
-  <li class="person"><a href="https://github.com/pnkfelix/">Felix Klock<br/>
-      <img class="headshot" src="https://avatars.githubusercontent.com/pnkfelix"></a></li>
-  <li class="person"><a href="https://github.com/erickt/">Erick Tryzelaar<br/>
-      <img class="headshot" src="https://avatars.githubusercontent.com/erickt"></a></li>
-</ul>
+{% endfor %}


### PR DESCRIPTION
https://internals.rust-lang.org/t/announcing-the-subteams/2042/2?u=huon

Embarrassingly, I'm unsure of @jakub-'s exact IRC nick.

You can see what this looks like at: http://huonw.github.io/rust-www/team.html