### PR TITLE
only check for BOM at the start of the line

### DIFF
--- a/tidy.sh
+++ b/tidy.sh
@@ -1,3 +1,3 @@
-git grep -l $'\xEF\xBB\xBF' .
+git grep -l $'^\xEF\xBB\xBF' .
 
 if [ $? -eq 0 ]; then exit 1; else exit 0; fi


### PR DESCRIPTION
Looking in general causes false positives, see https://github.com/rust-lang/rust-www/pull/550