### PR TITLE
fix(css): ensure font-weight is readable

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,21 +1,5 @@
-@font-face {
-	font-family: 'Fira Sans';
-	font-style: normal;
-	font-weight: 300;
-	src: local('Fira Sans Light'), url("../fonts/FiraSans-Light.woff") format('woff');
-}
-@font-face {
-	font-family: 'Fira Sans';
-	font-style: normal;
-	font-weight: 400;
-	src: local('Fira Sans'), url("../fonts/FiraSans-Regular.woff") format('woff');
-}
-@font-face {
-	font-family: 'Fira Sans';
-	font-style: normal;
-	font-weight: 500;
-	src: local('Fira Sans Medium'), url("../fonts/FiraSans-Medium.woff") format('woff');
-}
+@import url('https://fonts.googleapis.com/css?family=Open+Sans:400,600,700');
+
 @font-face {
     font-family: 'fontello';
     src: url('data:application/octet-stream;base64,d09GRgABAAAAAApAAA4AAAAAESwAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAABPUy8yAAABRAAAAEQAAABWPZlJd2NtYXAAAAGIAAAAOAAAAUrQERm3Y3Z0IAAAAcAAAAAUAAAAHAbYACRmcGdtAAAB1AAABPkAAAmRigp4O2dhc3AAAAbQAAAACAAAAAgAAAAQZ2x5ZgAABtgAAADuAAAA/Hj3u0FoZWFkAAAHyAAAADUAAAA2Ad6oCGhoZWEAAAgAAAAAHQAAACQHlgNVaG10eAAACCAAAAAIAAAACAfQAABsb2NhAAAIKAAAAAYAAAAGAH4AAG1heHAAAAgwAAAAIAAAACAA0AnubmFtZQAACFAAAAF3AAACzcydGhxwb3N0AAAJyAAAAB8AAAAxz/bnmXByZXAAAAnoAAAAVgAAAFaSoZr/eJxjYGR+wTiBgZWBg6mKaQ8DA0MPhGZ8wGDIyMTAwMTAysyAFQSkuaYwOLxgeMHAHPQ/iyGKOYiBHSjMCJIDAAfOC454nGNgYGBmgGAZBkYGEHAB8hjBfBYGDSDNBqQZGZgYGF4w/P8PUgChJRih6oGAkY1hxAMAY8cGrnicY2BAA0YMRsxB/3+CMAAVKgT/eJydVdl201YUlTxkcBI6ZKCgDtfcOFDryoQpGDBpKsV2IR0cCK0EHaQMdOSdxz7ra45Cu1Yf+bTufT0ktHSttiyWz75HW2fYOudGHCMqfRqIa9ShkpcDqaw9lkr3SVzXdS+PlQwGcV22Ek9Jm6idJEpq3exQLvFY6ypZJ1gn4+UgVk9VnmegDOIUHmVJRBtEG6mXJkniieMniRZnEB8lSSAloxCn0shQQjUaxFLVoUzp0KvXE3HTQMpGox51WFT3Q8UnxzWn1KwDRipXOcIV69VGvhunAy97kMQ6wbOthzEeeKx+lCqQipHpyD92Sk6UhoFUcdShVuLoMJNf95FMKs1ApoxiRaXugbjd/XTbFjE9dDq+LkqVRqq6uc4omu3R8aiDKA/Zxumk3NDZ9vDlGVNUq11xs+1AZg1cSslsdJ9EAB0mUuPpAU41nAKpGfVHxdnnzwESyVyUqjxVMod6A5kzO3txMe1uJ6uycKSfBzJvdnbjnYdDp1eHf9H6F0zhzEeP4mJ+PkL6UGp+Ik4kpUZYzPKnhh9xVyBCuTGICxfK4FOEOXRF2tlmXeO1MfaGz/lKqWE9Cdroo/h+Cv1OJCscZ1Gj9UiczWPXda3cZ1BLtbsXOzKvQ5Ui7u8LC64z54RhnhYLVV+e+d4FNP8GiGf8QN40hUv7lilKtG+boky7aIoK7RJUpV02xRTtiimmac+aYob2HVPM0p4zMuP/y9znkfsc3vGQm/Zd5KZ9D7lp30du2g+Qm1YhN20duWkvIDetRm7aVaM6dgQaBmkXUhVB0DSy+mHcVpv1QNaMNHxpYPIuYsj66kRHnbW1yh/Ff3XiCwdyaaKnuyIXm+Iur9sWPjzd7quPmkbdsNX4xpHyMB5Gehya0Fn5zeG/7U3dLpruMqoy6AEVTArAAGXtQALTOtsJpPWap/jyB2BchnjOSkO1VJ87hqbv5Xlf97E58b7H7cYut1x3eQlZ1g1yY/bw31Jkqusf5S2tVCdHrCsnj1VrGEMqvCi6vpKUe7S1G78oqbLyXpTWyueTkJs9gxtCW7buYbAjTGnKJR5eU6UoPdRSjrJDLG8pyjzglIsLWobEuA51D2prxOmhehgbCyGGobS9EHBIKV0V37TKd/Eeq2vY6PjFFeHpenISEZ/iKvtR8FTXRv3oDtq8Zt0ygylVqqf7jE+xr9v2UVlppI6zF7dUB9c06xo5FdNP5GvgdG84aN0DPVR8NEEjVTXH6MYoYzSWNeXfBHQxVn7DaNVi+z3cT52kVay5S5jsmxP34LS7/Sr7tZxbRtb91wa9beSKnyMxvy0K/DsHYrdkDdQ7k4EYC8hZ0BjGFiZ3GK6DbcRt9j8mp//fhoVFclc7Grt56sPVk1Eld9nyuMtNdlnXozZH1U4a+wiNLQ835tjhciy2xGBBtv7B/zHuAXdpUQLg0MhlmIjadKGe6uHqHquxbThXEgF2zbHjdAB6AC5B3xy71vMJgPXcI+cuwH1yCHbIIfiUHILPyLkF8Dk5BF+QQzAgh2CXnDsAD8gheEgOwR45BI/I2QT4khyCr8ghiMkhSMi5DfCYHIIn5BB8TQ7BN0auTmT+lgfZAPrOoptAqZ0aHNo4ZEauTdj7PFj2gUVkH1pE6pGR6xPqUx4s9XuLSP3BIlJ/NHJjQv2JB0v92SJSf7GI1GfGl5kjKa8OnvOODv4El+qtXgAAAAABAAH//wAPeJwdjbFKw1AUhs85N/ck3oBt9HoFaYfUJhUEW9LbG7BopHF0EjchQwvi4O4zuPdJ+iSdHFxdfAWXqyH/9sH38QMB/P2KH/EIE6jg9m55gcjlFQVEKwhIUiBfQQqS4gUQKEB6BmZVgxDwBAAx3F+fLdrNQ3OJJ5rP01G+SKwr08IMsWMOE21O08LdoHVLLMxxojmftkejKea2xElu3bz1xVFT+1ndNDV+hEqF/j2z6Ma4z6yKxpH6NIN47beyLytmfNso3cdhT+PDrmv2qwY7z2Z+1pW7SCn88t89Qwcbv2Wu+LAN1/HAGPgHy/UqTwAAeJxjYGRgYADiQPvm5fH8Nl8ZuJlfAEUYzmef44HQU88wMPz/yfyCOQjI5WBgAokCAE8zDEMAAAB4nGNgZGBgDvqfxRDF/IIBCIAkIwMqYAIAZnQD8wAAAAPoAAAD6AAAAAAAAAB+AAAAAQAAAAIAQAACAAAAAAACAA4AGwBuAAAATwmRAAAAAHicdZDLasJAFIb/8dKLQlta6LazKkppvGA3giBYdNNupLgtMcYkEjMyGQVfo+/Qh+lL9Fn6m4ylKE2YzHe+OXPmZABc4xsC+fPEkbPAGaOcCzhFz3KR/tlyifxiuYwq3iyf0L9bruABgeUqbvDBCqJ0zmiBT8sCV+LScgEX4s5ykf7Rconcs1zGrXi1fELvWa5gIlLLVdyLr4FabXUUhEbWBnXZbrY6crqViipK3Fi6axMqncq+nKvE+HGsHE8t9zz2g3Xs6n24nye+TiOVyJbT3KuRn/jaNf5sVz3dBG1j5nKu1VIObYZcabXwPeOExqy6jcbf8zCAwgpbaES8qhAGEjXaOuc2mmihQ5oyQzIzz4qQwEVM42LNHWG2kjLuc8wZJbQ+M2KyA4/f5ZEfkwLuj1lFH60exhPS7owo85J9OezuMGtESrJMN7Oz395TbHham9Zw165LnXUlMTyoIXkfu7UFjUfvZLdiaLto8P3n/34A3V+ESwB4nGNgYoAALgbsACjPyMSRk5mXrZtaUcLAAAAXRwNGAEu4AMhSWLEBAY5ZuQgACABjILABI0SwAyNwsgQoCUVSRLIKAgcqsQYBRLEkAYhRWLBAiFixBgNEsSYBiFFYuAQAiFixBgFEWVlZWbgB/4WwBI2xBQBEAAA=') format('woff'),
@@ -25,17 +9,19 @@
 }
 
 body {
-	font-family: 'Fira Sans', "Helvetica Neue", Helvetica, Arial, sans-serif;
+	font-family: 'Open Sans', "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-weight: 400;
 	margin-top: 20px;
 	margin-bottom: 10px;
 	max-width: 820px;
 }
 p {
+  font-weight: 400;
 	margin-top: 1.2em;
 	margin-bottom: 1.2em;
 }
 .pitch b {
-	font-weight: 400;
+	font-weight: 700;
 }
 li {
 	margin-bottom: .5em;
@@ -62,7 +48,7 @@ ul.menu li {
 }
 ul.menu h2 {
 	font-size: 20px;
-	font-weight: 500;
+	font-weight: 600;
 	margin: 1em;
 	display: inline;
 	line-height: 1.5em;
@@ -89,11 +75,11 @@ ul.menu li>ul {
 }
 
 h2 {
-	font-weight: 500;
+	font-weight: 600;
 	font-size: 18.5px; /* gridfit */
 }
 h3 {
-	font-weight: 500;
+	font-weight: 600;
 }
 
 .table-features {
@@ -153,7 +139,7 @@ div.install {
 
 p.pitch {
 	font-size: 25px;
-	font-weight: 300;
+	font-weight: 400;
 	text-align: center;
 }
 @media (min-width: 992px) {
@@ -368,7 +354,7 @@ ul.laundry-list {
     line-height: 1.5em;
     margin-top: 0;
     margin-bottom: 1rem;
-    font-weight: 400;
+    font-weight: 700;
     position: relative;
 }
 
@@ -376,20 +362,20 @@ ul.laundry-list {
     font-size: 2em;
     line-height: 1.5em;
     margin: 3rem 0 1rem;
-    font-weight: 400;
-    border-top: 2px solid #dedede;
-    padding-top: 1rem;
+    font-weight: 700;
+		border-top: 2px solid #dedede;
+		padding-top: 1rem;
 }
 
 .content h3 {
     font-size: 1em;
     line-height: 1.5em;
-    font-weight: 500;
+    font-weight: 700;
     margin: 2rem 0;
 }
 
 .side-header h2 {
-	font-weight: 500;
+	font-weight: 700;
 	font-size: 18.5px;
 	line-height: 24px;
 	margin-top: 7px;
@@ -487,7 +473,7 @@ ul.laundry-list {
     text-align: center;
     padding-top: 10px;
     font-size: 2.5em;
-    font-weight: 400;
+    font-weight: 700;
     margin: 0px;
     padding-top: 50px;
 }
@@ -496,7 +482,7 @@ ul.laundry-list {
     text-align: center;
     font-size: 1.5em;
     line-height: 1.5em;
-    font-weight: 400;
+    font-weight: 700;
     margin: 0px;
     padding-bottom: 60px;
 }


### PR DESCRIPTION
fixes #658 

this issue appears to be with the Fira Sans font, across FireFox and Chrome at least. i made a codepen to demo that the font-weight has a HUGE jump: http://codepen.io/anon/pen/dNbeza

<img width="494" alt="screen shot 2017-01-01 at 6 53 37 pm" src="https://cloud.githubusercontent.com/assets/1163554/21583576/7049a844-d055-11e6-974b-d27c4eb4191d.png">


so i switched to the very similar Open Sans which does not have this font-weight issue

<img width="896" alt="screen shot 2017-01-01 at 6 59 27 pm" src="https://cloud.githubusercontent.com/assets/1163554/21583574/67583f02-d055-11e6-8337-3509b6610425.png">
<img width="935" alt="screen shot 2017-01-01 at 7 00 13 pm" src="https://cloud.githubusercontent.com/assets/1163554/21583573/67533d2c-d055-11e6-8b5b-b123537fc5a5.png">


---
if I just stick with Fira Sans, this is the best I can do.

<img width="944" alt="screen shot 2017-01-01 at 6 40 05 pm" src="https://cloud.githubusercontent.com/assets/1163554/21583499/ec9cfe36-d051-11e6-939e-8ce32efd24bc.png">
