### PR TITLE
Use absolute URL for menu items

### DIFF
--- a/_layouts/basic.html
+++ b/_layouts/basic.html
@@ -26,10 +26,10 @@
           </a>
 	</li>
 	<li class="col-xs-12 col-md-10 menu">
-	  <h2><a href="documentation.html">Documentation</a></h2>
-	  <h2><a href="community.html">Community</a></h2>
-	  <h2><a href="downloads.html">Downloads</a></h2>
-	  <h2><a href="contribute.html">Contribute</a></h2>
+	  <h2><a href="/documentation.html">Documentation</a></h2>
+	  <h2><a href="/community.html">Community</a></h2>
+	  <h2><a href="/downloads.html">Downloads</a></h2>
+	  <h2><a href="/contribute.html">Contribute</a></h2>
 	</li>
       </ul>
     </header>


### PR DESCRIPTION
Menu items won't link to their correct pages in some cases.

Example: https://www.rust-lang.org/404/