### PR TITLE
Add a language footer to the French basic template

### DIFF
--- a/_layouts/fr-FR/basic.html
+++ b/_layouts/fr-FR/basic.html
@@ -36,6 +36,13 @@
 
     {{ content }}
 
+    <footer>
+      <p>Notre site dans d'autres langues&nbsp;:
+        <a href="/pt-BR/">Português</a>,
+        <a href="/ru-RU/">Русский</a>,
+      </p>
+    </footer>
+
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/_layouts/fr-FR/basic.html
+++ b/_layouts/fr-FR/basic.html
@@ -38,8 +38,10 @@
 
     <footer>
       <p>Notre site dans d'autres langues&nbsp;:
+        <a href="/en-US/">English</a>,
         <a href="/pt-BR/">Português</a>,
         <a href="/ru-RU/">Русский</a>,
+	<a href="/zh-CN/">简体中文</a>
       </p>
     </footer>
 


### PR DESCRIPTION
Allows visitors to switch back to English (or any other language) if they get the French version of the website.