### PR TITLE
Spanish translation

### DIFF
--- a/es/friends.html
+++ b/es/friends.html
@@ -1,0 +1,71 @@
+---
+layout: es/basic
+title:  Amigos de Rust &middot; El lenguaje de programación Rust
+---
+
+<div id="users">
+
+  <h1>Amigos de Rust</h1>
+  <h2>(Organizaciones que ejecutan Rust en producción)</h2>
+
+  {% for user in site.data.users %}
+    {% assign mod = forloop.index | minus:1 | modulo:3 %}
+    {% if mod != 0 %}
+    {% continue %}
+    {% endif %}
+
+    {% assign offset = forloop.index | minus:1 %}
+
+    <div class="row">
+      {% for user in site.data.users limit:3 offset:offset %}
+        <div class="col-md-4"
+             id="user-logo-{{offset}}-{{forloop.index}}">
+          <div class="user-container">
+            <a href="{{user.url}}" rel="nofollow" alt="{{user.name}}">
+              <img src="../user-logos/{{user.logo}}">
+            </a>
+          </div>
+          <div class="details user-detail fade-out"
+            id="user-details-{{offset}}-{{forloop.index}}">
+            <p><em>{{user.name}}</em> : {{user.how}}</p>
+          </div>
+        </div>
+
+        <script type="text/javascript">
+          var logo = document.getElementById("user-logo-{{offset}}-{{forloop.index}}");
+          logo.onmouseover = function() {
+            var allDetails = document.querySelectorAll(".user-detail");
+            for (var i = 0; i < allDetails.length; i++) {
+              var details = allDetails[i];
+              details.className = details.className.replace(" fade-in", "");
+              details.className = details.className.replace(" fade-out", "");
+              details.className += " fade-out";
+            }
+
+            var details = document.getElementById("user-details-{{offset}}-{{forloop.index}}");
+            details.className = details.className.replace(" fade-in", "");
+            details.className = details.className.replace(" fade-out", "");
+            details.className += " fade-in";
+          };
+
+          logo.onmouseout = function() {
+            var details = document.getElementById("user-details-{{offset}}-{{forloop.index}}");
+            details.className = details.className.replace(" fade-in", "");
+            details.className = details.className.replace(" fade-out", "");
+            details.className += " fade-out";
+          };
+        </script>
+      {% endfor %}
+
+  </div>
+
+  {% endfor %}
+
+  <p id="user-add-info">
+    Si su organización usa Rust en producción y desea estar listado en esta
+    página,<br/> por favor
+    <a href="https://github.com/rust-lang/rust-www/issues/new?title=New+Website+Logo%3A+[insert+name]%0A&body=To+list+your+organization%27s+logo+on+the+Rust+website%2C+fill+out+the+following+information+and+click+%22submit+new+issue%22.+Alternately%2C+you+may+edit+_data%2Fusers.yml+as+described+therein+and+submit+a+pull+request.%0D%0A%0D%0A-+Organization+name%3A+%28as+you+want+it+displayed%29%0D%0A-+Homepage+url%3A+%28homepage%2Fprimary+entry+point+for+users%29%0D%0A-+Logo+url%3A+%28svg+if+possible%2C+pngs+over+400x200px+with+transparent+backgrounds+are+also+acceptable%29%0D%0A-+How+you+are+using+Rust%3A+%28one+sentence+describing+your+use+of+Rust%29%0D%0A-+Url+describing+Rust+usage%3A+%28optional+link+to+e.g.+blog+post+explaining+how+you+use+Rust%29%0D%0A-+Organization+contact%3A+%28name+and+email.+we+may+contact+you+when+updating+this+page.+alternately+you+may+email+this+information+to+user-logos%40rust-lang.org+and+it+will+be+kept+secret%29.%0D%0A">
+      abra un <i>issue</i> y llénelo con la información solicitada</a>.
+  </p>
+
+</div>

--- a/es/index.html
+++ b/es/index.html
@@ -1,0 +1,63 @@
+---
+layout: es/basic
+title: El lenguaje de programación Rust
+---
+
+    <div class="row pitch-row">
+      <div class="col-md-8">
+        <p class="pitch">
+          <b>Rust</b> es un lenguaje de programación de sistemas
+          extremadamente rápido, previene fallas de segmentación y
+          garantiza la seguridad de los hilos de ejecución.
+          <br/>
+          <b><a href="friends.html">Descubre quiénes usan Rust.</a></b>
+        </p>
+      </div>
+      <div class="col-md-4">
+        <a class="release-button" href="install.html">
+          <div class="release-version">Instalar Rust <span>{{ site.stable }}</span></div>
+        </a>
+        <div class="release-date">{{ site.stable_date | date: "%B %-d, %Y" }}</div>
+      </div>
+    </div>
+
+    <div class="row code-row">
+      <div class="col-md-4">
+      <h2>Funcionalidades</h2>
+      <ul class="laundry-list">
+        <li>abstracciones sin costo</li>
+        <li>semántica de movimiento</li>
+        <li>seguridad de memoria garantizada</li>
+        <li>hilos de ejecución sin condición de carrera</li>
+        <li>generalización basada en <i>traits</i></li>
+        <li>comparación de patrones</li>
+        <li>inferencia de tipos</li>
+        <li><i>runtime</i> mínimo</li>
+        <li><i>bindings</i> eficientes con C</li>
+        <li></li>
+      </ul>
+      </div>
+      <div class="col-md-8">
+        <div id="active-code">
+          <button type="button" class="btn btn-primary btn-sm" id="run-code">Ejecutar</button>
+          <div id="editor">{% include example.rs %}</div>
+          <div id="result" data-msg-running="Running...">
+            <a id="playlink"><i class="icon-link-ext"></i></a>
+          </div>
+        </div>
+        <div id="static-code">{% include example.rs.html %}</div>
+        <div class="more-examples">
+          <a href="http://rustbyexample.com/">Más ejemplos</a>
+        </div>
+      </div>
+    </div>
+
+  <script type="text/javascript">
+    {% include include.js %}
+
+    include("https://cdn.jsdelivr.net/ace/1.1.3/noconflict/ace.js", function () {
+      include("https://cdn.jsdelivr.net/ace/1.1.3/noconflict/mode-rust.js", function () {
+        {% include editor.js %}
+      });
+    });
+  </script>

