### PR TITLE
Remove claim about "thread safety"

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,8 @@ title: The Rust Programming Language
           <b>Rust</b> is a systems programming language
           that runs blazingly fast,
           prevents nearly all segfaults,
-          and guarantees thread safety.
+          and gives compile-time erorrs for
+          concurrency problems.
           <br/>
           <a href="http://doc.rust-lang.org/book/README.html">Show me!</a>
         </p>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@ title: The Rust Programming Language
           <b>Rust</b> is a systems programming language
           that runs blazingly fast,
           prevents nearly all segfaults,
-          and gives compile-time erorrs for
+          and gives compile-time errors for
           concurrency problems.
           <br/>
           <a href="http://doc.rust-lang.org/book/README.html">Show me!</a>


### PR DESCRIPTION
As https://github.com/rust-lang/rust/issues/26215 and others have pointed out, "thread safety" is a bad way to phrase this. When talking to people about Rust, the thing they've found most striking is compile-time errors, which is really unique to us, so it seems like a good proxy here.

r? @brson what do you think of this framing?

Fixes rust-lang/rust#26215