### PR TITLE
Update team mailing lists to use @rust-lang.org mailing lists

### DIFF
--- a/community.md
+++ b/community.md
@@ -22,7 +22,7 @@ care about making the community a safe space for you.
 
 [coc]: https://www.rust-lang.org/conduct.html
 [mod_team]: https://www.rust-lang.org/team.html#Moderation
-[mod_team_email]: mailto:rust-mods@googlegroups.com
+[mod_team_email]: mailto:rust-mods@rust-lang.org
 
 ## Getting Started
 

--- a/conduct.md
+++ b/conduct.md
@@ -7,7 +7,7 @@ title: The Rust Code of Conduct &middot; The Rust Programming Language
 
 ## Conduct
 
-**Contact**: [rust-mods@googlegroups.com](mailto:rust-mods@googlegroups.com)
+**Contact**: [rust-mods@rust-lang.org](mailto:rust-mods@rust-lang.org)
 
 * We are committed to providing a friendly, safe and welcoming environment for all, regardless of gender, sexual orientation, disability, ethnicity, religion, or similar personal characteristic.
 * On IRC, please avoid using overtly sexual nicknames or other nicknames that might detract from a friendly, safe and welcoming environment for all.

--- a/team.md
+++ b/team.md
@@ -94,6 +94,7 @@ teams:
     responsibility: "coordinating events, outreach, commercial users, teaching materials, and exposure"
     lead: steveklabnik
     members: [brson, skade, manishearth, steveklabnik, bstrie, erickt]
+    email: rust-community [at] rust-lang [dot] org
   - name: Moderation
     responsibility: "helping uphold the <a href='http://www.rust-lang.org/conduct.html'>code of conduct</a>"
     members: [mbrubeck, BurntSushi, manishearth, pnkfelix, erickt, niconii]


### PR DESCRIPTION
confirmed with @edunham that these addresses work earlier today.