### PR TITLE
Translate the entire comments to pt-BR

### DIFF
--- a/_includes/pt-BR/example.rs
+++ b/_includes/pt-BR/example.rs
@@ -1,8 +1,8 @@
 // Esse código é editável e rodável!
 fn main() {
     // Uma calculadora simples de inteiros:
-    // `+` or `-` significa somar ou subtrair 1
-    // `*` or `/` significa multiplicar ou dividir por 2
+    // `+` ou `-` significa somar ou subtrair 1
+    // `*` ou `/` significa multiplicar ou dividir por 2
 
     let programa = "+ + * - /";
     let mut acumulador = 0;


### PR DESCRIPTION
Just update the comments to PT-BR the comment, all the comments are in Portuguese, but the "OR" condition not, today this is common use in Portuguese not only in english.

cc @lazpeng 

NOTE: Not change the first line comment because already have a PR that fix the translation
