### PR TITLE
Add whitespace to fix markdown heading.

### DIFF
--- a/en-US/community.md
+++ b/en-US/community.md
@@ -54,6 +54,7 @@ If you can't read English, You can also follow our [Weibo][weibo] for Chinese.
 [reddit_coc]: https://www.reddit.com/r/rust/comments/2rvrzx/our_code_of_conduct_please_read/
 [twitter]: https://twitter.com/rustlang
 [weibo]: http://weibo.com/u/5616913483
+
 ## IRC Channels
 
 Rustaceans maintain a number of friendly, high-traffic [IRC] channels on Mozilla's IRC network, irc.mozilla.org.


### PR DESCRIPTION
The heading "IRC Channels" in https://www.rust-lang.org/en-US/community.html is unformatted, displaying the raw `##` characters.