### PR TITLE
Fix broken link to tutorial in FAQ

### DIFF
--- a/en-US/faq.md
+++ b/en-US/faq.md
@@ -107,7 +107,7 @@ TODO: Write this answer.
 How can I try Rust easily?
 </a></h3>
 
-The easiest way to try Rust is through the [playpen](https://play.rust-lang.org/), an online app for writing and running Rust code. If you want to try Rust on your system, [install it](https://www.rust-lang.org/install.html) and go through the ["Learn Rust"](https://doc.rust-lang.org/stable/book/learn-rust.html) section of the book.
+The easiest way to try Rust is through the [playpen](https://play.rust-lang.org/), an online app for writing and running Rust code. If you want to try Rust on your system, [install it](https://www.rust-lang.org/install.html) and go through the [Guessing Game](https://doc.rust-lang.org/stable/book/guessing-game.html) tutorial in the book.
 
 <h3><a href="#how-do-i-get-help-with-rust-issues" name="how-do-i-get-help-with-rust-issues">
 How do I get help with Rust issues?


### PR DESCRIPTION
I noticed the FAQ was linking to the "Learn Rust" section of the book, but it looks like the book got rewritten a while back, and now you just get a 404 error.

I've tried to fix the link here with an appropriate replacement.