### PR TITLE
fix title in redirect page

### DIFF
--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <title>Ruby Programming Language</title>
+    <title>The Rust Programming Language</title>
     <script type="text/javascript">
       // a list of mappings, the keys are what we might get from a browser, and the
       // values are what URL we should send that value to.


### PR DESCRIPTION
When I added this, I credited Ruby in the issue. No need to also credit Ruby in the title :wink: