### PR TITLE
Change many HTTP links to HTTPS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing to the Rust site!
 
 As a reminder, all contributors are expected to follow our [Code of Conduct][coc].
 
-[coc]: http://www.rust-lang.org/conduct.html
+[coc]: https://www.rust-lang.org/conduct.html
 
 ## What this repo isn't
 

--- a/_data/users.yml
+++ b/_data/users.yml
@@ -54,7 +54,7 @@
   how: "Fast and robust monitoring agent for web applications."
 -
   name: Ather Energy
-  url: http://www.atherenergy.com/
+  url: https://www.atherenergy.com/
   logo: ather.svg
   how: "Sending scooter data to the cloud reliably."
 -
@@ -96,7 +96,7 @@
   name: Mozilla
   url: https://www.mozilla.org
   logo: mozilla.png
-  how: "Building the <a href='http://servo.org'>Servo</a> browser engine, <a href='https://bugzilla.mozilla.org/show_bug.cgi?id=1135640'>integrating into Firefox</a>, other projects."
+  how: "Building the <a href='https://servo.org'>Servo</a> browser engine, <a href='https://bugzilla.mozilla.org/show_bug.cgi?id=1135640'>integrating into Firefox</a>, other projects."
 -
   name: Navitia
   url: http://www.navitia.io

