### PR TITLE
Improve meta tags according Bootstrap documentation

### DIFF
--- a/_layouts/basic.html
+++ b/_layouts/basic.html
@@ -3,8 +3,9 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>{{ page.title }}</title>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ page.title }}</title>
     <meta name="keywords" content="Rust, Rust programming language, rustlang, rust-lang, Mozilla Rust">
     <meta name="description" content="A systems programming language that runs blazingly fast, prevents segfaults, and guarantees thread safety.">
 


### PR DESCRIPTION
Bootstrap framework is not supported in the old Internet Explorer
compatibility modes. Bootstrap recommends usage of following meta
tag to be sure that the latest rendering mode for IE is used:

`<meta http-equiv="X-UA-Compatible" content="IE=edge">`

According Bootstrap documentation first three meta tags should be:

```
<meta charset="...">
<meta http-equiv="...">
<meta name="viewport" content="...">
```

See: http://getbootstrap.com/getting-started/