### PR TITLE
Update info about IntelliJ-Rust plugin

### DIFF
--- a/ides.html
+++ b/ides.html
@@ -96,9 +96,9 @@ Repository: TBA
 <br>
 <br><b>IntelliJ IDEA</b>
 <br>
-<br>Repository: <a href="https://github.com/alexeykudinkin/intellij-rust">https://github.com/alexeykudinkin/intellij-rust</a>
-<br>Issues: <a href="https://github.com/alexeykudinkin/intellij-rust/issues">https://github.com/alexeykudinkin/intellij-rust/issues</a>
-<br>Contact: <a href="https://groups.google.com/d/forum/intellij-rust">https://groups.google.com/d/forum/intellij-rust</a>
+<br>Repository: <a href="https://github.com/intellij-rust/intellij-rust">https://github.com/intellij-rust/intellij-rust</a>
+<br>Issues: <a href="https://github.com/intellij-rust/intellij-rust/issues">https://github.com/intellij-rust/intellij-rust/issues</a>
+<br>Contact: <a href="https://gitter.im/intellij-rust/intellij-rust">https://gitter.im/intellij-rust/intellij-rust</a>
 <br>
 <br><b>Visual Studio (Visual Rust)</b>
 <br>


### PR DESCRIPTION
Hi!

We've moved the repo to the dedicated organization, and while the google group is basically dead, the gitter is rather active. 