### PR TITLE
Fix styling and markup of nested lists in faq

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -478,6 +478,12 @@ ul.laundry-list {
     color: black;
 }
 
+.faq ol ul {
+    padding-left: 0px;
+    margin-top: 0.5em;
+    margin-left: 1em;
+}
+
 #toc h2 {
     border: 0;
     font-size: 2rem;

--- a/faq.md
+++ b/faq.md
@@ -632,14 +632,13 @@ it explicitly. The rules are as follows:
    explicitly. Lifetimes there use a simple defaulting scheme called
    ["lifetime elision"](https://doc.rust-lang.org/book/lifetimes.html#lifetime-elision),
    which consists of the following three rules:
-
-   - Each elided lifetime in a function’s arguments becomes a distinct lifetime parameter.
-   - If there is exactly one input lifetime, elided or not, that
-     lifetime is assigned to all elided lifetimes in the return values
-     of that function.
-   - If there are multiple input lifetimes, but one of them is &self
-     or &mut self, the lifetime of self is assigned to all elided
-     output lifetimes.
+  - Each elided lifetime in a function’s arguments becomes a distinct lifetime parameter.
+  - If there is exactly one input lifetime, elided or not, that
+    lifetime is assigned to all elided lifetimes in the return values
+    of that function.
+  - If there are multiple input lifetimes, but one of them is &self
+    or &mut self, the lifetime of self is assigned to all elided
+    output lifetimes.
 3. Finally, in a `struct` or `enum` definition, all lifetimes must be explicitly declared.
 
 If these rules result in compilation errors, the Rust compiler will provide an error message indicating the error caused, and suggesting a potential solution based on which step of the inference process caused the error.


### PR DESCRIPTION
Fixes [this](https://www.rust-lang.org/faq.html#when-are-lifetimes-required-to-be-explicit).