### PR TITLE
Fix minor nitpick in the FAQ

### DIFF
--- a/en-US/faq.md
+++ b/en-US/faq.md
@@ -1295,8 +1295,8 @@ Converting a C-style enum to an integer can be done with an `as` expression, lik
 
 Converting in the other direction can be done with a `match` statement, which maps different numeric values to different potential values for the enum.
 
-<h3><a href="#why-do-rust-programs-use-more-memory-than-c" name="why-do-rust-programs-use-more-memory-than-c">
-Why do Rust programs use more memory than C?
+<h3><a href="#why-do-rust-programs-have-larger-binary-sizes-than-C-programs" name="why-do-rust-programs-have-larger-binary-sizes-than-C-programs">
+Why do Rust programs have larger binary sizes than C programs?
 </a></h3>
 
 There are several factors that contribute to Rust programs having, by default, larger binary sizes than functionally-equivalent C programs. In general, Rust's preference is to optimize for the performance of real-world programs, not the size of small programs.


### PR DESCRIPTION
Closes #657 
  
Changed only [en-US/faq.md](https://github.com/rust-lang/rust-www/blob/dcd6613f08cb410326b54e9e48421212ba1dcc9d/en-US/faq.md)
  
[ru-RU/faq.md](https://github.com/rust-lang/rust-www/blob/dcd6613f08cb410326b54e9e48421212ba1dcc9d/ru-RU/faq.md) is empty so left it as it is.  
  
1.  [fr/faq.md](https://github.com/rust-lang/rust-www/blob/dcd6613f08cb410326b54e9e48421212ba1dcc9d/fr/faq.md), [zh-CN/faq.md](https://github.com/rust-lang/rust-www/blob/dcd6613f08cb410326b54e9e48421212ba1dcc9d/zh-CN/faq.md) and [pt-BR/faq.md](https://github.com/rust-lang/rust-www/blob/dcd6613f08cb410326b54e9e48421212ba1dcc9d/pt-BR/faq.md) are not yet translated to the respective languages, so left them as it is. Should i modify them as well?
2.  In [ko-KR/faq.md](https://github.com/rust-lang/rust-www/blob/dcd6613f08cb410326b54e9e48421212ba1dcc9d/ko-KR/faq.md), only the hyperlink needs changing should i change the hyperlink or leave it as it is?