### PR TITLE
Change "Téléchargements" for "Télécharger" in French navigation bar

### DIFF
--- a/_layouts/fr-FR/basic.html
+++ b/_layouts/fr-FR/basic.html
@@ -28,7 +28,7 @@
 	<li class="col-xs-12 col-md-10 menu">
 	  <h2><a href="/fr-FR/documentation.html">Documentation</a></h2>
 	  <h2><a href="/fr-FR/community.html">Communauté</a></h2>
-	  <h2><a href="/fr-FR/downloads.html">Téléchargements</a></h2>
+	  <h2><a href="/fr-FR/downloads.html">Télécharger</a></h2>
 	  <h2><a href="/fr-FR/contribute.html">Contribuer</a></h2>
 	</li>
       </ul>


### PR DESCRIPTION
This makes it fit on a single line on the current layout (instead of two with "Téléchargements").