### PR TITLE
Add a link to friends page to index.html

### DIFF
--- a/en-US/index.html
+++ b/en-US/index.html
@@ -11,7 +11,7 @@ title: The Rust Programming Language
           prevents segfaults,
           and guarantees thread safety.
           <br/>
-          <a href="https://doc.rust-lang.org/book/README.html">Show me!</a>
+          <b><a href="friends.html">See who's using Rust.</a></b>
         </p>
       </div>
       <div class="col-md-4 install-box">


### PR DESCRIPTION
This implements the comment [here](https://github.com/rust-lang/rust-www/pull/486#issuecomment-242837005) to add "See who's using Rust" below the pitch. I don't particularly love how this looks, but it's late and I'm tired.

[Rendered](https://www.rust-lang.org/en-US/index.html).

r? @steveklabnik @aturon 