--- a/es/install.html
+++ b/es/install.html
@@ -1,0 +1,215 @@
+---
+layout: es/default
+title: Instalación &middot; El lenguaje de programación Rust
+---
+    <h1 class="rustup">Instalar Rust</h1>
+
+    <div class="row rustup-row">
+      <div class="col-md-8 instr-column">
+        <div id="platform-instructions-unix" class="instructions" style="display: none;">
+          <p>Para instalar Rust, ejecuta lo siguiente en tu termina, luego sigue las instrucciones en pantalla.</p>
+          <pre>curl https://sh.rustup.rs -sSf | sh</pre>
+        </div>
+
+        <div id="platform-instructions-win" class="instructions" style="display: none;">
+          <p>
+            Para instalar Rust, descarga y ejecuta
+            <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+            luego sigue las instrucciones en pantalla.
+          </p>
+        </div>
+
+        <div id="platform-instructions-android" class="instructions" style="display: none;"> 
+         <p>Parece que estas ejecutando Android.</p>
+          <p>
+            The Rust compiler does not run on Android directly (yet),
+            but it does make it easy to cross-compile <em>to</em> Android.
+            Install Rust on a supported host platform and
+            <a href="https://github.com/rust-lang-nursery/rustup.rs/#cross-compilation">
+              follow the cross-compilation instructions
+            </a>
+            to build Rust applications for Android.
+          </p>
+          <p>
+            El compilador de Rust no se puede ejecutar directamente en Android (aún),
+            pero si puede compilar código <em>para</em> Android.
+            Instala Rust en una plataforma soportada y
+            <a href="https://github.com/rust-lang-nursery/rustup.rs/#cross-compilation">
+              sigue las instrucciones de <i>cross-compilation</i>
+            </a>
+            para compilar aplicaciones Rust para Android.
+          </p>
+        </div>
+
+        <div id="platform-instructions-unknown" class="instructions" style="display: none;">
+          <p>No reconozco tu plataforma.</p>
+          <p>
+            Rust runs on Windows, Linux, Mac OS X, FreeBSD and NetBSD. If
+            you are on one of these platforms and are seeing this then please
+            <a href="https://github.com/rust-lang/rust-www/issues/new">report an issue</a>,
+            along with the following values:
+            <div>
+              <div>navigator.platform:</div>
+              <div id="nav-plat"></div>
+              <div>navigator.appVersion:</div>
+              <div id="nav-app"></div>
+            </div>
+          </p>
+          <p>
+            Rust se puede ejecutar en Windows, Linux, Max OS X, FreeBSD y
+            NetBSD. Si estas en una de estas plataformas y estás viendo esto,
+            por favor
+            <a href="https://github.com/rust-lang/rust-www/issues/new">reporta un error</a>,
+            con la siguientes información:
+            <div>
+              <div>navigator.platform:</div>
+              <div id="nav-plat"></div>
+              <div>navigator.appVersion:</div>
+              <div id="nav-app"></div>
+            </div>
+          </p>
+        </div>
+
+        <div id="platform-instructions-default" class="instructions">
+          <div>
+            <p>Para instalar Rust en Unix,<br/>ejecuta lo siguiente en tu
+                terminal y sigue las instrucciones en pantalla.</p>
+            <pre>curl https://sh.rustup.rs -sSf | sh</pre>
+          </div>
+
+          <hr/>
+
+          <div>
+            <p>
+              If you are running Windows,<br/>download and run
+              <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+              then follow the onscreen instructions.
+            </p>
+            <p>
+              Si estas en Windows,<br/>descarga y ejecuta
+              <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+              luego sigue las instrucciones en pantalla.
+            </p>
+          </div>
+        </div>
+
+      </div>
+
+      <div class="col-md-4 release-info-column">
+        <div>
+          <div class="release-version">Rust <span>{{ site.stable }}</span></div>
+          <a href="{{ site.stable_blog }}">
+            <div class="release-date">{{ site.stable_date | date: "%B %-d, %Y" }}</div>
+          </a>
+
+          <br>
+
+          <a id="platform-button" style="display: none;" href="#">
+            haz click o presiona "n" para cambiar de plataforma
+          </a>
+        </div>
+      </div>
+
+    </div>
+
+    <h2>Notas sobre la instalación de Rust</h2>
+
+    <div class="row">
+      <div class="col-md-12">
+
+        <h3>Administración de herramientas con <code>rustup</code></h3>
+
+        <p>
+          Rust se instala y administra con la herramienta
+          <a href="https://github.com/rust-lang-nursery/rustup.rs"><code>rustup</code></a>
+          . Rust tiene un
+          <a href="https://github.com/rust-lang/rfcs/blob/master/text/0507-release-channels.md">
+            proceso de liberación veloz
+          </a> en periodos de 6 semanas y soporta un
+          <a href="https://forge.rust-lang.org/platform-support.html">
+             gran número de plataformas
+          </a>, así que siempre hay varias versiones de Rust disponibles.
+          <code>rustup</code> administra estas versiones en una forma
+          consistente en todas las plataformas que Rust soporta, permitiendo la
+          instalación de Rust en las versiones <i>beta</i> y <i>nightly</i> así
+          como el soporte de compilación para otras plataformas usando
+          <i>cross-compiling</i>
+        </p>
+
+        <p>
+          Para más información lee la
+          <a href="https://github.com/rust-lang-nursery/rustup.rs/blob/master/README.md"> documentación de <code>rustup</code></a>.
+        </p>
+
+        <h3>Configurando la variable de entorno <code>PATH</code></h3>
+
+        <p>
+          En el entorno de desarrollo de Rust, todas las herramientas se
+          instalan en el directorio
+          <span class="platform-specific not-win" style="display: inline;">
+            <code>~/.cargo/bin</code>
+          </span>
+          <span class="platform-specific win" style="display: none;">
+            <code>%USERPROFILE%\.cargo\bin</code>
+          </span>
+          , es ahí donde encontrarás todas las herramientas de Rust, incluyendo
+          <code>rustc</code>, <code>cargo</code>, y <code>rustup</code>.
+        </p>
+
+        <p>
+          Por esto, es común que los desarrolladores de Rust incluyan este
+          directorio en su
+          <a href="https://en.wikipedia.org/wiki/PATH_(variable)"> variable de entorno <code>PATH </code></a>.
+          Durante la instalación, <code>rustup</code>,
+          intentará configurar el
+          <code>PATH</code>, pero debido a las diferencias entre las diferentes plataformas,
+          shells de comandos y errores en <code>rustup</code>, las
+          modificaciones al <code>PATH</code> pueden no tomar efecto hasta que
+          se reinicie la consola, el usuario cierre la sesión, o puede no
+          funcionar en lo absoluto.
+        </p>
+
+        <p>
+          Si luego de la instalación, ejecutar <code>rustc --version</code> en
+          la consola falla, esta es la razón más posible.
+        </p>
+
+        <div class="platform-specific win">
+
+          <h3>Consideraciones en Windows</h3>
+          <!-- This anchor is probably linked in the wild and should not be broken -->
+          <a id="win-foot"></a>
+
+	  <p>
+
+	  </p>
+
+          <p>
+            Para más información sobre como configurar Rust en Windows, puedes
+            leer la
+            <a href="https://github.com/rust-lang-nursery/rustup.rs/blob/master/README.md#working-with-rust-on-windows">Windows-specific <code>rustup</code>
+            documentación</a>.
+          </p>
+
+        </div>
+
+      </div>
+    </div>
+
+    <h2>Otros métodos de instalación</h2>
+
+    <div class="row">
+      <div class="col-md-12">
+        <p>
+          La instalación descrita antes, usando
+          <code>rustup</code>, es la forma recomendada de instalar Rust para la
+          mayoría de desarrolladores, pero Rust se puede
+          <a href="other-installers.html">instalar usando otros métodos</a>
+          también.
+        </p>
+      </div>
+    </div>
+
+    <script type="text/javascript">
+      {% include rustup.js %}
+    </script>


### PR DESCRIPTION
So I started the Spanish translation here, but wanted to be sure I'm doing it correctly before proceeding with the rest of it.

I noticed the convention is `lang`-`2-letter-country-code`, but there is also french named just `fr` and the Spanish translation also fits best just as `es` (is that ok?)