--- a/_includes/editor.js
+++ b/_includes/editor.js
@@ -49,7 +49,7 @@
 
   // Changes the height of the editor to match its contents
   function updateEditorHeight() {
-    // http://stackoverflow.com/questions/11584061/
+    // https://stackoverflow.com/questions/11584061/
     var newHeight = editor.getSession().getScreenLength()
       * editor.renderer.lineHeight
       + editor.renderer.scrollBar.getWidth();

--- a/contribute-community.md
+++ b/contribute-community.md
@@ -73,12 +73,12 @@ Conduct training on Rust. (link to training material).
 [/r/rust]: https://reddit.com/r/rust
 [E-easy]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-easy
 [E-mentor]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-easy+label%3AE-mentor
-[Stack Overflow]: http://stackoverflow.com/questions/tagged/rust
-[This Week in Rust]: http://www.this-week-in-rust.org
+[Stack Overflow]: https://stackoverflow.com/questions/tagged/rust
+[This Week in Rust]: https://this-week-in-rust.org
 [community team]: https://www.rust-lang.org/team.html#Community
 [events]: https://www.google.com/calendar/embed?src=apd9vmbc22egenmtu5l6c5jbfc@group.calendar.google.com
-[helpful]: http://blogs.msmvps.com/jonskeet/2009/02/17/answering-technical-questions-helpfully/
+[helpful]: https://codeblog.jonskeet.uk/2009/02/17/answering-technical-questions-helpfully/
 [mentor]: https://users.rust-lang.org/t/mentoring-newcomers-to-the-rust-ecosystem/3088
-[mentor-guide]: http://manishearth.github.io/blog/2016/01/03/making-your-open-source-project-newcomer-friendly/
+[mentor-guide]: https://manishearth.github.io/blog/2016/01/03/making-your-open-source-project-newcomer-friendly/
 [user groups]: user-groups.html
 [users.rust-lang.org]: https://users.rust-lang.org

--- a/contribute-compiler.md
+++ b/contribute-compiler.md
@@ -96,7 +96,7 @@ TODO: some of this RFC description could probably go in the RFC readme
 [I-slow]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AI-slow
 [Rust DXR]: https://dxr.mozilla.org/rust/source/src
 [ice]: https://users.rust-lang.org/t/glacier-a-big-ol-pile-of-ice/3380
-[internals-docs]: http://manishearth.github.io/rust-internals-docs
+[internals-docs]: https://manishearth.github.io/rust-internals-docs
 [internals.rust-lang.org]: https://internals.rust-lang.org/
 [issue-fcp]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AB-unstable+label%3Afinal-comment-period
 [mir]: https://github.com/rust-lang/rust/issues/27840

--- a/contribute-docs.md
+++ b/contribute-docs.md
@@ -54,16 +54,16 @@ TODO: blogging, translation
 [A-docs]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-docs
 [Rust By Example]: https://github.com/rust-lang/rust-by-example
 [Rust Design Patterns]: https://github.com/nrc/patterns
-[Rust Style Guidelines]: http://doc.rust-lang.org/style/index.html
-[The Book]: http://doc.rust-lang.org/book/index.html
-[The Rust Reference]: http://doc.rust-lang.org/reference.html
-[The Rustonomicon]: http://doc.rust-lang.org/nomicon/index.html
+[Rust Style Guidelines]: https://doc.rust-lang.org/style/index.html
+[The Book]: https://doc.rust-lang.org/book/index.html
+[The Rust Reference]: https://doc.rust-lang.org/reference.html
+[The Rustonomicon]: https://doc.rust-lang.org/nomicon/index.html
 [awesome-rust]: https://github.com/kud1ing/awesome-rust
 [crate_docs]: https://users.rust-lang.org/t/lets-talk-about-ecosystem-documentation/2791
 [err-issue]: https://github.com/rust-lang/rust/issues/24407
-[err]: http://doc.rust-lang.org/error-index.html
+[err]: https://doc.rust-lang.org/error-index.html
 [rust-learning]: https://github.com/ctjhoa/rust-learning
 [rust-rosetta]: https://github.com/Hoverbear/rust-rosetta
 [src/doc]: https://github.com/rust-lang/rust/tree/master/src/doc
-[std]: http://doc.rust-lang.org/std/index.html
+[std]: https://doc.rust-lang.org/std/index.html
 [Rust website Git repository]: https://github.com/rust-lang/rust-www

--- a/documentation.md
+++ b/documentation.md
@@ -89,8 +89,8 @@ Much of the official Rust documentation is also available for the
 [nightly] and [beta] releases in addition to the stable documentation
 linked above.
 
-[nightly]: http://doc.rust-lang.org/nightly/
-[beta]: http://doc.rust-lang.org/beta/
+[nightly]: https://doc.rust-lang.org/nightly/
+[beta]: https://doc.rust-lang.org/beta/
 
 ## Non-english resources
 

--- a/downloads.html
+++ b/downloads.html
@@ -111,7 +111,7 @@ title: Downloads &middot; The Rust Programming Language
         <p>
         The current development branch.
 	It includes
-	<a href="http://doc.rust-lang.org/book/nightly-rust.html">unstable features</a>
+	<a href="https://doc.rust-lang.org/book/nightly-rust.html">unstable features</a>
 	that are not available in the betas or stable releases.
         </p>
       </div>
@@ -159,7 +159,7 @@ title: Downloads &middot; The Rust Programming Language
     <div class="row">
       <div class="col-md-12">
       <p>
-        Discover other downloads in <a href="http://static.rust-lang.org/dist/index.html">the archives.</a>
+        Discover other downloads in <a href="https://static.rust-lang.org/dist/index.html">the archives.</a>
       </p>
       </div>
     </div>

--- a/faq.md
+++ b/faq.md
@@ -117,7 +117,7 @@ There are several ways. You can:
 
 - Post in [users.rust-lang.org](https://users.rust-lang.org/), the official Rust users forum
 - Ask in the official [Rust IRC channel](https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust) (#rust on irc.mozilla.org)
-- Ask on [Stack Overflow](http://stackoverflow.com/questions/tagged/rust) with the "rust" tag
+- Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/rust) with the "rust" tag
 - Post in [/r/rust](https://www.reddit.com/r/rust), the unofficial Rust subreddit
 
 <h3><a href="#why-has-rust-changed-so-much" name="why-has-rust-changed-so-much">
@@ -168,7 +168,7 @@ This is partly due to preference of the original developer (Graydon), and partly
 How fast is Rust?
 </a></h3>
 
-Fast! Rust is already competitive with idiomatic C and C++ in a number of benchmarks (like the [Benchmarks Game](http://benchmarksgame.alioth.debian.org/u64q/compare.php?lang=rust&lang2=gpp) and [others](https://github.com/kostya/benchmarks)).
+Fast! Rust is already competitive with idiomatic C and C++ in a number of benchmarks (like the [Benchmarks Game](https://benchmarksgame.alioth.debian.org/u64q/compare.php?lang=rust&lang2=gpp) and [others](https://github.com/kostya/benchmarks)).
 
 Like C++, Rust takes [zero-cost abstractions](http://blog.rust-lang.org/2015/05/11/traits.html) as one of its core principles: none of Rust's abstractions impose a global performance penalty, nor is there overhead from any runtime system.
 
@@ -185,7 +185,7 @@ By avoiding GC, Rust can offer numerous benefits: predictable cleanup of resourc
 Rust avoids the need for GC through its system of ownership and borrowing, but that same system helps with a host of other problems, including
 [resource management in general](http://blog.skylight.io/rust-means-never-having-to-close-a-socket/) and [concurrency](http://blog.rust-lang.org/2015/04/10/Fearless-Concurrency.html).
 
-For when single ownership does not suffice, Rust programs rely on the standard reference-counting smart pointer type, [`Rc`](http://doc.rust-lang.org/std/rc/struct.Rc.html), and its thread-safe counterpart, [`Arc`](http://doc.rust-lang.org/std/sync/struct.Arc.html), instead of GC.
+For when single ownership does not suffice, Rust programs rely on the standard reference-counting smart pointer type, [`Rc`](https://doc.rust-lang.org/std/rc/struct.Rc.html), and its thread-safe counterpart, [`Arc`](https://doc.rust-lang.org/std/sync/struct.Arc.html), instead of GC.
 
 We are however investigating *optional* garbage collection as a future
 extension. The goal is to enable smooth integration with
@@ -193,7 +193,7 @@ garbage-collected runtimes, such as those offered by the
 [Spidermonkey](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey)
 and [V8](https://developers.google.com/v8/?hl=en) JavaScript engines.
 Finally, some people have investigated implementing
-[pure Rust garbage collectors](http://manishearth.github.io/blog/2015/09/01/designing-a-gc-in-rust/)
+[pure Rust garbage collectors](https://manishearth.github.io/blog/2015/09/01/designing-a-gc-in-rust/)
 without compiler support.
 
 <h3><a href="#why-is-my-program-slow" name="why-is-my-program-slow">
@@ -270,7 +270,7 @@ Why is there no literal syntax for dictionaries?
 
 Rust's overall design preference is for limiting the size of the *language* while enabling powerful *libraries*. While Rust does provide initialization syntax for arrays and string literals, these are the only collection types built into the language. Other library-defined types, including the ubiquitous [`Vec`][Vec] collection type, use macros for initialization like the [`vec!`][VecMacro] macro.
 
-This design choice of using Rust's macro facilities to initialize collections will likely be extended generically to other collections in the future, enabling simple initialization of not only [`HashMap`][HashMap] and [`Vec`][Vec], but also other collection types such as [`BTreeMap`][BTreeMap]. In the meantime, if you want a more convenient syntax for initializing collections, you can [create your own macro](http://stackoverflow.com/questions/27582739/how-do-i-create-a-hashmap-literal) to provide it.
+This design choice of using Rust's macro facilities to initialize collections will likely be extended generically to other collections in the future, enabling simple initialization of not only [`HashMap`][HashMap] and [`Vec`][Vec], but also other collection types such as [`BTreeMap`][BTreeMap]. In the meantime, if you want a more convenient syntax for initializing collections, you can [create your own macro](https://stackoverflow.com/questions/27582739/how-do-i-create-a-hashmap-literal) to provide it.
 
 <h3><a href="#when-should-i-use-an-implicit-return" name="when-should-i-use-an-implicit-return">
 When should I use an implicit return?
@@ -537,7 +537,7 @@ There are at least four options (discussed at length in [Too Many Linked Lists](
 although this approach pays the cost of memory management.
 - You can implement it using `unsafe` code using raw pointers. This will be
 more efficient, but bypasses Rust's safety guarantees.
-- Using vectors and indices into those vectors. There are [several](http://smallcultfollowing.com/babysteps/blog/2015/04/06/modeling-graphs-in-rust-using-vector-indices/) [available](http://featherweightmusings.blogspot.com/2015/04/graphs-in-rust.html) examples and explanations of this approach.
+- Using vectors and indices into those vectors. There are [several](http://smallcultfollowing.com/babysteps/blog/2015/04/06/modeling-graphs-in-rust-using-vector-indices/) [available](https://featherweightmusings.blogspot.com/2015/04/graphs-in-rust.html) examples and explanations of this approach.
 - Using borrowed references with [`UnsafeCell`][UnsafeCell]. There are [explanations and code](https://github.com/nrc/r4cppp/blob/master/graphs/README.md#node-and-unsafecell) available for this approach.
 
 <h3><a href="#how-can-i-define-a-struct-that-contains-a-reference-to-one-of-its-own-fields" name="how-can-i-define-a-struct-that-contains-a-reference-to-one-of-its-own-fields">
@@ -742,7 +742,7 @@ based on the parameter types of calls to that function (or uses of the structure
 
 During monomorphisisation a new copy of the generic function is translated for each unique set of types the function is instantiated with. This is the same strategy used by C++. It results in fast code that is specialized for every call-site and statically dispatched, with the tradeoff that functions instantiated with many different types can cause "code bloat", where multiple function instances result in larger binaries than would be created with other translation strategies.
 
-Functions that accept [trait objects](http://doc.rust-lang.org/book/trait-objects.html) instead of type parameters do not undergo monomorphisation. Instead, methods on the trait objects are dispatched dynamically at runtime.
+Functions that accept [trait objects](https://doc.rust-lang.org/book/trait-objects.html) instead of type parameters do not undergo monomorphisation. Instead, methods on the trait objects are dispatched dynamically at runtime.
 
 <h3><a href="#whats-the-difference-between-a-function-and-a-closure-that-doesnt-capture" name="whats-the-difference-between-a-function-and-a-closure-that-doesnt-capture">
 What's the difference between a function and a closure that doesn't capture any variables?
@@ -938,7 +938,7 @@ Not currently. Rust macros are ["hygienic macros"](https://en.wikipedia.org/wiki
 How do I debug Rust programs?
 </a></h3>
 
-Rust programs can be debugged using [gdb](http://sourceware.org/gdb/current/onlinedocs/gdb/) or [lldb](http://lldb.llvm.org/tutorial.html), the same as C and C++. In fact, every Rust installation comes with one or both of rust-gdb and rust-lldb (depending on platform support). These are wrappers over gdb and lldb with Rust pretty-printing enabled.
+Rust programs can be debugged using [gdb](https://sourceware.org/gdb/current/onlinedocs/gdb/) or [lldb](http://lldb.llvm.org/tutorial.html), the same as C and C++. In fact, every Rust installation comes with one or both of rust-gdb and rust-lldb (depending on platform support). These are wrappers over gdb and lldb with Rust pretty-printing enabled.
 
 <h3><a href="#how-do-i-locate-a-panic" name="how-do-i-locate-a-panic">
 <code>rustc</code> said a panic occurred in standard library code. How do I locate the mistake in my code?
@@ -1033,7 +1033,7 @@ Yes it can! There are already examples of using Rust for both [Android](https://
 Can I run my Rust program in a web browser?
 </a></h3>
 
-Not yet, but there are efforts underway to make Rust compile to the web with [Emscripten](http://kripken.github.io/emscripten-site/).
+Not yet, but there are efforts underway to make Rust compile to the web with [Emscripten](https://kripken.github.io/emscripten-site/).
 
 <h3><a href="#how-do-i-cross-compile-rust" name="how-do-i-cross-compile-rust">
 How do I cross-compile in Rust?
@@ -1041,7 +1041,7 @@ How do I cross-compile in Rust?
 
 Cross compilation is possible in Rust, but it requires [a bit of work](https://github.com/japaric/rust-cross/blob/master/README.md) to set up. Every Rust compiler is a cross-compiler, but libraries need to be cross-compiled for the target platform.
 
-Rust does distribute [copies of the standard library](http://static.rust-lang.org/dist/) for each of the supported platforms, which are contained in the `rust-std-*` files for each of the build directories found on the distribution page, but there are not yet automated ways to install them.
+Rust does distribute [copies of the standard library](https://static.rust-lang.org/dist/) for each of the supported platforms, which are contained in the `rust-std-*` files for each of the build directories found on the distribution page, but there are not yet automated ways to install them.
 
 <h2 id="modules-and-crates">Modules and Crates</h2>
 
@@ -1137,7 +1137,7 @@ If you know this is going to happen, perhaps it saves a small number of keystrok
 However, in the future, an IDE could help manage declarations, which gives you the best of both worlds: machine assistance for pulling in names, but explicit declarations about where those names are coming from.
 
 <!--
-### How do I package and archive crates from [http://crates.io](http://crates.io)?
+### How do I package and archive crates from [https://crates.io](https://crates.io)?
 
 TODO: Write this answer.
 -->
@@ -1152,7 +1152,7 @@ Import dynamic libraries in Rust with [libloading](https://crates.io/crates/libl
 Why doesn't crates.io have namespaces?
 </a></h3>
 
-Quoting the [official explanation](https://internals.rust-lang.org/t/crates-io-package-policies/1041) of [http://crates.io](http://crates.io)'s design:
+Quoting the [official explanation](https://internals.rust-lang.org/t/crates-io-package-policies/1041) of [https://crates.io](https://crates.io)'s design:
 
 > In the first month with crates.io, a number of people have asked us about the possibility of introducing [namespaced packages](https://github.com/rust-lang/crates.io/issues/58).<br><br>
 >
@@ -1266,7 +1266,7 @@ Does Rust allow non-constant-expression values for globals?
 
 No. Globals cannot have a non-constant-expression constructor and cannot have a destructor at all. Static constructors are undesirable because portably ensuring a static initialization order is difficult. Life before main is often considered a misfeature, so Rust does not allow it.
 
-See the [C++ FQA](http://yosefk.com/c++fqa/ctors.html#fqa-10.12) about the "static initialization order fiasco", and [Eric Lippert's blog](http://ericlippert.com/2013/02/06/static-constructors-part-one/) for the challenges in C#, which also has this feature.
+See the [C++ FQA](http://yosefk.com/c++fqa/ctors.html#fqa-10.12) about the "static initialization order fiasco", and [Eric Lippert's blog](https://ericlippert.com/2013/02/06/static-constructors-part-one/) for the challenges in C#, which also has this feature.
 
 You can approximate non-constant-expression globals with the [lazy-static](https://crates.io/crates/lazy_static/) crate.
 

--- a/ides.html
+++ b/ides.html
@@ -52,7 +52,7 @@
 <br><a href="https://github.com/saviorisdead/RustyCode">Visual Studio Code</a>
 </p>
 
-<p>Code completion is available via <a href="https://github.com/phildawes/racer">Racer</a>. See <a href="http://areweideyet.com/">areweideyet.com</a> for more details on editor plugins and integration with Racer.</p>
+<p>Code completion is available via <a href="https://github.com/phildawes/racer">Racer</a>. See <a href="https://areweideyet.com/">areweideyet.com</a> for more details on editor plugins and integration with Racer.</p>
 
 <p>The next steps are as follows. To finish the plan as described in the RFC. Then to begin implementation work on the compiler and oracle, and continue work on the IDE plugins.</p>
 
@@ -89,7 +89,7 @@ Repository: TBA
 <b>Eclipse (RustDT)</b>
 <br>
 <br>Installation instructions: <a href="https://github.com/RustDT/RustDT/blob/latest/documentation/Installation.md">https://github.com/RustDT/RustDT/blob/latest/documentation/Installation.md</a>
-<br>Download: <a href="http://rustdt.github.io/releases/">http://rustdt.github.io/releases/</a> (via Eclipse)
+<br>Download: <a href="https://rustdt.github.io/releases/">https://rustdt.github.io/releases/</a> (via Eclipse)
 <br>Repository: <a href="https://github.com/RustDT/RustDT">https://github.com/RustDT/RustDT</a>
 <br>Issues: <a href="https://github.com/RustDT/RustDT/issues">https://github.com/RustDT/RustDT/issues</a>
 <br>Contact: Bruno Medeiros
@@ -123,7 +123,7 @@ Repository: TBA
 <ul>
 <li><a href="http://ncameron.org/rust.html">Getting started contributing to Rust</a></li>
 <li><a href="https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md">Contributing to Rust</a></li>
-<li><a href="http://kmcallister.github.io/talks/rust/2015-contributing-to-rust/slides.html">Contributing slides</a></li>
+<li><a href="https://kmcallister.github.io/talks/rust/2015-contributing-to-rust/slides.html">Contributing slides</a></li>
 <li><a href="https://internals.rust-lang.org/">Rust internals forum</a></li>
 <li><a href="https://dxr.mozilla.org/rust/source/">Rust DXR instance</a></li>
 </ul>
@@ -133,7 +133,7 @@ Repository: TBA
 <ul>
 <li><a href="https://git-scm.com/book/en/v2">The Git book</a></li>
 <li><a href="https://guides.github.com/">GitHub guides</a></li>
-<li><a href="http://featherweightmusings.blogspot.co.nz/2015/06/my-git-and-github-work-flow.html">Cheat sheet for my personal workflow</a></li>
+<li><a href="https://featherweightmusings.blogspot.com/2015/06/my-git-and-github-work-flow.html">Cheat sheet for my personal workflow</a></li>
 </ul>
 
 </body>

--- a/legal.md
+++ b/legal.md
@@ -18,7 +18,7 @@ and [COPYRIGHT](https://github.com/rust-lang/rust/blob/master/COPYRIGHT) for det
 
 The Rust and Cargo logos (bitmap and vector) are owned by Mozilla and
 distributed under the terms of the
-[Creative Commons Attribution license (CC-BY)](http://creativecommons.org/licenses/by/4.0/). This
+[Creative Commons Attribution license (CC-BY)](https://creativecommons.org/licenses/by/4.0/). This
 is the most permissive Creative Commons license, and allows reuse and
 modifications for any purpose. The restrictions are that distributors must "give
 appropriate credit, provide a link to the license, and indicate if changes were
@@ -195,4 +195,4 @@ Thanks!
 ## License
 
 Interested parties may adapt this document freely under the
-[Creative Commons CC0 license](http://creativecommons.org/publicdomain/zero/1.0/).
+[Creative Commons CC0 license](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/team.md
+++ b/team.md
@@ -98,7 +98,7 @@ teams:
     members: [brson, carols10cents, skade, manishearth, steveklabnik, bstrie, erickt]
     email: community-team [at] rust-lang [dot] org
   - name: Moderation
-    responsibility: "helping uphold the <a href='http://www.rust-lang.org/conduct.html'>code of conduct</a>"
+    responsibility: "helping uphold the <a href='https://www.rust-lang.org/conduct.html'>code of conduct</a>"
     members: [mbrubeck, BurntSushi, manishearth, pnkfelix, niconii]
     email: rust-mods [at] rust-lang [dot] org
 

--- a/travis/inval-list.py
+++ b/travis/inval-list.py
@@ -3,7 +3,7 @@
 """
 This script creates an invalidation batch for use by the AWS CLI. 
 
-http://docs.aws.amazon.com/cli/latest/reference/cloudfront/create-invalidation.html
+https://docs.aws.amazon.com/cli/latest/reference/cloudfront/create-invalidation.html
 
 Files are listed from `site` and output is written to `target`. 
 """

--- a/user-groups.md
+++ b/user-groups.md
@@ -18,61 +18,61 @@ even better, open a pull request against
 
 ## Australia
 
-[Rust Melbourne](http://www.meetup.com/Rust-Melbourne/), Melbourne.
+[Rust Melbourne](https://www.meetup.com/Rust-Melbourne/), Melbourne.
 
-[Rust Sydney](http://www.meetup.com/Rust-Sydney/), Sydney.
+[Rust Sydney](https://www.meetup.com/Rust-Sydney/), Sydney.
 
 ## Austria
 
-[Klagenfurt Rust Programmers](http://www.meetup.com/Klagenfurt-Rust/), Klagenfurt.
+[Klagenfurt Rust Programmers](https://www.meetup.com/Klagenfurt-Rust/), Klagenfurt.
 
 ## Brazil
 
-[Rust São Paulo](http://www.meetup.com/Rust-Sao-Paulo-Meetup/), São Paulo.
+[Rust São Paulo](https://www.meetup.com/Rust-Sao-Paulo-Meetup/), São Paulo.
 
 ## Canada
 
-[Montréal Rust Language Meetup](http://www.meetup.com/Montreal-Rust-Language-Meetup/), Montréal, QC.
+[Montréal Rust Language Meetup](https://www.meetup.com/Montreal-Rust-Language-Meetup/), Montréal, QC.
 
-[Rust Toronto](http://www.meetup.com/Rust-Toronto/), Toronto.
+[Rust Toronto](https://www.meetup.com/Rust-Toronto/), Toronto.
 
 ## France
 
-[Lille Rust Meetup](http://www.meetup.com/rust-lille/), Lille.
+[Lille Rust Meetup](https://www.meetup.com/rust-lille/), Lille.
 
-[Rust Paris](http://www.meetup.com/Rust-Paris/), Paris.
+[Rust Paris](https://www.meetup.com/Rust-Paris/), Paris.
 
 ## Germany
 
-[Rust Cologne/Bonn User Group](http://www.meetup.com/Rust-Cologne-Bonn/), Köln.
+[Rust Cologne/Bonn User Group](https://www.meetup.com/Rust-Cologne-Bonn/), Köln.
 
-[Rust Berlin](http://www.meetup.com/Rust-Berlin/), Berlin.
+[Rust Berlin](https://www.meetup.com/Rust-Berlin/), Berlin.
 
-[Rust Meetup Hamburg](http://www.meetup.com/Rust-Meetup-Hamburg/), Hamburg.
+[Rust Meetup Hamburg](https://www.meetup.com/Rust-Meetup-Hamburg/), Hamburg.
 
-[Rust Munich](http://www.meetup.com/rust-munich/), München.
+[Rust Munich](https://www.meetup.com/rust-munich/), München.
 
 ## India
 
-[Hyderabad Rust Meetup](http://www.meetup.com/Hyderabad-Rust-Meetup/), Hyderabad.
+[Hyderabad Rust Meetup](https://www.meetup.com/Hyderabad-Rust-Meetup/), Hyderabad.
 
 [Rust Group Bangalore](https://www.facebook.com/groups/RustBLR/1579069959026339/), Bangalore.
 
 ## Indonesia
 
-[Lambda Jakarta](http://www.meetup.com/Lambda-Jakarta/), Jakarta.
+[Lambda Jakarta](https://www.meetup.com/Lambda-Jakarta/), Jakarta.
 
 ## Ireland
 
-[Rust Dublin](http://www.meetup.com/Rust-Dublin/), Dublin.
+[Rust Dublin](https://www.meetup.com/Rust-Dublin/), Dublin.
 
 ## Italy
 
-[Rust lang Milano](http://www.meetup.com/Rust-lang-Milano/), Milano.
+[Rust lang Milano](https://www.meetup.com/Rust-lang-Milano/), Milano.
 
 ## Japan
 
-[Tokyo Rust](http://www.meetup.com/Tokyo-Rust-Meetup/), Tokyo.
+[Tokyo Rust](https://www.meetup.com/Tokyo-Rust-Meetup/), Tokyo.
 
 [Rust Of Us](https://rust-of-us.doorkeeper.jp/), Akihabara, Tokyo.
 
@@ -82,95 +82,95 @@ even better, open a pull request against
 
 ## Mexico
 
-[Rust Lang Comunidad Mexico](http://www.meetup.com/rustlangmx/), Guadalajara.
-[Rust MX](http://www.meetup.com/Rust-MX/), Mexico city.
+[Rust Lang Comunidad Mexico](https://www.meetup.com/rustlangmx/), Guadalajara.
+[Rust MX](https://www.meetup.com/Rust-MX/), Mexico city.
 
 ## Netherlands
 
-[Rust Amsterdam](http://www.meetup.com/Rust-Amsterdam/), Amsterdam.
+[Rust Amsterdam](https://www.meetup.com/Rust-Amsterdam/), Amsterdam.
 
 ## New Zealand
 
-[Wellington Rust Meetup](http://www.meetup.com/Wellington-Rust-Meetup/), Wellington.
+[Wellington Rust Meetup](https://www.meetup.com/Wellington-Rust-Meetup/), Wellington.
 
 ## Phillipines
 
 [Rust Users Group Philippines] (https://www.facebook.com/groups/rustph/), Manila.
 
-[Cebu Rust Camp](http://www.meetup.com/Cebu-Rust-Camp/), Cebu.
+[Cebu Rust Camp](https://www.meetup.com/Cebu-Rust-Camp/), Cebu.
 
 ## Poland
 
-[Rust Warsaw](http://www.meetup.com/Rust-Warsaw/), Warsaw.
+[Rust Warsaw](https://www.meetup.com/Rust-Warsaw/), Warsaw.
 
 ## Russia
 
-[Rust in Moscow](http://www.meetup.com/Rust-%D0%B2-%D0%9C%D0%BE%D1%81%D0%BA%D0%B2%D0%B5/), Moscow.
+[Rust in Moscow](https://www.meetup.com/Rust-%D0%B2-%D0%9C%D0%BE%D1%81%D0%BA%D0%B2%D0%B5/), Moscow.
 
 ## Singapore
 
-[Singapore Rust Meetup](http://www.meetup.com/Singapore-Rust-Meetup/), Singapore.
+[Singapore Rust Meetup](https://www.meetup.com/Singapore-Rust-Meetup/), Singapore.
 
 ## Spain
 
-[Rust Madrid](http://www.meetup.com/Rust-Madrid/), Madrid.
+[Rust Madrid](https://www.meetup.com/Rust-Madrid/), Madrid.
 
-[Rust Barcelona](http://www.meetup.com/Rust-Barcelona/), Barcelona.
+[Rust Barcelona](https://www.meetup.com/Rust-Barcelona/), Barcelona.
 
 ## South Korea
 
-[Rust Seoul](http://www.meetup.com/Rust-Seoul/), Seoul.
+[Rust Seoul](https://www.meetup.com/Rust-Seoul/), Seoul.
 
 ## Sweden
 
-[Rust Skåne](http://www.meetup.com/rust-skane/), Lund.
+[Rust Skåne](https://www.meetup.com/rust-skane/), Lund.
 
 ## Switzerland
 
-[Rust Romandie](http://www.meetup.com/rust-romandie/), Genève.
+[Rust Romandie](https://www.meetup.com/rust-romandie/), Genève.
 
-[Rust Zurich](http://www.meetup.com/Rust-Zurich/), Zürich.
+[Rust Zurich](https://www.meetup.com/Rust-Zurich/), Zürich.
 
 ## Taiwan
 
-[RUST.TW](http://www.meetup.com/RUST-TW/), Taipei
+[RUST.TW](https://www.meetup.com/RUST-TW/), Taipei
 
 ## UK
 
-[Rust London User Group](http://www.meetup.com/Rust-London-User-Group/), London.
+[Rust London User Group](https://www.meetup.com/Rust-London-User-Group/), London.
 
 ## Uruguay
 
-[Rust Montevideo](http://www.meetup.com/Rust-Montevideo/), Montevideo.
+[Rust Montevideo](https://www.meetup.com/Rust-Montevideo/), Montevideo.
 
 ## USA
 
-[The Austin Rust Meetup](http://www.meetup.com/Austin-Rust-Meetup/), Austin.
+[The Austin Rust Meetup](https://www.meetup.com/Austin-Rust-Meetup/), Austin.
 
-[Chicago Rust Meetup](http://www.meetup.com/Chicago-Rust-Meetup/), Chicago, IL.
+[Chicago Rust Meetup](https://www.meetup.com/Chicago-Rust-Meetup/), Chicago, IL.
 
-[Columbus Rust Society](http://www.meetup.com/columbus-rs/), Columbus, OH.
+[Columbus Rust Society](https://www.meetup.com/columbus-rs/), Columbus, OH.
 
-[Desert Rust](http://www.meetup.com/Desert-Rustaceans/), Phoenix, AZ.
+[Desert Rust](https://www.meetup.com/Desert-Rustaceans/), Phoenix, AZ.
 
-[PDXRust](http://www.meetup.com/PDXRust/), Portland, OR.
+[PDXRust](https://www.meetup.com/PDXRust/), Portland, OR.
 
-[Rust Bay Area](http://www.meetup.com/Rust-Bay-Area/), San Francisco, CA.
+[Rust Bay Area](https://www.meetup.com/Rust-Bay-Area/), San Francisco, CA.
 
-[Rust Boston](http://www.meetup.com/Boston-Rust-Meetup-25317522aNpHwZdw/), Boston, MA.
+[Rust Boston](https://www.meetup.com/Boston-Rust-Meetup-25317522aNpHwZdw/), Boston, MA.
 
-[Rust Boulder/Denver](http://www.meetup.com/Rust-Boulder-Denver/), Boulder, CO.
+[Rust Boulder/Denver](https://www.meetup.com/Rust-Boulder-Denver/), Boulder, CO.
 
-[Rust Detroit](http://www.meetup.com/rust-detroit/), Detroit, MI.
+[Rust Detroit](https://www.meetup.com/rust-detroit/), Detroit, MI.
 
-[Rust Learning Group](http://www.meetup.com/Rust-Learning-Group/), Oakland, CA.
+[Rust Learning Group](https://www.meetup.com/Rust-Learning-Group/), Oakland, CA.
 
-[Rust Los Angeles](http://www.meetup.com/Rust-Los-Angeles/), Los Angeles, CA.
+[Rust Los Angeles](https://www.meetup.com/Rust-Los-Angeles/), Los Angeles, CA.
 
-[Rust NYC](http://www.meetup.com/Rust-NYC/), New York, NY
+[Rust NYC](https://www.meetup.com/Rust-NYC/), New York, NY
 
-[Rust Twin Cities](http://www.meetup.com/Rust-TC/), Minneapolis, MN.
+[Rust Twin Cities](https://www.meetup.com/Rust-TC/), Minneapolis, MN.
 
-[San Diego Rust](http://www.meetup.com/San-Diego-Rust/), San Diego, CA.
+[San Diego Rust](https://www.meetup.com/San-Diego-Rust/), San Diego, CA.
 
-[Seattle Rust Meetup](http://www.meetup.com/Seattle-Rust-Meetup/), Seattle, WA.
+[Seattle Rust Meetup](https://www.meetup.com/Seattle-Rust-Meetup/), Seattle, WA.


### PR DESCRIPTION
Change many links to resources identified by URLs with the `http` scheme
to use HTTPS instead, where available.