### PR TITLE
Move the moderation team after the doc team

### DIFF
--- a/en-US/team.md
+++ b/en-US/team.md
@@ -119,13 +119,13 @@ teams:
     lead: erickt
     members: [brson, skade, manishearth, johannhof, steveklabnik, carols10cents, badboy, booyaa, bstrie, erickt, jonathandturner]
     email: community-team [at] rust-lang [dot] org
+  - name: Documentation team
+    responsibility: "ensuring Rust has fantastic documentation"
+    members: [steveklabnik, GuillaumeGomez, jonathandturner, peschkaj]
   - name: Moderation team
     responsibility: "helping uphold the <a href='https://www.rust-lang.org/conduct.html'>code of conduct</a>"
     members: [mbrubeck, BurntSushi, manishearth, pnkfelix, niconii]
     email: rust-mods [at] rust-lang [dot] org
-  - name: Documentation team
-    responsibility: "ensuring Rust has fantastic documentation"
-    members: [steveklabnik, GuillaumeGomez, jonathandturner, peschkaj]
   - name: Rust team alumni
     responsibility: "enjoying a leisurely retirement"
     members: [Gankro, huonw]


### PR DESCRIPTION
I think it's appropriate for the 'special' teams - mods and alums - to be last.

r? @steveklabnik 