### PR TITLE
Tweaks to friends page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -562,6 +562,18 @@ ul.laundry-list {
     z-index: -1;
 }
 
+@media (min-width: 992px) {
+
+    #users .fade-in {
+        opacity: 1;
+    }
+
+    #users .fade-out {
+        opacity: 0;
+    }
+
+}
+
 #users .user-details-row-1 div {
     height: 2em;
     margin-top: 0em;

--- a/friends.html
+++ b/friends.html
@@ -49,6 +49,13 @@ title:  Friends of Rust &middot; The Rust Programming Language
             details.className += " fade-in";
             details.setAttribute("style", "opacity: 1;");
           };
+
+          logo.onmouseout = function() {
+            var details = document.getElementById("user-details-{{offset}}-{{forloop.index}}");
+            details.className = details.className.replace(" fade-in", "");
+            details.className = details.className.replace(" fade-out", "");
+            details.setAttribute("style", "opacity: 0;");
+          };
         </script>
       {% endfor %}
 

--- a/friends.html
+++ b/friends.html
@@ -31,25 +31,25 @@ title:  Friends of Rust &middot; The Rust Programming Language
             </div>
         </div>
 
-	<script type="text/javascript">
-	  var logo = document.getElementById("user-logo-{{offset}}-{{forloop.index}}");
-	  logo.onmouseover = function() {
-	    var allDetails = document.querySelectorAll(".user-detail");
-	    for (var i = 0; i < allDetails.length; i++) {
-	      var details = allDetails[i];
+        <script type="text/javascript">
+          var logo = document.getElementById("user-logo-{{offset}}-{{forloop.index}}");
+          logo.onmouseover = function() {
+            var allDetails = document.querySelectorAll(".user-detail");
+            for (var i = 0; i < allDetails.length; i++) {
+              var details = allDetails[i];
               details.className = details.className.replace(" fade-in", "");
               details.className = details.className.replace(" fade-out", "");
               details.className += " fade-out";
-	      details.setAttribute("style", "opacity: 0;");
-	    }
+              details.setAttribute("style", "opacity: 0;");
+            }
 
-	    var details = document.getElementById("user-details-{{offset}}-{{forloop.index}}");
+            var details = document.getElementById("user-details-{{offset}}-{{forloop.index}}");
             details.className = details.className.replace(" fade-in", "");
             details.className = details.className.replace(" fade-out", "");
             details.className += " fade-in";
-	    details.setAttribute("style", "opacity: 1;");
-	  };
-	</script>
+            details.setAttribute("style", "opacity: 1;");
+          };
+        </script>
       {% endfor %}
 
   </div>

--- a/friends.html
+++ b/friends.html
@@ -25,10 +25,10 @@ title:  Friends of Rust &middot; The Rust Programming Language
               <img src="user-logos/{{user.logo}}">
             </a>
           </div>
-            <div class="details user-detail" style="opacity: 0;"
-              id="user-details-{{offset}}-{{forloop.index}}">
-              <p><em>{{user.name}}</em> : {{user.how}}</p>
-            </div>
+          <div class="details user-detail" style="opacity: 0;"
+            id="user-details-{{offset}}-{{forloop.index}}">
+            <p><em>{{user.name}}</em> : {{user.how}}</p>
+          </div>
         </div>
 
         <script type="text/javascript">

--- a/friends.html
+++ b/friends.html
@@ -25,7 +25,7 @@ title:  Friends of Rust &middot; The Rust Programming Language
               <img src="user-logos/{{user.logo}}">
             </a>
           </div>
-          <div class="details user-detail" style="opacity: 0;"
+          <div class="details user-detail fade-out"
             id="user-details-{{offset}}-{{forloop.index}}">
             <p><em>{{user.name}}</em> : {{user.how}}</p>
           </div>
@@ -40,21 +40,19 @@ title:  Friends of Rust &middot; The Rust Programming Language
               details.className = details.className.replace(" fade-in", "");
               details.className = details.className.replace(" fade-out", "");
               details.className += " fade-out";
-              details.setAttribute("style", "opacity: 0;");
             }
 
             var details = document.getElementById("user-details-{{offset}}-{{forloop.index}}");
             details.className = details.className.replace(" fade-in", "");
             details.className = details.className.replace(" fade-out", "");
             details.className += " fade-in";
-            details.setAttribute("style", "opacity: 1;");
           };
 
           logo.onmouseout = function() {
             var details = document.getElementById("user-details-{{offset}}-{{forloop.index}}");
             details.className = details.className.replace(" fade-in", "");
             details.className = details.className.replace(" fade-out", "");
-            details.setAttribute("style", "opacity: 0;");
+            details.className += " fade-out";
           };
         </script>
       {% endfor %}


### PR DESCRIPTION
Fade out the descriptions on mouseout. On small form-factors always show the descriptions; on mobile we can't use hover, but there's also less on the screen so clutter of the text isn't as distracting.

r? @huonw 