### PR TITLE
Remove the BOM

### DIFF
--- a/ru-RU/documentation.md
+++ b/ru-RU/documentation.md
@@ -1,4 +1,4 @@
-﻿---
+---
 layout: ru-RU/default
 title: Документация Rust &middot; Язык Программирования Rust
 ---


### PR DESCRIPTION
Whoops we did it again :)

@E100Beta please make sure there are no Unicode Byte Order Marks in Markdown files in further PRs. Jekyll doesn't process such files correctly :(