### PR TITLE
Fix URL for Tilde in "Friends of Rust" page

### DIFF
--- a/_data/users.yml
+++ b/_data/users.yml
@@ -109,6 +109,6 @@
   how: "The backend of our training platform classroom.thoughtram.io is 100 % Rust using nickel.rs"
 -
   name: Tilde
-  url: http://www.tilde.org
+  url: http://www.tilde.io
   logo: tilde.png
   how: "<a href='http://blog.skylight.io/rust-means-never-having-to-close-a-socket/'>Optimizing Skylight</a>, the Rails profiler."


### PR DESCRIPTION
The URL for Tilde was tilde.org, but is actually tilde.io in practice. 👍 