### PR TITLE
Use merged RfC link for governance RfC, not PR link

### DIFF
--- a/team.md
+++ b/team.md
@@ -29,7 +29,7 @@ title: The Rust Team
 
 # The Rust Team
 
-The Rust project is [governed](https://github.com/rust-lang/rfcs/pull/1068) by a
+The Rust project is [governed](https://github.com/rust-lang/rfcs/blob/master/text/1068-rust-governance.md) by a
 number of teams, each focused on a specific area of concern. Below are the
 rosters, in alphabetical order.
 


### PR DESCRIPTION
The PR isn't rendered by default and shows a lot of discussion. While this discussion is important; in the context of the teams page people will more likely be interested in the workings of the teams and not the discussion up to it.

r? @alexcrichton 