### PR TITLE
Fix FAQ contributing link

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -10,7 +10,7 @@ This page exists to answer common questions about the Rust programming language.
 </p>
 
 <p class="faq-intro">
-If there is some common or important question you feel is wrongly left unanswered here, feel free to <a href="contribute.html">help us fix it</a>.
+If there is some common or important question you feel is wrongly left unanswered here, feel free to <a href="https://github.com/rust-lang/rust-www/blob/master/CONTRIBUTING.md">help us fix it</a>.
 </p>
 
 <div id="toc">


### PR DESCRIPTION
I made this link point to the main contributing page, but it should go to the www contributing page.