### PR TITLE
Changes nrc/rustfmt to rust-lang-nursery/rustfmt.

### DIFF
--- a/contribute-bugs.md
+++ b/contribute-bugs.md
@@ -59,7 +59,7 @@ TODO: @nrc says suggesting everybody review w/o training is bad
 [nix]: https://github.com/nix-rust/nix/
 [pull]: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md#pull-requests
 [reviews]: http://blog.originate.com/blog/2014/09/29/effective-code-reviews/
-[rustfmt]: https://github.com/nrc/rustfmt
+[rustfmt]: https://github.com/rust-lang-nursery/rustfmt
 [team]: team.html
 [test]: https://github.com/rust-lang/rust-wiki-backup/blob/master/Note-testsuite.md
 [triage]: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md#issue-triage

--- a/contribute-libs.md
+++ b/contribute-libs.md
@@ -62,6 +62,6 @@ TODO: Not sure #rust-libs is the place to direct people
 [redox-os]: https://github.com/redox-os
 [requested]: https://github.com/rust-lang/rfcs/labels/A-community-library
 [rust-lang-nursery]: https://github.com/rust-lang-nursery
-[rustfmt]: https://github.com/nrc/rustfmt
+[rustfmt]: https://github.com/rust-lang-nursery/rustfmt
 [trending]: https://github.com/trending?l=rust
 [users.rust-lang.org]: https://users.rust-lang.org


### PR DESCRIPTION
In faq.md and community.md, the link points to rust-lang-nursery.
In contribute-bugs.md and contribute-libs.md, the link pointed to nrc.