### PR TITLE
Include original reference to 'gender' in COC

### DIFF
--- a/conduct.md
+++ b/conduct.md
@@ -9,7 +9,7 @@ title: The Rust Code of Conduct &middot; The Rust Programming Language
 
 **Contact**: [rust-mods@rust-lang.org](mailto:rust-mods@rust-lang.org)
 
-* We are committed to providing a friendly, safe and welcoming environment for all, regardless of gender identity and expression, sexual orientation, disability, ethnicity, religion, or similar personal characteristic.
+* We are committed to providing a friendly, safe and welcoming environment for all, regardless of gender, gender identity and expression, sexual orientation, disability, ethnicity, religion, or similar personal characteristic.
 * On IRC, please avoid using overtly sexual nicknames or other nicknames that might detract from a friendly, safe and welcoming environment for all.
 * Please be kind and courteous. There's no need to be mean or rude.
 * Respect that people have differences of opinion and that every design or implementation choice carries a trade-off and numerous costs. There is seldom a right answer.


### PR DESCRIPTION
To be extra explicit for the following reason:

'Gender' can be defined as the way society perceives your gender to be (often in a binary format). Whereas 'gender identity' may be referred to as your own sense of self/identity. As they can certainly both form the basis of harassment, I felt I should correct my mistake and put 'gender' back in much like the [Contributor Covenant](http://contributor-covenant.org/version/1/3/0/code_of_conduct.md) does.

Happy to discuss, and apologies for my original mistake.
