### PR TITLE
Add alt attribute to images for team members

### DIFF
--- a/team.md
+++ b/team.md
@@ -187,7 +187,7 @@ the [Rust security disclosure process](https://www.rust-lang.org/security.html).
   <a href="{{ site.url | replace:'%nick',nick }}">
     <div class="name">{{ person.name }}</div>
     <div class="irc">irc: {% if person.irc %}{{ person.irc }}{% else %}{{ nick }}{% endif %}</div>
-    <img class="headshot" src="{{ site.avatar | replace:'%nick',nick }}">
+    <img class="headshot" src="{{ site.avatar | replace:'%nick',nick }}" alt="{{ person.name }}">
   </a>
 </li>
 {% endfor %}


### PR DESCRIPTION
Images should have an alt attribute, except under certain
conditions.

[Requirements for providing text to act as an alternative for images](https://www.w3.org/TR/html5/embedded-content-0.html#alt)