### PR TITLE
Redirect VC++ Build Tools link to landing page

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -187,8 +187,8 @@ title: Downloads &middot; The Rust Programming Language
 	  MSVC builds of Rust additionally require the Microsoft Visual
           C++ build tools for Visual Studio 2013 or later.
 	  The easiest way to acquire the build tools is by installing
-	  <a href="https://blogs.msdn.microsoft.com/vcblog/2016/03/31/announcing-the-official-release-of-the-visual-c-build-tools-2015/">
-	  Microsoft Visual C++ Build Tools 2015</a> (<a href="http://go.microsoft.com/fwlink/?LinkId=691126">installer</a>)
+	  <a href="http://landinghub.visualstudio.com/visual-cpp-build-tools">
+	  Microsoft Visual C++ Build Tools 2015</a> 
 	  which provides just the Visual C++ build tools.
 	  Alternately, you can <a href="https://www.visualstudio.com/downloads/">install</a>
 	  Visual Studio 2015 or Visual Studio 2013 and during install select the "C++ tools".


### PR DESCRIPTION
We (finally!) have a landing page for the VC++ Build Tools. I'd like to redirect the link on downloads.html from my blog post to the landing page. Also, I'd like to remove the direct download link because it's 1) easy to find on the landing page and 2) can go stale as we update the Build Tools. Note that the next option--install Visual Studio Community--has no direct download link, so removing this adds consistency. 