### PR TITLE
Add Windows -msvc links to the Downloads page.

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -28,7 +28,7 @@ title: Downloads &middot; The Rust Programming Language
           <td><a href="https://static.rust-lang.org/dist/rust-1.3.0-i686-apple-darwin.pkg"><div class="inst-button">32-bit</div></a></td>
           </tr>
           <tr>
-          <td class="inst-type">Windows (.msi)</td>
+          <td class="inst-type">Windows MSYS -gnu ABI (.msi)</td>
           <td><a href="https://static.rust-lang.org/dist/rust-1.3.0-x86_64-pc-windows-gnu.msi"><div class="inst-button">64-bit</div></a></td>
           <td><a href="https://static.rust-lang.org/dist/rust-1.3.0-i686-pc-windows-gnu.msi"><div class="inst-button">32-bit</div></a></td>
           </tr>
@@ -72,7 +72,12 @@ title: Downloads &middot; The Rust Programming Language
           <td><a href="https://static.rust-lang.org/dist/rust-beta-i686-apple-darwin.pkg"><div class="inst-button">32-bit</div></a></td>
           </tr>
           <tr>
-          <td class="inst-type">Windows (.msi)</td>
+          <td class="inst-type">Windows native -msvc ABI (.msi) </td>
+          <td><a href="https://static.rust-lang.org/dist/rust-beta-x86_64-pc-windows-msvc.msi"><div class="inst-button">64-bit</div></a></td>
+          <td><a href="https://static.rust-lang.org/dist/rust-beta-i686-pc-windows-msvc.msi"><div class="inst-button">32-bit</div></a></td>
+          </tr>
+          <tr>
+          <td class="inst-type">Windows MSYS -gnu ABI (.msi)</td>
           <td><a href="https://static.rust-lang.org/dist/rust-beta-x86_64-pc-windows-gnu.msi"><div class="inst-button">64-bit</div></a></td>
           <td><a href="https://static.rust-lang.org/dist/rust-beta-i686-pc-windows-gnu.msi"><div class="inst-button">32-bit</div></a></td>
           </tr>
@@ -117,7 +122,12 @@ title: Downloads &middot; The Rust Programming Language
           <td><a href="https://static.rust-lang.org/dist/rust-nightly-i686-apple-darwin.pkg"><div class="inst-button">32-bit</div></a></td>
           </tr>
           <tr>
-          <td class="inst-type">Windows (.msi)</td>
+          <td class="inst-type">Windows native -msvc ABI (.msi) </td>
+          <td><a href="https://static.rust-lang.org/dist/rust-nightly-x86_64-pc-windows-msvc.msi"><div class="inst-button">64-bit</div></a></td>
+          <td><a href="https://static.rust-lang.org/dist/rust-nightly-i686-pc-windows-msvc.msi"><div class="inst-button">32-bit</div></a></td>
+          </tr>
+          <tr>
+          <td class="inst-type">Windows MSYS -gnu ABI (.msi)</td>
           <td><a href="https://static.rust-lang.org/dist/rust-nightly-x86_64-pc-windows-gnu.msi"><div class="inst-button">64-bit</div></a></td>
           <td><a href="https://static.rust-lang.org/dist/rust-nightly-i686-pc-windows-gnu.msi"><div class="inst-button">32-bit</div></a></td>
           </tr>


### PR DESCRIPTION
It is very hard to find the native -msvc tools.

I didn't add links for stable 1.3 because my understanding is that 1.4 is the first version where -msvc will be recommended.