### PR TITLE
Set opt-level=0 in the live code editor.

### DIFF
--- a/_includes/editor.js
+++ b/_includes/editor.js
@@ -91,7 +91,7 @@
     var req = new XMLHttpRequest();
     var data = JSON.stringify({
       version: "beta",
-      optimize: "2",
+      optimize: "0",
       code: program
     });
 


### PR DESCRIPTION
The old opt-level=2 setting is only accessible when calling evaluate.json directly; neither of the playpen editor's two choices match it, and Cargo defines five profiles, none of which set opt-level=2. High performance can not be critical to a remote execution service subject to internet-scale latency, so opt-level=3 does not gain us much. (On the contrary, it'll probably increase compile times!) Also, we gain overflow checks at opt-level=0. Nice.