### PR TITLE
Rename "Community" nav header to "Resources"

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -46,9 +46,6 @@
       </li>
       <li class="col-xs-4 col-md-2"><h2>Resources</h2>
         <ul>
-          <li>
-            <a href="http://this-week-in-rust.org/">News</a>
-          </li>
 	  <li>
 	    <a href="community.html">Community</a>
 	  </li>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -52,6 +52,9 @@
           <li>
             <a href="legal.html">Legal</a>
           </li>
+	  <li>
+	    <a href="security.html">Security</a>
+	  </li>
         </ul>
       </li>
   </header>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -44,7 +44,7 @@
           </li>
         </ul>
       </li>
-      <li class="col-xs-4 col-md-2"><h2>Community</h2>
+      <li class="col-xs-4 col-md-2"><h2>Resources</h2>
         <ul>
           <li>
             <a href="http://this-week-in-rust.org/">News</a>

--- a/security.html
+++ b/security.html
@@ -1,7 +1,9 @@
 ---
 layout: default
-title: Security &middot; The Rust Programming Language
+title: Rust Security Policy &middot; The Rust Programming Language
 ---
+
+<h1>Rust Security Policy</h1>
 
 <h2>Reporting a Bug</h2>
 


### PR DESCRIPTION
This way "Community" isn't repeated.

r? @steveklabnik 