### PR TITLE
Add community subteam

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -18,7 +18,7 @@
     <header>
 
     <ul class="row menu">
-      <li class="col-xs-12 col-md-4">
+      <li class="col-xs-12 col-md-2">
         <a href="index.html">
           <img class="img-responsive" src="logos/rust-logo-blk.svg" onerror="this.src='logos/rust-logo-256x256-blk.png'" height="128" width="128" alt="Rust logo" />
         </a>
@@ -72,6 +72,13 @@
           </li>
           <li>
             <a href="https://www.google.com/calendar/embed?src=apd9vmbc22egenmtu5l6c5jbfc%40group.calendar.google.com">Calendar</a>
+          </li>
+        </ul>
+      </li>
+      <li class="col-xs-4 col-md-2"><h2>&nbsp;</h2>
+        <ul>
+          <li>
+            <a href="team.html">Team</a>
           </li>
         </ul>
       </li>

--- a/team.md
+++ b/team.md
@@ -16,6 +16,8 @@ people:
     name: Brian Koropoff
   brson:
     name: Brian Anderson
+  bstrie:
+    name: Ben Striegel
   BurntSushi:
     name: Andrew Gallant
     irc: burntsushi
@@ -53,8 +55,13 @@ people:
     name: Patrick Walton
   pnkfelix:
     name: Felix Klock
+  rpcraig:
+    name: Rachel Craig
+    site: twitter
   sfackler:
     name: Steven Fackler
+  skade:
+    name: Florian Gilcher
   steveklabnik:
     name: Steve Klabnik
   vadimcn:
@@ -83,10 +90,23 @@ teams:
     responsibility: "tool support (e.g. Cargo, multirust), CI infrastructure, etc."
     members: [brson, nrc, alexcrichton, vadimcn, wycats, michaelwoerister]
     lead: alexcrichton
+  - name: Community
+    responsibility: "coordinating events, outreach, commercial users, teaching materials, and exposure"
+    lead: steveklabnik
+    members: [brson, rpcraig, skade, manishearth, steveklabnik, bstrie, erickt]
   - name: Moderation
     responsibility: "helping uphold the <a href='http://www.rust-lang.org/conduct.html'>code of conduct</a>"
     members: [mbrubeck, BurntSushi, manishearth, pnkfelix, erickt]
     email: rust-mods@googlegroups.com
+
+# Information on sites to get profile information from
+sites:
+  github:
+    url: https://github.com/%nick
+    avatar: http://avatars.githubusercontent.com/%nick
+  twitter:
+    url: https://twitter.com/%nick
+    avatar: https://avatars.io/twitter/%nick?size=large
 ---
 
 <style type="text/css">
@@ -146,13 +166,19 @@ rosters, in alphabetical order.
 {% endif %}
 
 <ul class="headshots">
-{% for github in team.members %}
-  {% assign person = page.people[github] %}
-  <li class="person {% if team.lead and team.lead == github %}lead{% endif %}">
-  <a href="https://github.com/{{ github }}">
+{% for nick in team.members %}
+  {% assign person = page.people[nick] %}
+  {% if person.site %}
+    {% assign sitename = person.site %}
+  {% else %}
+    {% assign sitename = "github" %}
+  {% endif %}
+  {% assign site = page.sites[sitename] %}
+  <li class="person {% if team.lead and team.lead == nick %}lead{% endif %}">
+  <a href="{{ site.url | replace:'%nick',nick }}">
     <div class="name">{{ person.name }}</div>
-    <div class="irc">irc: {% if person.irc %}{{ person.irc }}{% else %}{{ github }}{% endif %}</div>
-    <img class="headshot" src="http://avatars.githubusercontent.com/{{ github }}">
+    <div class="irc">irc: {% if person.irc %}{{ person.irc }}{% else %}{{ nick }}{% endif %}</div>
+    <img class="headshot" src="{{ site.avatar | replace:'%nick',nick }}">
   </a>
 </li>
 {% endfor %}


### PR DESCRIPTION
Add the new community subteam, as [announced on internals](https://internals.rust-lang.org/t/announcing-the-community-subteam/2248), to the team page, and provide a link to the team page from the front page.

[1]: https://internals.rust-lang.org/t/announcing-the-community-subteam/2248