### PR TITLE
RWIB Mission 5 Documentation Page

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -1,0 +1,147 @@
+---
+layout: default
+title:  Documentation
+---
+
+# Rust Documentation
+
+- [Getting Started][getting_started]
+- [The Standard Library][standard_library]
+- [Community &amp; Getting Help][community_and_help]
+- [Specification][specification]
+- [Tools][tools]
+- [FAQs][faqs]
+- [The Error index][error_index]
+- [Community Translations][translations]
+
+Welcome to the Rust documentation! You can use the section headings
+above to jump to any particular section.
+
+[getting_started]: #getting_started
+[standard_library]: #standard_library
+[community_and_help]: #community_and_help 
+[specification]: #specification
+[tools]: #tools 
+[faqs]: #faqs 
+[error_index]: #error_index 
+[translations]: #translations
+
+# Getting Started  <a name="getting_started"></a>
+
+If you haven't seen Rust at all yet, the first thing you should read
+is the introduction to [The Rust Programming Language][rustbook]. It'll
+give you a good idea of what Rust is like.
+
+The book provides a lengthy explanation of Rust, its syntax, and its
+concepts. Upon completing the book, you'll be an intermediate Rust
+developer, and will have a good grasp of the fundamental ideas behind
+Rust.
+
+[Rust By Example][rust_by_example] was originally a community
+resource, but was then donated to the Rust project. As the name
+implies, it teaches you Rust through a series of small examples.
+
+[rustbook]: https://doc.rust-lang.org/book/
+[rust_by_example]: http://rustbyexample.com/
+
+# The Standard Library<a name="standard_library"></a>
+
+We have [API documentation][rustdocs] for the entire standard library. There's a
+list of crates on the left with more specific sections, or you can use
+the search bar at the top to search for something if you know its
+name.
+
+[rustdocs]: https://doc.rust-lang.org/
+
+# Community &amp; Getting Help <a name="community_and_help"></a>
+
+If you need help with something, or just want to talk about Rust with
+others, there are a few places you can do that:
+
+The Rust IRC channels on [irc.mozilla.org][irc_mozilla] are the
+fastest way to get help.
+
+\#rust is the general discussion channel, and you'll find people
+willing to help you with any questions you may have.
+
+There are also three specialty channels:
+\#rust-gamedev and #rust-osdev are for game development and operating
+system development, respectively. There's also #rust-internals, which
+is for discussion of the development of Rust itself.
+
+You can also get help on [Stack Overflow][stack_overflow]. Searching
+for your problem might reveal someone who has asked it before!
+
+There is an active [subreddit][reddit] with lots of discussion and
+news about Rust.
+
+There is also a [user forum][user_forum], for all user-oriented
+discussion, and a [developer forum][developer_forum], where the
+development of Rust itself is discussed.
+
+[irc_mozilla]: https://wiki.mozilla.org/IRC
+[stack_overflow]: http://stackoverflow.com/questions/tagged/rust
+[reddit]: https://www.reddit.com/r/rust/
+[user_forum]: https://users.rust-lang.org/
+[developer_forum]: https://internals.rust-lang.org/
+
+# Specification<a name="specification"></a>
+
+Rust does not have an exact specification, but an effort to describe as much of
+the language in as much detail as possible is in [the Reference][reference]</a>.
+
+[reference]: https://doc.rust-lang.org/reference.html
+
+# Tools<a name="tools"></a>
+Rust is still a young language, so there isn't a ton of tooling yet,
+but the tools we have are really nice.
+
+[Cargo][cargo] is Rust's package manager, and its website contains
+lots of good documentation.
+
+[cargo]: https://crates.io
+
+[Rustdoc][rustdoc] is used to generate documentation for Rust code.
+
+[rustdoc]: https://doc.rust-lang.org/book/documentation.html
+
+# FAQs<a name="faqs"></a>
+
+There are questions that are asked quite often, so we've made a FAQ for
+them:
+
+- [FAQ][faq]
+
+[faq]: "faq.md"
+
+# The Error Index<a name="error_index"></a>
+
+If you encounter an error while compiling your code you may be able to
+look it up in the [Rust Compiler Error Index][error_index].
+
+[error_index]: https://doc.rust-lang.org/error-index.html
+
+# Community Translations<a name="translations"></a>
+
+Several projects have been started to translate the documentation into other
+languages:
+
+
+- [Russian][russian_translation]
+- [Korean][korean_translation]
+- [Chinese][chinese_translation]
+- [Spanish][spanish_translation]
+
+[russian_translation]: https://github.com/kgv/rust_book_ru
+[korean_translation]: https://github.com/rust-kr/doc.rust-kr.org
+[chinese_translation]: https://github.com/KaiserY/rust-book-chinese
+[spanish_translation]: https://github.com/goyox86/elpr
+
+Copyright &copy; 2011-2015 The Rust Project Developers. Licensed under the
+[Apache License, Version 2.0][apache_license] or the [MIT
+license][mit_license], at your option. This file may not be copied,
+modified, or distributed except according to those terms.
+
+[apache_license]: http://www.apache.org/licenses/LICENSE-2.0
+[mit_license]: http://opensource.org/licenses/MIT
+


### PR DESCRIPTION
This is a copy of the landing page in the documentation tree.

No changes to content, only cleanup of formatting.

I checked to see if there were any links in the documentation tree that required redirection in the documentation tree but there were none.