### PR TITLE
Added a syntax-highligting stylesheet for the FAQ

### DIFF
--- a/_layouts/faq.html
+++ b/_layouts/faq.html
@@ -3,8 +3,8 @@ layout: default
 ---
 
 <link href='https://fonts.googleapis.com/css?family=Source+Serif+Pro:400,600' rel='stylesheet' type='text/css'>
+<link href='/css/syntax-highlighting.css' rel='stylesheet' type='text/css'>
 
 <div class="faq">
   {{ content }}
 </div>
-

--- a/css/syntax-highlight.css
+++ b/css/syntax-highlight.css
@@ -1,0 +1,71 @@
+/*
+    Name:       Base16 Atelier Dune Light
+    Author:     Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/dune)
+    Pygments template by Jan T. Sott (https://github.com/idleberg)
+    Created with Base16 Builder by Chris Kempson (https://github.com/chriskempson/base16-builder)
+*/
+.highlight .hll { background-color: #e8e4cf }
+.highlight  { color: #6E6B5E; }
+.highlight .c { color: #999580 } /* Comment */
+.highlight .err { color: #d73737 } /* Error */
+.highlight .k { color: #b854d4 } /* Keyword */
+.highlight .l { color: #b65611 } /* Literal */
+.highlight .n { color: #6E6B5E; } /* Name */
+.highlight .o { color: #1fad83 } /* Operator */
+.highlight .p { color: #6E6B5E; } /* Punctuation */
+.highlight .cm { color: #999580 } /* Comment.Multiline */
+.highlight .cp { color: #999580 } /* Comment.Preproc */
+.highlight .c1 { color: #999580 } /* Comment.Single */
+.highlight .cs { color: #999580 } /* Comment.Special */
+.highlight .gd { color: #d73737 } /* Generic.Deleted */
+.highlight .ge { font-style: italic } /* Generic.Emph */
+.highlight .gh { color: #20201d; font-weight: bold } /* Generic.Heading */
+.highlight .gi { color: #60ac39 } /* Generic.Inserted */
+.highlight .gp { color: #999580; font-weight: bold } /* Generic.Prompt */
+.highlight .gs { font-weight: bold } /* Generic.Strong */
+.highlight .gu { color: #1fad83; font-weight: bold } /* Generic.Subheading */
+.highlight .kc { color: #b854d4 } /* Keyword.Constant */
+.highlight .kd { color: #b854d4 } /* Keyword.Declaration */
+.highlight .kn { color: #1fad83 } /* Keyword.Namespace */
+.highlight .kp { color: #b854d4 } /* Keyword.Pseudo */
+.highlight .kr { color: #b854d4 } /* Keyword.Reserved */
+.highlight .kt { color: #ae9513 } /* Keyword.Type */
+.highlight .ld { color: #60ac39 } /* Literal.Date */
+.highlight .m { color: #b65611 } /* Literal.Number */
+.highlight .s { color: #2A9292; } /* Literal.String */
+.highlight .na { color: #6684e1 } /* Name.Attribute */
+.highlight .nb { color: #B65611; } /* Name.Builtin */
+.highlight .nc { color: #ae9513 } /* Name.Class */
+.highlight .no { color: #d73737 } /* Name.Constant */
+.highlight .nd { color: #1fad83 } /* Name.Decorator */
+.highlight .ni { color: #20201d } /* Name.Entity */
+.highlight .ne { color: #d73737 } /* Name.Exception */
+.highlight .nf { color: #6684e1 } /* Name.Function */
+.highlight .nl { color: #20201d } /* Name.Label */
+.highlight .nn { color: #ae9513 } /* Name.Namespace */
+.highlight .nx { color: #6684e1 } /* Name.Other */
+.highlight .py { color: #20201d } /* Name.Property */
+.highlight .nt { color: #1fad83 } /* Name.Tag */
+.highlight .nv { color: #d73737 } /* Name.Variable */
+.highlight .ow { color: #1fad83 } /* Operator.Word */
+.highlight .w { color: #20201d } /* Text.Whitespace */
+.highlight .mf { color: #b65611 } /* Literal.Number.Float */
+.highlight .mh { color: #b65611 } /* Literal.Number.Hex */
+.highlight .mi { color: #b65611 } /* Literal.Number.Integer */
+.highlight .mo { color: #b65611 } /* Literal.Number.Oct */
+.highlight .sb { color: #60ac39 } /* Literal.String.Backtick */
+.highlight .sc { color: #20201d } /* Literal.String.Char */
+.highlight .sd { color: #999580 } /* Literal.String.Doc */
+.highlight .s2 { color: #60ac39 } /* Literal.String.Double */
+.highlight .se { color: #b65611 } /* Literal.String.Escape */
+.highlight .sh { color: #60ac39 } /* Literal.String.Heredoc */
+.highlight .si { color: #b65611 } /* Literal.String.Interpol */
+.highlight .sx { color: #60ac39 } /* Literal.String.Other */
+.highlight .sr { color: #60ac39 } /* Literal.String.Regex */
+.highlight .s1 { color: #60ac39 } /* Literal.String.Single */
+.highlight .ss { color: #60ac39 } /* Literal.String.Symbol */
+.highlight .bp { color: #CD0101 } /* Name.Builtin.Pseudo */
+.highlight .vc { color: #d73737 } /* Name.Variable.Class */
+.highlight .vg { color: #d73737 } /* Name.Variable.Global */
+.highlight .vi { color: #d73737 } /* Name.Variable.Instance */
+.highlight .il { color: #b65611 } /* Literal.Number.Integer.Long */


### PR DESCRIPTION
@brson  This should solve #246 but I can't test it locally because I am not able to start the jekyll server.

I didn't find a theme that matched the color scheme that the Ace editor uses on the front page so I based this theme on the one I use in mdBook, at least it would have the same colors as the new book..

If you don't like the theme, you can change / tweak it to match the theme of front page, however I don't have time to do that  so I guess `Some(syntax_highlighting)` is better than `None` :wink: 

Let me know if it works