### PR TITLE
Specify correct logo email in _data/users.yml

### DIFF
--- a/_data/users.yml
+++ b/_data/users.yml
@@ -14,7 +14,7 @@
 # the name and email of a contact within your organization who the
 # Rust team can contact should we need to make changes to the web
 # page. You may either do this on the pull request itself, or
-# alternately email rust-logos@rust-lang.org with the subject line
+# alternately email user-logos@rust-lang.org with the subject line
 # "Rust User Logo Contact". This information will be kept private.
 
 # Logos will be displayed against a white background and constrained


### PR DESCRIPTION
Corrects the email address for sending logos for the Friends of Rust page.

@brson @steveklabnik 