### PR TITLE
Fix relative links on error page

### DIFF
--- a/_layouts/basic.html
+++ b/_layouts/basic.html
@@ -21,15 +21,15 @@
 
     <ul class="row menu">
       <li class="col-xs-12 col-md-2">
-        <a href="index.html">
-          <img class="img-responsive" src="logos/rust-logo-blk.svg" onerror="this.src='logos/rust-logo-256x256-blk.png'" height="128" width="128" alt="Rust logo" />
+        <a href="/index.html">
+          <img class="img-responsive" src="/logos/rust-logo-blk.svg" onerror="this.src='/logos/rust-logo-256x256-blk.png'" height="128" width="128" alt="Rust logo" />
         </a>
       </li>
       <li class="col-xs-12 col-md-10 menu">
-	<h2><a href="documentation.html">Documentation</a></h2>
-	<h2><a href="community.html">Community</a></h2>
-	<h2><a href="downloads.html">Downloads</a></h2>
-	<h2><a href="contribute.html">Contribute</a></h2>
+	<h2><a href="/documentation.html">Documentation</a></h2>
+	<h2><a href="/community.html">Community</a></h2>
+	<h2><a href="/downloads.html">Downloads</a></h2>
+	<h2><a href="/contribute.html">Contribute</a></h2>
       </li>
     </ul>
   </header>

--- a/error.html
+++ b/error.html
@@ -4,7 +4,7 @@ title: Internal Website Error &middot; The Rust Programming Language
 ---
 <div align="center">
 <br>
-<img src="logos/error.png">
+<img src="/logos/error.png">
 <br>
 <br>
     <p>Something went terribly wrong!</p>


### PR DESCRIPTION
This should fix the broken images and links on urls like:
https://www.rust-lang.org/fail/