### PR TITLE
Revert " #268: Update CoC w/ 'gender identity and expression'"

### DIFF
--- a/conduct.md
+++ b/conduct.md
@@ -9,7 +9,7 @@ title: The Rust Code of Conduct &middot; The Rust Programming Language
 
 **Contact**: [rust-mods@rust-lang.org](mailto:rust-mods@rust-lang.org)
 
-* We are committed to providing a friendly, safe and welcoming environment for all, regardless of gender identity and expression, sexual orientation, disability, ethnicity, religion, or similar personal characteristic.
+* We are committed to providing a friendly, safe and welcoming environment for all, regardless of gender, sexual orientation, disability, ethnicity, religion, or similar personal characteristic.
 * On IRC, please avoid using overtly sexual nicknames or other nicknames that might detract from a friendly, safe and welcoming environment for all.
 * Please be kind and courteous. There's no need to be mean or rude.
 * Respect that people have differences of opinion and that every design or implementation choice carries a trade-off and numerous costs. There is seldom a right answer.


### PR DESCRIPTION
This reverts commit 139a9ad162fdc38082e3218ae541a0e696629a0b.

This change to what is in some sense Rust's constitution happened far too casually for my comfort. I was not aware it was happening.

cc https://github.com/rust-lang/rust-www/pull/273 https://github.com/rust-lang/rust-www/pull/270 https://github.com/rust-lang/rust-www/issues/268

cc @Charlotteis @rust-lang/core