### PR TITLE
Allow the release dates to be translated

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 name: The Rust Programming Language
 stable: "1.11.0"
-stable_date: "August 18, 2016"
+stable_date: "2016-08-18"
 stable_blog: "/2016/08/18/Rust-1.11.html"
 beta: "1.12"
-beta_date: "September 29, 2016"
+beta_date: "2016-09-29"
 nightly: "1.13"

--- a/en-US/downloads.html
+++ b/en-US/downloads.html
@@ -9,13 +9,12 @@ title: Downloads &middot; The Rust Programming Language
     <div class="row install">
       <div class="col-md-4 side-header">
         <h2 id="stable">{{ site.stable }}&nbsp;</h2>
-        <h3>{{ site.stable_date }}</h3>
+        <h3>{{ site.stable_date | date: "%B %-d, %Y" }}</h3>
         <p>
 	  The
           <a href="http://blog.rust-lang.org{{ site.stable_blog }}">
-	    current stable release of Rust
-	  </a>
-	  , updated every six weeks and backwards-compatible.
+	    current stable release of Rust</a>,
+	  updated every six weeks and backwards-compatible.
         </p>
       </div>
       <div class="col-md-8">
@@ -65,7 +64,7 @@ title: Downloads &middot; The Rust Programming Language
 	A preview of the upcoming stable release, intended for testing by
 	crate authors. Updated every six weeks and as needed.
         </p>
-        <p><em>Scheduled for stable release<br/>{{ site.beta_date }}</em>.<p>
+        <p><em>Scheduled for stable release<br/>{{ site.beta_date | date: "%B %-d, %Y" }}</em>.<p>
       </div>
       <div class="col-md-8">
         <table class="table-features table-installers"><tbody>

--- a/pt-BR/downloads.html
+++ b/pt-BR/downloads.html
@@ -6,18 +6,20 @@ title: Downloads &middot; A linguagem de programação Rust
     <!-- -->
     <h1>Downloads</h1>
 
+    {% assign months = '/janeiro/fevereiro/março/abril/maio/junho/julho/agosto/setembro/outubro/novembro/dezembro' | split: '/' -%}
+    {% assign stable_month = site.stable_date | date: '%-m' | plus: '0' -%}
+    {% assign beta_month = site.beta_date | date: '%-m' | plus: '0' -%}
     <hr>
 
     <div class="row install">
       <div class="col-md-4 side-header">
         <h2 id="stable">{{ site.stable }}&nbsp;</h2>
-        <h3>{{ site.stable_date }}</h3>
+	<h3>{{ site.stable_date | date: '%-d' }} de {{ months[stable_month] }} de {{ site.stable_date | date: '%Y' }}</h3>
         <p>
 	  O
           <a href="http://blog.rust-lang.org{{ site.stable_blog }}">
-	    atual lançamento estável de rust
-	  </a>
-	  , atualizado à cada 6 semanas e compatível com versões anteriores.
+	    atual lançamento estável de rust</a>,
+	  atualizado à cada 6 semanas e compatível com versões anteriores.
         </p>
       </div>
       <div class="col-md-8">
@@ -67,7 +69,7 @@ title: Downloads &middot; A linguagem de programação Rust
   Uma preview da versão estável que virá, intencionada para teste por
   autores de pacotes. Atualizado à cada seis semanas e quando necessário.
         </p>
-        <p><em>Esperado lançamento como estável:<br/>{{ site.beta_date }}</em>.<p>
+        <p><em>Esperado lançamento como estável:<br/>{{ site.beta_date | date: '%-d' }} de {{ months[beta_month] }} de {{ site.beta_date | date: '%Y' }}</em>.<p>
       </div>
       <div class="col-md-8">
         <table class="table-features table-installers"><tbody>


### PR DESCRIPTION
Use the ISO 8601 format in the config (probably not necessary as Ruby `Time.parse` is lax, but allows graceful degradation when not localized) and put some Liquid hacks [1] to properly display the localized date. Also removed an annoying space between date and comma ;)

Note: I've looked the Portuguese date format up from [ICU](http://www.localeplanet.com/icu/pt-BR/), but I don't know if I'm correct. Anyone care to review?

[1] Inspired from http://alanwsmith.com/jekyll-liquid-date-formatting-examples (but this one is better).