### PR TITLE
Remove extra margin above main menu on phones

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -60,9 +60,6 @@ ul.menu li {
 	margin-top: 0em;
 	margin-bottom: 0em;
 }
-ul.menu li.menu {
-	margin-top: 3em;
-}
 ul.menu h2 {
 	font-size: 20px;
 	font-weight: 500;
@@ -80,6 +77,9 @@ ul.menu li>ul {
 	margin: 0 auto 20px auto;
 }
 @media (min-width: 992px) {
+	ul.menu li.menu {
+		margin-top: 3em;
+	}
 	ul.menu {
 		text-align: left;
 	}


### PR DESCRIPTION
This margin just makes a big space between the logo and menu on small screens.