### PR TITLE
French: Tweaks to ABI wording in downloads page

### DIFF
--- a/fr-FR/downloads.html
+++ b/fr-FR/downloads.html
@@ -79,12 +79,12 @@ title: Téléchagements &middot; Le langage de programmation Rust
           <td><a href="https://static.rust-lang.org/dist/rust-beta-i686-apple-darwin.pkg"><div class="inst-button">32 bits</div></a></td>
           </tr>
           <tr>
-          <td class="inst-type">Windows (<a href="#win-foot">GNU ABI <sup>†</sup></a>) (.msi)</td>
+          <td class="inst-type">Windows (<a href="#win-foot">ABI GNU <sup>†</sup></a>) (.msi)</td>
           <td><a href="https://static.rust-lang.org/dist/rust-beta-x86_64-pc-windows-gnu.msi"><div class="inst-button">64 bits</div></a></td>
           <td><a href="https://static.rust-lang.org/dist/rust-beta-i686-pc-windows-gnu.msi"><div class="inst-button">32 bits</div></a></td>
           </tr>
           <tr>
-          <td class="inst-type">Windows (<a href="#win-foot">MSVC ABI <sup>†</sup></a>) (.msi) </td>
+          <td class="inst-type">Windows (<a href="#win-foot">ABI MSVC <sup>†</sup></a>) (.msi) </td>
           <td><a href="https://static.rust-lang.org/dist/rust-beta-x86_64-pc-windows-msvc.msi"><div class="inst-button">64 bits</div></a></td>
           <td><a href="https://static.rust-lang.org/dist/rust-beta-i686-pc-windows-msvc.msi"><div class="inst-button">32 bits</div></a></td>
           <td></td>
@@ -130,12 +130,12 @@ title: Téléchagements &middot; Le langage de programmation Rust
           <td><a href="https://static.rust-lang.org/dist/rust-nightly-i686-apple-darwin.pkg"><div class="inst-button">32 bits</div></a></td>
           </tr>
           <tr>
-          <td class="inst-type">Windows (<a href="#win-foot">GNU ABI <sup>†</sup></a>) (.msi)</td>
+          <td class="inst-type">Windows (<a href="#win-foot">ABI GNU <sup>†</sup></a>) (.msi)</td>
           <td><a href="https://static.rust-lang.org/dist/rust-nightly-x86_64-pc-windows-gnu.msi"><div class="inst-button">64 bits</div></a></td>
           <td><a href="https://static.rust-lang.org/dist/rust-nightly-i686-pc-windows-gnu.msi"><div class="inst-button">32 bits</div></a></td>
           </tr>
           <tr>
-          <td class="inst-type">Windows (<a href="#win-foot">MSVC ABI <sup>†</sup></a>) (.msi) </td>
+          <td class="inst-type">Windows (<a href="#win-foot">ABI MSVC <sup>†</sup></a>) (.msi) </td>
           <td><a href="https://static.rust-lang.org/dist/rust-nightly-x86_64-pc-windows-msvc.msi"><div class="inst-button">64 bits</div></a></td>
           <td><a href="https://static.rust-lang.org/dist/rust-nightly-i686-pc-windows-msvc.msi"><div class="inst-button">32 bits</div></a></td>
           <td></td>


### PR DESCRIPTION
"GNU ABI"/"MSVC ABI" -> "ABI GNU"/"ABI MSVC" in more places (leftover from my other commit).

Sorry, it looks like I forgot some occurences of the old (incorrect in French) wording.