### PR TITLE
Provide link in case redirect fails

### DIFF
--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -21,7 +21,10 @@
       document.location = "/" + language + '{{ page.url }}';
     </script>
     <noscript>
-      <meta http-equiv="refresh" content="0; url=/en-US/">
+      <meta http-equiv="refresh" content="0; url=/en-US{{ page.url }}">
     </noscript>
   </head>
+  <body>
+    <p><a href="/en-US{{ page.url }}">Click here</a> to be redirected.</p>
+  </body>
 </html>


### PR DESCRIPTION
Browsers using uMatrix or uBlock to block JavaScript appear to block `<noscript>` tags as well.

https://github.com/gorhill/uMatrix/issues/319
https://github.com/gorhill/uBlock/issues/308

In other words, neither `<script>` nor `<noscript>` can be relied on to work. This PR adds a body to the redirect page which provides a link, in case the redirect fails.