### PR TITLE
Detect 32 bit windows

### DIFF
--- a/_includes/set_platform.js
+++ b/_includes/set_platform.js
@@ -6,7 +6,13 @@
     if (navigator.platform === "Linux x86_64") { return "x86_64-unknown-linux-gnu";}
     if (navigator.appVersion.indexOf("Linux")  !== -1) { return "x86_64-unknown-linux-gnu";}
     if (navigator.appVersion.indexOf("Mac") !== -1) { return "x86_64-apple-darwin";}
-    if (navigator.appVersion.indexOf("Win") !== -1) { return"x86_64-pc-windows-gnu";}
+    if (navigator.appVersion.indexOf("Win") !== -1) {
+      if (navigator.appVersion.indexOf("Win64") !== -1 || navigator.appVersion.indexOf("WOW64") !== -1) {
+        return "x86_64-pc-windows-gnu";
+      } else {
+        return "i686-pc-windows-gnu";
+      }
+    }
     return "unknown";
   }
 
@@ -28,6 +34,9 @@
   } else if (platform == "x86_64-pc-windows-gnu") {
     rec_version_type = "Windows installer";
     rec_download_file = "rust-" + rec_package_name + "-x86_64-pc-windows-gnu.msi";
+  } else if (platform == "i686-pc-windows-gnu") {
+    rec_version_type = "Windows installer";
+    rec_download_file = "rust-" + rec_package_name + "-i686-pc-windows-gnu.msi";
   }
 
   var rec_package_desc = rec_package_name + " (<span>" + rec_version_type + "</span>)";


### PR DESCRIPTION
Based on http://stackoverflow.com/questions/1741933/detect-64-bit-or-32-bit-windows-from-user-agent-or-javascript
and http://www.useragentstring.com/pages/useragentstring.php

Closes #303 

Unfortunately I was unable to test this locally, `jekyll serve` failed on both windows and linux, with different errors :( Is there some sort of staging site maybe? 