### PR TITLE
Removed indent from sides of install pages

### DIFF
--- a/install.html
+++ b/install.html
@@ -4,14 +4,14 @@ title: Install &middot; The Rust Programming Language
 ---
 
     <div class="row install">
-      <div class="col-md-offset-1 col-md-3 side-header">
+      <div class="col-md-4 side-header">
         <h2>1.0.0</h2>
         <h3>May 15, 2015</h3>
         <p>
 	  The current stable release of Rust, updated every six weeks and backwards-compatible.
         </p>
       </div>
-      <div class="col-md-7">
+      <div class="col-md-8">
         <table class="table-features table-installers"><tbody>
           <tr>
           <td class="inst-type">Linux binaries (.tar.gz)</td>
@@ -42,7 +42,7 @@ title: Install &middot; The Rust Programming Language
     </div>
 
      <div class="row">
-      <div class="col-md-offset-1 col-md-10">
+      <div class="col-md-8 col-md-offset-4">
         <p>An easy way to install the stable binaries for Linux and Mac is to run this in your shell:</p>
         <pre><code>$ curl -sSf https://static.rust-lang.org/rustup.sh | sh</code></pre>
       </div>
@@ -51,14 +51,14 @@ title: Install &middot; The Rust Programming Language
     <hr/>
 
     <div class="row">
-      <div class="col-md-3 col-md-offset-1 side-header">
+      <div class="col-md-4 side-header">
         <h2>Beta</h2>
         <p>
 	A beta of the upcoming stable release, intended for testing by
 	crate authors. Updated as needed.
         </p>
       </div>
-      <div class="col-md-7">
+      <div class="col-md-8">
         <table class="table-features table-installers"><tbody>
           <tr>
           <td class="inst-type">Linux binaries (.tar.gz)</td>
@@ -89,7 +89,7 @@ title: Install &middot; The Rust Programming Language
     </div>
 
      <div class="row">
-      <div class="col-md-offset-1 col-md-10">
+      <div class="col-md-8 col-md-offset-4">
         <p>An easy way to install the beta binaries for Linux and Mac is to run this in your shell:</p>
         <pre><code>$ curl -sSf https://static.rust-lang.org/rustup.sh | sh -s -- --channel=beta</code></pre>
       </div>
@@ -98,7 +98,7 @@ title: Install &middot; The Rust Programming Language
     <hr/>
 
     <div class="row">
-      <div class="col-md-3 col-md-offset-1 side-header">
+      <div class="col-md-4 side-header">
         <h2>Nightly</h2>
         <p>
         The current development branch.
@@ -107,7 +107,7 @@ title: Install &middot; The Rust Programming Language
 	that are not available in the betas or stable releases.
         </p>
       </div>
-      <div class="col-md-7">
+      <div class="col-md-8">
         <table class="table-features table-installers"><tbody>
           <tr>
           <td class="inst-type">Linux binaries (.tar.gz)</td>
@@ -138,7 +138,7 @@ title: Install &middot; The Rust Programming Language
     </div>
 
      <div class="row">
-      <div class="col-md-offset-1 col-md-10">
+      <div class="col-md-8 col-md-offset-4">
         <p>An easy way to install the nightly binaries for Linux and Mac is to run this in your shell:</p>
         <pre><code>$ curl -sSf https://static.rust-lang.org/rustup.sh | sh -s -- --channel=nightly</code></pre>
       </div>
@@ -147,7 +147,7 @@ title: Install &middot; The Rust Programming Language
     <hr/>
 
     <div class="row">
-      <div class="col-md-offset-1 col-md-11">
+      <div class="col-md-12">
       <p>
         Discover other downloads in <a href="http://static.rust-lang.org/dist/index.html">the archives.</a>
       </p>


### PR DESCRIPTION
None of the other pages have that offset, so, I removed it.

Also made the easy installation instructions a col-8 offset-4, so they line up with the download links.