### PR TITLE
Update meta tag description to match index page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,7 +6,7 @@
     <title>{{ page.title }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="keywords" content="Rust, Rust programming language, rustlang, rust-lang, Mozilla Rust">
-    <meta name="description" content="A systems programming language that runs blazingly fast, prevents almost all crashes, and eliminates data races.">
+    <meta name="description" content="A systems programming language that runs blazingly fast, prevents segfaults, and guarantees thread safety.">
     <link rel="stylesheet" href="/css/bootstrap.css">
     <link rel="stylesheet" href="/css/style.css">
   </head>


### PR DESCRIPTION
Noticed that the meta tag description no longer matches the blurb on the homepage so I've changed it. Thanks!