### PR TITLE
Fixed chrome TOC numbering bug

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -490,10 +490,14 @@ ul.laundry-list {
     line-height: 1.5em;
 }
 
+#toc .contents {
+    -webkit-columns: 3 150px;
+    -moz-columns: 3 150px;
+    columns: 3 150px;
+    -webkit-perspective: 1;
+}
+
 #toc ol {
     margin: 0 0 0 2rem;
     padding: 0;
-    -webkit-columns: 150px 3;
-    -moz-columns: 150px 3;
-    columns: 150px 3;
 }

--- a/faq.md
+++ b/faq.md
@@ -15,30 +15,31 @@ If there is some common or important question you feel is wrongly left unanswere
 
 <div id="toc">
     <h2>Table of Contents</h2><a href="#toggle-toc"></a>
-    <ol id="toc-contents">
-        <li><a href="#project">The Rust Project</a></li>
-        <li><a href="#performance">Performance</a></li>
-        <li><a href="#syntax">Syntax</a></li>
-        <li><a href="#numerics">Numerics</a></li>
-        <li><a href="#strings">Strings</a></li>
-        <li><a href="#collections">Collections</a></li>
-        <li><a href="#ownership">Ownership</a></li>
-        <li><a href="#lifetimes">Lifetimes</a></li>
-        <li><a href="#generics">Generics</a></li>
-        <li><a href="#input-output">Input / Output</a></li>
-        <li><a href="#error-handling">Error Handling</a></li>
-        <li><a href="#concurrency">Concurrency</a></li>
-        <li><a href="#macros">Macros</a></li>
-        <li><a href="#debugging">Debugging and Tooling</a></li>
-        <li><a href="#low-level">Low-Level</a></li>
-        <li><a href="#cross-platform">Cross-Platform</a></li>
-        <li><a href="#modules-and-crates">Modules and Crates</a></li>
-        <li><a href="#libraries">Libraries</a></li>
-        <li><a href="#design-patterns">Design Patterns</a></li>
-        <li><a href="#other-languages">Other Languages</a></li>
-        <li><a href="#documentation">Documentation</a></li>
-
-    </ol>
+    <div class="contents">
+        <ol id="toc-contents">
+            <li><a href="#project">The Rust Project</a></li>
+            <li><a href="#performance">Performance</a></li>
+            <li><a href="#syntax">Syntax</a></li>
+            <li><a href="#numerics">Numerics</a></li>
+            <li><a href="#strings">Strings</a></li>
+            <li><a href="#collections">Collections</a></li>
+            <li><a href="#ownership">Ownership</a></li>
+            <li><a href="#lifetimes">Lifetimes</a></li>
+            <li><a href="#generics">Generics</a></li>
+            <li><a href="#input-output">Input / Output</a></li>
+            <li><a href="#error-handling">Error Handling</a></li>
+            <li><a href="#concurrency">Concurrency</a></li>
+            <li><a href="#macros">Macros</a></li>
+            <li><a href="#debugging">Debugging and Tooling</a></li>
+            <li><a href="#low-level">Low-Level</a></li>
+            <li><a href="#cross-platform">Cross-Platform</a></li>
+            <li><a href="#modules-and-crates">Modules and Crates</a></li>
+            <li><a href="#libraries">Libraries</a></li>
+            <li><a href="#design-patterns">Design Patterns</a></li>
+            <li><a href="#other-languages">Other Languages</a></li>
+            <li><a href="#documentation">Documentation</a></li>
+        </ol>
+    </div>
 </div>
 
 


### PR DESCRIPTION
This fixes the Chrome table of contents numbering bug. The solution was to add a new containing div that has the columns set on it. I also added `-webkit-perspective: 1;` to fix another Chrome bug when calculating container height.