### PR TITLE
Change name attribute to id

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -167,7 +167,7 @@ title: Downloads &middot; The Rust Programming Language
 
     <div class="row">
       <div class="col-md-12">
-	<a name="win-foot"></a>
+	<a id="win-foot"></a>
 	<p>
 	  <em>†</em>
 	  There are two prominent


### PR DESCRIPTION
The name attribute is obsolete. The id attribute should be used instead.

See: https://www.w3.org/TR/html5/obsolete.html#obsolete