### PR TITLE
Removed bold from links to improve readability

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -6,54 +6,54 @@ title:  Rust Documentation &middot; The Rust Programming Language
 # Rust Documentation
 
 If you haven't seen Rust at all yet, the first thing you should read
-is the introduction to the book, [**The Rust Programming
-Language**][book]. It will give you a good idea of what Rust is like,
+is the introduction to the book, [The Rust Programming
+Language][book]. It will give you a good idea of what Rust is like,
 show you how to install it, and explain its syntax and concepts. Upon
 completing the book, you'll be an intermediate Rust developer, and
 will have a good grasp of the fundamental ideas behind Rust.
 
 ## Learning Rust
 
-[**The Rust Programming Language**][book]. Also known as "The Book",
+[The Rust Programming Language][book]. Also known as "The Book",
 The Rust Programming Language is the most comprehensive resource for
 all topics related to Rust, and is the primary official document of
 the language.
 
-[**Rust by Example**][rbe]. A collection of self-contained Rust
+[Rust by Example][rbe]. A collection of self-contained Rust
 examples on a variety of topics, executable in-browser.
 
-[**Frequently asked questions**][faq].
+[Frequently asked questions][faq].
 
-[**The Rustonomicon**][nomicon]. An entire book dedicated to
+[The Rustonomicon][nomicon]. An entire book dedicated to
 explaining how to write unsafe Rust code. It is for advanced Rust
 programmers.
 
-[**rust-learning**]. A community-maintained collection of resources
+[rust-learning]. A community-maintained collection of resources
 for learning Rust.
 
 [book]: https://doc.rust-lang.org/book/
 [rbe]: http://rustbyexample.com
 [faq]: faq.html
 [nomicon]: https://doc.rust-lang.org/nomicon/
-[**rust-learning**]: https://github.com/ctjhoa/rust-learning
+[rust-learning]: https://github.com/ctjhoa/rust-learning
 
 ## References
 
-[**Standard Library API Reference**][api]. Documentation for the
+[Standard Library API Reference][api]. Documentation for the
 standard library.
 
-[**The Rust Reference**][ref]. While Rust does not have a
+[The Rust Reference][ref]. While Rust does not have a
 specification, the reference tries to describe its working in
 detail. It tends to be out of date.
 
-[**Syntax Index**][syn]. This appendix from The Book contains examples
+[Syntax Index][syn]. This appendix from The Book contains examples
 of all syntax in Rust cross-referenced with the section of The Book
 that describes it.
 
-[**The Cargo Guide**][cargo]. The documentation for Cargo,
+[The Cargo Guide][cargo]. The documentation for Cargo,
 Rust's package manager.
 
-[**Compiler Error Index**][err]. Extended explanations of
+[Compiler Error Index][err]. Extended explanations of
 the errors produced by the Rust compiler.
 
 [api]: https://doc.rust-lang.org/std/
@@ -64,10 +64,10 @@ the errors produced by the Rust compiler.
 
 ## Project policies
 
-[**Rust security policy**][security]. The project's policies for
+[Rust security policy][security]. The project's policies for
 reporting, fixing and disclosing security-related bugs.
 
-[**Rust copyright and trademark policies**][legal]. The Rust
+[Rust copyright and trademark policies][legal]. The Rust
 copyrights are owned by The Rust Project Developers, and its
 trademarks are owned by Mozilla. Appropriate usage of Rust's
 trademarks are described here.


### PR DESCRIPTION
When Brian did [the documentation page overhaul](https://github.com/rust-lang/rust-www/commit/893021c95c286e637add50f7a952ecbbb893a364) he made most links in it bold. However, on OS X these small bold letters look fuzzy and are harder to read. The problem is more apparent in Firefox that tends to render glyph strokes wider than other browsers. Here I've put up the page fragment showing bold and regular fonts being used for links as it's rendered on my machine:

![Firefox render for bold and regular links](http://snappyimages.nextwavesrl.netdna-cdn.com/img/1391a2e656bb13ea307c354914fc3109.png)

Also, other pages on Rust website don't use bold for links within text body, and as it is now the documentation page looks out of place.

I know that the whole thing is highly subjective, so if Brian or anyone else feels strongly about the new style I won't mind. Thanks for great work!