### PR TITLE
Add ids to sections on downloads

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -5,7 +5,7 @@ title: Downloads &middot; The Rust Programming Language
 
     <div class="row install">
       <div class="col-md-4 side-header">
-        <h2>1.5.0&nbsp;</h2>
+        <h2 id="stable">1.5.0&nbsp;</h2>
         <h3>December 10, 2015</h3>
         <p>
 	  The
@@ -57,7 +57,7 @@ title: Downloads &middot; The Rust Programming Language
 
     <div class="row">
       <div class="col-md-4 side-header">
-        <h2>Beta&nbsp; (1.6)</h2>
+        <h2 id="beta">Beta&nbsp; (1.6)</h2>
         <p>
 	A preview of the upcoming stable release, intended for testing by
 	crate authors. Updated as needed.
@@ -106,7 +106,7 @@ title: Downloads &middot; The Rust Programming Language
 
     <div class="row">
       <div class="col-md-4 side-header">
-        <h2>Nightly&nbsp; (1.7)</h2>
+        <h2 id="nightly">Nightly&nbsp; (1.7)</h2>
         <p>
         The current development branch.
 	It includes


### PR DESCRIPTION
Adding ids to the different sections on the download page, would allow linking directly to the relevant section when asking users to install a rust version.