### PR TITLE
Allow the localized messages to go along with the HTML

### DIFF
--- a/_includes/editor.js
+++ b/_includes/editor.js
@@ -23,6 +23,9 @@
   var errorColor = "#F6E2E2";
   var warningColor = "#FFFBCB";
 
+  // Message to show when the program is running
+  var runningMsg = resultDiv.getAttribute("data-msg-running") || "Running...";
+
   // Error message to return when there's a server failure
   var errMsg = "The server encountered an error while running the program.";
 
@@ -235,7 +238,7 @@
   runButton.addEventListener("click", function(ev) {
     resultDiv.style.display = "block";
     clearResultDiv();
-    resultDiv.innerHTML = "Running...";
+    resultDiv.innerHTML = runningMsg;
 
     // clear previous markers, if any
     markers.map(function(id) { editor.getSession().removeMarker(id); });

--- a/_includes/set_platform.js
+++ b/_includes/set_platform.js
@@ -1,24 +1,6 @@
 (function () {
   "use strict";
 
-  // Returns the binary name for the given platform (Linux binary, Windows Installer, etc)
-  function binary_name(platform) {
-	var platforms = {
-		"en": {"linux": "Linux binary", "windows": "Windows Installer", "mac": "Mac Installer"},
-		"en-US": {"linux": "Linux binary", "windows": "Windows Installer", "mac": "Mac Installer"},
-		"pt": {"linux": "Binário Linux", "windows": "Instalador Windows", "mac": "Instalador Mac"},
-		"pt-BR": {"linux": "Binário Linux", "windows": "Instalador Windows", "mac": "Instalador Mac"},
-		"ru": {"linux": "Исполняемые файлы для Linux", "windows": "Установщик для Windows", "mac": "Установщик для Mac"},
-		"ru-RU": {"linux": "Исполняемые файлы для Linux", "windows": "Установщик для Windows", "mac": "Установщик для Mac"},
-		// Add more platforms here
-	};
-	return platforms[get_language()][platform];
-  }
-
-  function get_language() {
-	return window.navigator.language || window.navigator.userLanguage || "en";
-  }
-
   function detect_platform() {
     if (navigator.platform === "Linux i686") { return "i686-unknown-linux-gnu";}
     if (navigator.platform === "Linux x86_64") { return "x86_64-unknown-linux-gnu";}
@@ -41,24 +23,25 @@
   var rec_download_file = "rustc-{{ site.stable }}-src.tar.gz";
 
   if (platform == "x86_64-unknown-linux-gnu") {
-    rec_version_type = binary_name("linux");
+    rec_version_type = "linux";
     rec_download_file = "rust-" + rec_package_name + "-x86_64-unknown-linux-gnu.tar.gz";
   } else if (platform == "i686-unknown-linux-gnu") {
-    rec_version_type = binary_name("linux");
+    rec_version_type = "linux";
     rec_download_file = "rust-" + rec_package_name + "-i686-unknown-linux-gnu.tar.gz";
   } else if (platform == "x86_64-apple-darwin") {
-    rec_version_type = binary_name("mac");
+    rec_version_type = "mac";
     rec_download_file = "rust-" + rec_package_name + "-x86_64-apple-darwin.pkg";
   } else if (platform == "x86_64-pc-windows-gnu") {
-    rec_version_type = binary_name("windows");
+    rec_version_type = "windows";
     rec_download_file = "rust-" + rec_package_name + "-x86_64-pc-windows-gnu.msi";
   } else if (platform == "i686-pc-windows-gnu") {
-    rec_version_type = binary_name("windows");
+    rec_version_type = "windows";
     rec_download_file = "rust-" + rec_package_name + "-i686-pc-windows-gnu.msi";
   }
 
-  var rec_package_desc = rec_package_name + " (<span>" + rec_version_type + "</span>)";
   var rec_vers_div = document.getElementById("install-version");
+  var rec_vers_type_local = rec_vers_div.getAttribute('data-type-' + rec_version_type);
+  var rec_package_desc = rec_package_name + " (<span>" + (rec_vers_type_local || rec_version_type) + "</span>)";
   rec_vers_div.innerHTML = rec_package_desc;
 
   var rec_dl_addy = "https://static.rust-lang.org/dist/" + rec_download_file;

--- a/en-US/index.html
+++ b/en-US/index.html
@@ -17,7 +17,11 @@ title: The Rust Programming Language
       <div class="col-md-4 install-box">
         <span class="version-rec-box-inner">
           Recommended Version:<br>
-          <span id="install-version">
+          <span id="install-version"
+                data-type-linux="Linux binary"
+                data-type-windows="Windows Installer"
+                data-type-mac="Mac Installer"
+                data-type-source="source">
             {{ site.stable }}
             (<span>source</span>)
           </span>
@@ -47,7 +51,7 @@ title: The Rust Programming Language
         <div id="active-code">
           <button type="button" class="btn btn-primary btn-sm" id="run-code">Run</button>
           <div id="editor">{% include example.rs %}</div>
-          <div id="result">
+          <div id="result" data-msg-running="Running...">
             <a id="playlink"><i class="icon-link-ext"></i></a>
           </div>
         </div>

--- a/pt-BR/index.html
+++ b/pt-BR/index.html
@@ -17,7 +17,11 @@ title: A linguagem de programação Rust
       <div class="col-md-4 install-box">
         <span class="version-rec-box-inner">
           Versão recomendada:<br>
-          <span id="install-version">
+          <span id="install-version"
+                data-type-linux="Binário Linux"
+                data-type-windows="Instalador Windows"
+                data-type-mac="Instalador Mac"
+                data-type-source="source">
             {{ site.stable }}
             (<span>source</span>)
           </span>

--- a/ru-RU/index.html
+++ b/ru-RU/index.html
@@ -14,7 +14,11 @@ title: Язык программирования Rust
       <div class="col-md-4 install-box">
         <span class="version-rec-box-inner">
           Рекомендуемая версия:<br>
-          <span id="install-version">
+          <span id="install-version"
+                data-type-linux="Исполняемые файлы для Linux"
+                data-type-windows="Установщик для Windows"
+                data-type-mac="Установщик для Mac"
+                data-type-source="source">
             {{ site.stable }}
             (<span>source</span>)
           </span>


### PR DESCRIPTION
Previously dynamic messages were hard-coded in the script. As the HTML is already localized (or we at least assume so), it is better to put them into the HTML itself---in this case with HTML5 `data-*` attributes.

This change mainly concerns with playpen messages (currently "Running..." only) and the current version replacements (which didn't really work for untranslated languages anyway---check the browser console). Other kinds of dynamic messages or omitted ones (not sure how to deal with the playpen errors in general, seems not working) can be added in the same way.