### PR TITLE
Add intellij to short list

### DIFF
--- a/ides.html
+++ b/ides.html
@@ -39,6 +39,7 @@
 <p>Available IDE plugins:
 <br>
 <br><a href="https://github.com/RustDT/RustDT">Eclipse</a>
+<br><a href="https://github.com/intellij-rust/intellij-rust">IntelliJ IDEA</a>
 <br><a href="https://github.com/PistonDevelopers/VisualRust">Visual Studio</a>
 </p>
 


### PR DESCRIPTION
Just noticed that this was missing from the first list of plugins. Since we expand on it below it seems like it should be here as well.