### PR TITLE
Update the list of personal characteristics to synchronize with the Contributor's Covenant v1.3

### DIFF
--- a/conduct.md
+++ b/conduct.md
@@ -35,4 +35,4 @@ In the Rust community we strive to go the extra step to look out for each other.
 
 And if someone takes issue with something you said or did, resist the urge to be defensive. Just stop doing what it was they complained about and apologize. Even if you feel you were misinterpreted or unfairly accused, chances are good there was something you could've communicated better — remember that it's your responsibility to make your fellow Rustaceans comfortable. Everyone wants to get along and we are all here first and foremost because we want to talk about cool technology. You will find that people will be eager to assume good intent and forgive as long as you earn their trust.
 
-*Adapted from the [Node.js Policy on Trolling](http://blog.izs.me/post/30036893703/policy-on-trolling)*
+*Adapted from the [Node.js Policy on Trolling](http://blog.izs.me/post/30036893703/policy-on-trolling) as well as the [Contributor Covenant v1.3.0](http://contributor-covenant.org/version/1/3/0/).*

--- a/conduct.md
+++ b/conduct.md
@@ -9,7 +9,7 @@ title: The Rust Code of Conduct &middot; The Rust Programming Language
 
 **Contact**: [rust-mods@rust-lang.org](mailto:rust-mods@rust-lang.org)
 
-* We are committed to providing a friendly, safe and welcoming environment for all, regardless of gender identity and expression, sexual orientation, disability, ethnicity, religion, or similar personal characteristic.
+* We are committed to providing a friendly, safe and welcoming environment for all, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, nationality, or similar personal characteristic.
 * On IRC, please avoid using overtly sexual nicknames or other nicknames that might detract from a friendly, safe and welcoming environment for all.
 * Please be kind and courteous. There's no need to be mean or rude.
 * Respect that people have differences of opinion and that every design or implementation choice carries a trade-off and numerous costs. There is seldom a right answer.

--- a/conduct.md
+++ b/conduct.md
@@ -9,7 +9,7 @@ title: The Rust Code of Conduct &middot; The Rust Programming Language
 
 **Contact**: [rust-mods@rust-lang.org](mailto:rust-mods@rust-lang.org)
 
-* We are committed to providing a friendly, safe and welcoming environment for all, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, nationality, or similar personal characteristic.
+* We are committed to providing a friendly, safe and welcoming environment for all, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, nationality, or other similar characteristic.
 * On IRC, please avoid using overtly sexual nicknames or other nicknames that might detract from a friendly, safe and welcoming environment for all.
 * Please be kind and courteous. There's no need to be mean or rude.
 * Respect that people have differences of opinion and that every design or implementation choice carries a trade-off and numerous costs. There is seldom a right answer.


### PR DESCRIPTION
This PR updates the list of personal characteristics to synchronize with the [Contributor's Covenant v1.3](http://contributor-covenant.org/version/1/3/0/). This is not intended as a change to the actual meaning of the CoC, since all of these characteristics were intended to be implied by the original wording. However, making the list more explicit is clearer for readers overall, and the CC seems to have a reasonable list.

r? @rust-lang/core 
cc @rust-lang/moderation

UPDATE: Tweaked wording of this PR proposal somewhat.