### PR TITLE
ko-KR: Caught up with recent page additions.

### DIFF
--- a/ko-KR/community.md
+++ b/ko-KR/community.md
@@ -13,8 +13,7 @@ Rust 프로그래밍 언어에는 여러 특장점이 있지만, 그 가운데 �
 만약 커뮤니티 구성원에게 괴롭힘이나 불편함을 당했었거나 당하고 있다면, [Rust 중재 팀][mod_team] 누구에게나 즉시 [연락][mod_team_email]해 주십시오.
 당신이 자주 기여하는 사람이든 새로 오는 사람이든, 저희는 커뮤니티를 당신에게 안전한 장소로 만드는 데 주의를 기울일 것입니다.
 
-[coc]: https://www.rust-lang.org/conduct.html
-[mod_team]: https://www.rust-lang.org/team.html#Moderation
+[coc]: conduct.html
 [mod_team_email]: mailto:rust-mods@rust-lang.org
 
 ## 시작하기
@@ -36,12 +35,14 @@ Rust 언어와 라이브러리에 대한 최신 소식과, 앞으로의 행사 �
 그리고 Rust에서 일어나는 거의 모든 일들은 비공식 서브레딧 [/r/rust][reddit]에서도 함께 의논됩니다.
 
 저희는 [트위터][twitter] 계정도 운영합니다.
+<!-- 영어를 읽을 수 없다면, 중국어 [웨이보][weibo] 계정을 팔로할 수도 있습니다. -->
 
 [twir]: https://this-week-in-rust.org/
 [rust_blog]: http://blog.rust-lang.org/
 [reddit]: https://www.reddit.com/r/rust
 [reddit_coc]: https://www.reddit.com/r/rust/comments/2rvrzx/our_code_of_conduct_please_read/
 [twitter]: https://twitter.com/rustlang
+[weibo]: http://weibo.com/u/5616913483
 
 ## IRC 채널
 
@@ -79,6 +80,7 @@ Rust에 기여하는 데 대한 질문을 하는 데도 쓰입니다.
 - [#rust-bots][bots_irc]에서는 여러 봇들이 Rust에 대한 알림을 전달합니다.
 - [#rust-docs][docs_irc]는 비공식 문서 팀의 보금자리입니다.
 - [#rust-crypto][crypto_irc]는 Rust로 암호학을 하는 데 대해 다룹니다.
+- [#rust-embedded][embedded_irc]는 Rust로 임베디드 개발을 하는 사람들이 모입니다.
 - [#rust-gamedev][gamedev_irc]에는 Rust로 게임 개발을 하는 사람들이 모입니다.
 - [#rust-networking][networking_irc]에는 Rust로 컴퓨터 네트워킹을 하는 사람들이 모입니다.
 - [#rust-offtopic][offtopic_irc]는 Rust 커뮤니티가 온갖 잡담을 하는 장소입니다.
@@ -95,6 +97,7 @@ Rust에 기여하는 데 대한 질문을 하는 데도 쓰입니다.
 [crypto_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-crypto
 [de_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-de
 [es_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-es
+[embedded_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-embedded
 [fr_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-fr
 [gamedev_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-gamedev
 [internals_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
@@ -121,6 +124,13 @@ Rust에 기여하는 데 대한 질문을 하는 데도 쓰입니다.
 
 [users_forum]: https://users.rust-lang.org/
 [internals_forum]: https://internals.rust-lang.org/
+
+## 유튜브 채널
+
+Rust [유튜브 채널][youtube_channel]에는 Rust 프로그래밍을 다루는 비디오 자료가 올라옵니다.
+다양한 컨퍼런스에서 Rust 커뮤니티 사람들이 발표한 것을 녹화한 영상들이 많습니다.
+
+[youtube_channel]: https://www.youtube.com/channel/UCaYhcUwRBNscFNUKTjgPFiA
 
 ## 사용자 그룹과 모임
 
@@ -164,15 +174,15 @@ Rust는 커뮤니티가 주도하는 개발 프로세스를 따르며,
 공식 팀 구성원과는 별개로, 대부분의 팀에는 해당 분야에 대해 잘 알고 코드를 확인할 수 있는 더 많은 리뷰어들이 있습니다.
 이들 중 한 팀에 참여하고 싶다면, 부담 없이 팀 리더나 다른 구성원에게 요청해서 시작할 수 있도록 도움을 받으세요.
 
-[teams]: https://www.rust-lang.org/team.html
-[core_team]: https://www.rust-lang.org/team.html#Core
-[language_team]: https://www.rust-lang.org/team.html#Language-design
-[library_team]: https://www.rust-lang.org/team.html#Library
-[compiler_team]: https://www.rust-lang.org/team.html#Compiler
-[tool_team]: https://www.rust-lang.org/team.html#Tooling-and-infrastructure
-[community_team]: https://www.rust-lang.org/team.html#Community
-[mod_team]: https://www.rust-lang.org/team.html#Moderation
-[doc_team]: https://www.rust-lang.org/en-US/team.html#Documentation-team
+[teams]: team.html
+[core_team]: team.html#Core-team
+[language_team]: team.html#Language-design-team
+[library_team]: team.html#Library-team
+[compiler_team]: team.html#Compiler-team
+[tool_team]: team.html#Tooling-and-infrastructure-team
+[community_team]: team.html#Community-team
+[mod_team]: team.html#Moderation-team
+[doc_team]: team.html#Documentation-team
 
 ## Rust 개발
 

--- a/ko-KR/faq.md
+++ b/ko-KR/faq.md
@@ -67,7 +67,7 @@ Rust는 효율적인 코드와 편안한 수준의 추상화를 제공하며, �
 아니오. Rust는 2006년에 그레이던 호어(Graydon Hoare)가 시간을 쪼개서 하던 사이드 프로젝트로 시작하여 3년간 개발되었습니다.
 2009년에 언어가 기본 테스트를 실행하고 핵심 개념들을 시연할 수 있을 정도로 성숙하자 Mozilla가 관여하기 시작했습니다.
 Mozilla는 여전히 Rust를 지원하고 있습니다만, Rust는 전 세계의 많은 장소에 퍼져 있는 열정적인 사람들로 이루어진 커뮤니티가 개발하고 있습니다.
-[Rust 팀](https://www.rust-lang.org/team.html)은 Mozilla 직원들과 아닌 사람들 둘 다를 포함하고, `rustc`(Rust의 컴파일러)에는 [1,000명 이상의 서로 다른 기여자](https://github.com/rust-lang/rust/)가 참여해 왔습니다.
+[Rust 팀](https://www.rust-lang.org/team.html)은 Mozilla 직원들과 아닌 사람들 둘 다를 포함하고, GitHub의 `rust` 단체에는 [1,500명 이상의 서로 다른 기여자](https://github.com/rust-lang/rust/)가 참여해 왔습니다.
 
 [프로젝트 거버넌스](https://github.com/rust-lang/rfcs/blob/master/text/1068-rust-governance.md)를 따라, Rust는 프로젝트의 비전과 우선 순위를 설정하는 코어 팀에 의해 관리되며 이 코어 팀이 전체적인 관점에서 프로젝트를 인도합니다.
 또한 개별 관심 분야의 개발을 인도하고 장려하기 위한 서브팀들이 있으며, 핵심 언어, 컴파일러, Rust 라이브러리, Rust 도구, 그리고 공식 Rust 커뮤니티의 중재 등이 여기에 포함됩니다.
@@ -1523,8 +1523,8 @@ C 스타일의 열거형은 (`e`가 열거형일 때) `e as i64` 같은 식으�
 
 반대로 바꾸려면 `match` 문장을 써서, 서로 다른 숫자 값들을 열거형의 서로 다른 가능한 값들로 대응시킬 수 있습니다.
 
-<h3><a href="#why-do-rust-programs-use-more-memory-than-c" name="why-do-rust-programs-use-more-memory-than-c">
-왜 Rust 프로그램이 C보다 많은 메모리를 사용하는 거죠?
+<h3><a href="#why-do-rust-programs-have-larger-binary-sizes-than-C-programs" name="why-do-rust-programs-have-larger-binary-sizes-than-C-programs">
+왜 Rust 프로그램의 바이너리 크기가 C 프로그램보다 큰 거죠?
 </a></h3>
 
 Rust 프로그램이 동작이 같은 C 프로그램보다 기본값으로 더 큰 바이너리 크기를 가지는 데 영향을 미치는 여러 요소가 있습니다.
@@ -1768,7 +1768,7 @@ Rust에는 복사 생성자가 있나요?
 </a></h3>
 
 정확히는 아닙니다.
-`Copy`를 구현하는 타입은 C랑 비슷하게, 추가 작업 없이 표준적인 "얕은(shallow) 복사"를 하게 됩니다(이는 C++에서 "오래된 평범한 데이터(plain old data)"와 비슷합니다).
+`Copy`를 구현하는 타입은 C랑 비슷하게, 추가 작업 없이 표준적인 "얕은(shallow) 복사"를 하게 됩니다(이는 C++에서 자명하게 복사할 수 있는 타입들과 비슷합니다).
 사용자 정의된 복사 동작이 필요한 `Copy` 타입을 구현하는 건 불가능합니다.
 대신 Rust에서 "복사 생성자"는 `Clone` 트레이트를 구현하여 명시적으로 `clone` 메소드를 호출하는 걸로 만들어집니다.
 사용자 정의된 복사 연산자를 명시적으로 만드는 건 그 아래의 복잡도를 보여 주며, 개발자가 잠재적으로 비싼 연산을 파악하기 더 쉽게 만듭니다.

--- a/ko-KR/index.html
+++ b/ko-KR/index.html
@@ -17,7 +17,7 @@ title: Rust 프로그래밍 언어
       </div>
       <div class="col-md-4">
         <a class="release-button" href="install.html">
-          <div class="release-version">Install Rust <span>{{ site.stable }}</span></div>
+          <div class="release-version">Rust <span>{{ site.stable }}</span> 설치</div>
         </a>
         <div class="release-date">{{ site.stable_date | date: "%Y년 %-m월 %-d일" }}</div>
       </div>

--- a/ko-KR/install.html
+++ b/ko-KR/install.html
@@ -1,45 +1,43 @@
 ---
 layout: ko-KR/default
-title: Installation &middot; The Rust Programming Language
+title: 설치 &middot; Rust 프로그래밍 언어
 ---
-    <h1 class="rustup">Install Rust</h1>
+    <h1 class="rustup">Rust 설치</h1>
 
     <div class="row rustup-row">
       <div class="col-md-8 instr-column">
         <div id="platform-instructions-unix" class="instructions" style="display: none;">
-          <p>To install Rust, run the following in your terminal, then follow the onscreen instructions.</p>
+          <p>Rust를 설치하려면 다음을 터미널에 입력한 뒤 화면에 나오는 설명(영문)을 따르세요.</p>
           <pre>curl https://sh.rustup.rs -sSf | sh</pre>
         </div>
 
         <div id="platform-instructions-win" class="instructions" style="display: none;">
           <p>
-            To install Rust, download and run
-            <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
-            then follow the onscreen instructions.
+            Rust를 설치하려면
+            <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>을
+            받아 설치한 뒤 화면에 나오는 설명(영문)을 따르세요.
           </p>
         </div>
 
         <div id="platform-instructions-android" class="instructions" style="display: none;"> 
-         <p>It looks like you are running Android.</p>
+         <p>안드로이드를 사용하시는 듯 하네요.</p>
           <p>
-            The Rust compiler does not run on Android directly (yet),
-            but it does make it easy to cross-compile <em>to</em> Android.
-            Install Rust on a supported host platform and
+            Rust 컴파일러는 (아직) 안드로이드에서 직접 동작하진 않지만,
+            안드로이드<em>로</em> 크로스컴파일하는 것은 쉽게 할 수 있습니다.
+            안드로이드용 Rust 애플리케이션을 빌드하려면
+            지원되는 호스트 플랫폼에서 Rust를 설치한 뒤
             <a href="https://github.com/rust-lang-nursery/rustup.rs/#cross-compilation">
-              follow the cross-compilation instructions
-            </a>
-            to build Rust applications for Android.
+              크로스컴파일 방법을 따르십시오</a>.
           </p>
         </div>
 
         <div id="platform-instructions-unknown" class="instructions" style="display: none;">
           <!-- unrecognized platform: ask for help -->
-          <p>I don't recognize your platform.</p>
+          <p>무슨 플랫폼을 사용하시는지 알아내지 못 했습니다.</p>
           <p>
-            Rust runs on Windows, Linux, Mac OS X, FreeBSD and NetBSD. If
-            you are on one of these platforms and are seeing this then please
-            <a href="https://github.com/rust-lang/rust-www/issues/new">report an issue</a>,
-            along with the following values:
+            Rust는 윈도, 리눅스, Mac OS X, FreeBSD 및 NetBSD에서 동작합니다.
+            만약 이들 플랫폼을 쓰는데도 이 화면을 보신다면
+            <a href="https://github.com/rust-lang/rust-www/issues/new">이슈 트래커에 다음 값들을 보고해 주세요</a>:
           </p>
 
           <div>
@@ -51,8 +49,8 @@ title: Installation &middot; The Rust Programming Language
 
           <!-- duplicate the default cross-platform instructions -->
           <div>
-            <p>To install Rust, if you are running Unix,<br/>run the following
-            in your terminal, then follow the onscreen instructions.</p>
+            <p>Rust를 설치하려면, 유닉스를 사용하고 있을 경우,<br/>
+            다음을 터미널에 입력한 뒤 화면에 나오는 설명(영문)을 따르세요.</p>
             <pre>curl https://sh.rustup.rs -sSf | sh</pre>
           </div>
 
@@ -60,17 +58,17 @@ title: Installation &middot; The Rust Programming Language
 
           <div>
             <p>
-              If you are running Windows,<br/>download and run
-              <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
-              then follow the onscreen instructions.
+              윈도를 사용하고 있을 경우,<br/>
+              <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>를
+              받아 설치한 뒤 화면에 나오는 설명(영문)을 따르세요.
             </p>
           </div>
         </div>
 
         <div id="platform-instructions-default" class="instructions">
           <div>
-            <p>To install Rust, if you are running Unix,<br/>run the following
-            in your terminal, then follow the onscreen instructions.</p>
+            <p>Rust를 설치하려면, 유닉스를 사용하고 있을 경우,<br/>
+            다음을 터미널에 입력한 뒤 화면에 나오는 설명(영문)을 따르세요.</p>
             <pre>curl https://sh.rustup.rs -sSf | sh</pre>
           </div>
 
@@ -78,9 +76,9 @@ title: Installation &middot; The Rust Programming Language
 
           <div>
             <p>
-              If you are running Windows,<br/>download and run
-              <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
-              then follow the onscreen instructions.
+              윈도를 사용하고 있을 경우,<br/>
+              <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>를
+              받아 설치한 뒤 화면에 나오는 설명(영문)을 따르세요.
             </p>
           </div>
         </div>
@@ -97,96 +95,90 @@ title: Installation &middot; The Rust Programming Language
           <br>
 
           <a id="platform-button" style="display: none;" href="#">
-            click or press "n" to cycle platforms
+            여길 누르거나 "n"을 눌러서 플랫폼을 바꿉니다
           </a>
         </div>
       </div>
 
     </div>
 
-    <h2>Notes about Rust installation</h2>
+    <h2>Rust 설치에 대한 참고 사항</h2>
 
     <div class="row">
       <div class="col-md-12">
 
-        <h3>Toolchain management with <code>rustup</code></h3>
+        <h3><code>rustup</code>으로 툴체인 관리하기</h3>
 
         <p>
-          Rust is installed and managed by the
+          Rust는
           <a href="https://github.com/rust-lang-nursery/rustup.rs"><code>rustup</code></a>
-          tool. Rust has a 6-week
+          툴로 설치되고 관리됩니다. Rust는 6주 간격의
           <a href="https://github.com/rust-lang/rfcs/blob/master/text/0507-release-channels.md">
-            rapid release process
-          </a> and supports a
+            빠른 릴리스 프로세스</a>를 가지고 있으며
           <a href="https://forge.rust-lang.org/platform-support.html">
-             great number of platforms
-          </a>, so there are many builds of Rust available at any time.
-          <code>rustup</code> manages these builds in a consistent way on every
-          platform that Rust supports, enabling installation of Rust from the
-          beta and nightly release channels as well as support for additional
-          cross-compilation targets
+             많은 수의 플랫폼</a>을 지원하기 때문에,
+          언제나 수많은 Rust 빌드가 존재합니다.
+          <code>rustup</code>은 Rust가 지원하는 모든 플랫폼에서 이 빌드들을 일관되게 다루며,
+          베타 및 나이틀리 릴리스 채널에서 Rust를 설치하는 걸 가능케 하고,
+          추가적인 크로스컴파일 타겟 또한 지원합니다.
         </p>
 
         <p>
-          For more information see the
+          더 자세한 정보는
           <a href="https://github.com/rust-lang-nursery/rustup.rs/blob/master/README.md"><code>rustup</code>
-          documentation</a>.
+          문서</a>를 참고하세요.
         </p>
 
-        <h3>Configuring the <code>PATH</code> environment variable</h3>
+        <h3><code>PATH</code> 환경 변수 설정하기</h3>
 
         <p>
-          In the Rust development environment, all tools are installed to the
+          Rust 개발 환경에서 모든 도구는
           <span class="platform-specific not-win" style="display: inline;">
             <code>~/.cargo/bin</code>
           </span>
           <span class="platform-specific win" style="display: none;">
             <code>%USERPROFILE%\.cargo\bin</code>
-          </span> directory,
-          and this is where you will find the Rust toolchain, including
-          <code>rustc</code>, <code>cargo</code>, and <code>rustup</code>.
+          </span> 디렉토리에 설치되며,
+          <code>rustc</code>, <code>cargo</code>, 그리고 <code>rustup</code>을 포함한
+          Rust 툴체인은 여기에서 찾을 수 있습니다.
         </p>
 
         <p>
-          Accordingly, it is customary for Rust developers to include this
-          directory in their
+          따라서 Rust 개발자는 이 디렉토리를
           <a href="https://en.wikipedia.org/wiki/PATH_(variable)"><code>PATH</code>
-          environment variable</a>.  During installation, <code>rustup</code>,
-          will attempt to configure
-          <code>PATH</code>, but because of differences between platforms,
-          command shells, and bugs in <code>rustup</code>, the modifications
-          to <code>PATH</code> may not take effect until the console is
-          restarted, or the user logged out, or may not succeed at all.
+          환경 변수</a>에 추가하는 게 일반적입니다.
+          설치 과정에서 <code>rustup</code>은 <code>PATH</code>를 설정하려 시도하나,
+          플랫폼의 차이, 명령줄 셸의 차이 및 <code>rustup</code>의 버그 때문에
+          <code>PATH</code>가 콘솔이 재시작될 때까지, 또는 사용자가 로그아웃할 때까지,
+          또는 아예 변경되지 않을 수도 있습니다.
         </p>
 
         <p>
-          If, after installation, running <code>rustc --version</code> in the
-          console fails, this is the most likely reason.
+          만약 설치 후에 콘솔에서 <code>rustc --version</code>를 실행했을 때 실패한다면
+          이게 가장 가능성이 높은 이유입니다.
         </p>
 
         <div class="platform-specific win">
 
-          <h3>Windows considerations</h3>
+          <h3>윈도 한정</h3>
           <!-- This anchor is probably linked in the wild and should not be broken -->
           <a id="win-foot"></a>
 
 	  <p>
-            On Windows, Rust additionally requires the C++ build tools
-            for Visual Studio 2013 or later. The easiest way to acquire the build
-            tools is by installing
+            윈도에서 Rust는 추가적으로 Visual Studio 2013 또는 이후를 위한 C++ 빌드 도구를
+            필요로 합니다. 빌드 도구를 받는 가장 쉬운 방법은
 	    <a href="http://landinghub.visualstudio.com/visual-cpp-build-tools">
-	      Microsoft Visual C++ Build Tools 2015
-            </a>
-            which provides just the Visual C++ build tools. Alternately, you
-	    can <a href="https://www.visualstudio.com/downloads/">install</a>
-	    Visual Studio 2015 or Visual Studio 2013 and during install select
-	    the "C++ tools".
+	      Microsoft Visual C++ Build Tools 2015</a>를
+            설치하여 Visual C++ 빌드 도구만을 설치하는 것입니다.
+            아니면 Visual Studio 2015나 Visual Studio 2013을
+	    <a href="https://www.visualstudio.com/downloads/">설치</a>한 뒤
+            설치 과정에서 "C++ 도구"를 선택해도 됩니다.
 	  </p>
 
           <p>
-            For further information about configuring Rust on Windows see the
-            <a href="https://github.com/rust-lang-nursery/rustup.rs/blob/master/README.md#working-with-rust-on-windows">Windows-specific <code>rustup</code>
-            documentation</a>.
+            윈도에서 Rust를 설정하는 데 더 자세한 정보는
+            <a href="https://github.com/rust-lang-nursery/rustup.rs/blob/master/README.md#working-with-rust-on-windows">윈도용 <code>rustup</code>
+            문서</a>를 참고하십시오.
           </p>
 
         </div>
@@ -194,16 +186,14 @@ title: Installation &middot; The Rust Programming Language
       </div>
     </div>
 
-    <h2>Other installation methods</h3>
+    <h2>다른 설치 방법</h3>
 
     <div class="row">
       <div class="col-md-12">
         <p>
-          The installation described above, via
-          <code>rustup</code>, is the preferred way to install Rust for most developers,
-          but Rust can be
-          <a href="other-installers.html">installed via other methods</a>
-          as well.
+          위에서 설명한 <code>rustup</code>를 사용한 설치는
+          대부분의 개발자들에게 권장되는 Rust 설치 방법이지만,
+          <a href="other-installers.html">다른 방법</a>으로도 설치할 수 있습니다.
         </p>
       </div>
     </div>

--- a/ko-KR/other-installers.md
+++ b/ko-KR/other-installers.md
@@ -1,75 +1,79 @@
 ---
 layout: ko-KR/default
-title: Other Installation Methods &middot; The Rust Programming Language
+title: 다른 설치 방법 &middot; Rust 프로그래밍 언어
+
+localized-channels:
+  stable: 안정
+  beta: 베타
+  nightly: 나이틀리
 ---
 
-# Other Rust Installation Methods
+# 다른 Rust 설치 방법
 
-- [Which installer should you use?](#which)
-- [Other ways to install `rustup`](#more-rustup)
-- [Standalone installers](#standalone)
-- [Source code](#source)
+- [무슨 인스톨러를 써야 합니까?](#which)
+- [`rustup`을 설치하는 다른 방법](#more-rustup)
+- [자기 완결 인스톨러](#standalone)
+- [소스 코드](#source)
 
-## Which installer should you use?
+## 무슨 인스톨러를 써야 합니까?
 <span id="which"></span>
 
-Rust runs on many platforms, and there are many ways to install Rust. If you
-want to install Rust in the most straightforward, recommended way, then follow
-the instructions on the main [installation page].
+Rust는 많은 플랫폼에서 동작하며, Rust를 설치하는 방법 또한 많이 있습니다.
+만약 Rust를 가장 쉽고 권장되는 방법으로 설치하려면
+기본 [설치 페이지][installation page]의 방법을 따라 주세요.
 
-That page describes installation via [`rustup`], a tool that manages multiple
-Rust toolchains in a consistent way across all platforms Rust supports. Why
-might one _not_ want to install using those instructions?
+이 페이지에서는 [`rustup`]으로 설치하는 방법을 설명하는데,
+이 도구는 Rust가 지원하는 모든 플랫폼에서 Rust 툴체인을 일관된 방법으로 다룰 수 있게 해 줍니다.
+이 방법대로 설치를 하지 _않아야_ 할 이유로는 뭐가 있을까요?
 
-- Offline installation. `rustup` downloads components from the internet on
-  demand. If you need to install Rust without access to the internet, `rustup`
-  is not suitable.
-- Preference for the system package manager. On Linux in particular, but also on
-  macOS with [Homebrew], and Windows with [Chocolatey], developers sometimes
-  prefer to install Rust with their platform's package manager.
-- Preference against `curl | sh`. On Unix, we usually install `rustup` by
-  running a shell script via `curl`. Some have concerns about the security of
-  this arrangement and would prefer to download and run the installer
-  themselves.
-- Validating signatures. Although `rustup` performs its downloads over HTTPS,
-  the only way to verify the signatures of Rust installers today is to do so
-  manually with the standalone installers.
-- GUI installation and integration with "Add/Remove Programs" on
-  Windows. `rustup` runs in the console and does not register its installation
-  like typical Windows programs. If you prefer a more typical GUI installation
-  on Windows there are standalone `.msi` installers. In the future
-  `rustup` will also have a GUI installer on Windows.
+- 오프라인 설치. `rustup`은 필요에 따라 인터넷에서 구성 요소를 내려 받습니다.
+  인터넷 접속이 없이 Rust를 설치해야 한다면 `rustup`은 적합하지 않습니다.
 
-Rust's platform support is defined in [three tiers], which correspond closely
-with the installation methods available: in general, the Rust project provides
-binary builds for all tier 1 and tier 2 platforms, and they are all installable
-via `rustup`. Some tier 2 platforms though have only the standard library
-available, not the compiler itself; that is, they are cross-compilation targets
-only; Rust code can run on those platforms, but they do not run the compiler
-itself. Such targets can be installed with the `rustup target add` command.
+- 시스템 패키지 관리자를 쓰고자 할 경우. 특히 리눅스에서 그렇습니다만,
+  macOS에서 [Homebrew]를 쓰는 경우나, 윈도에서 [Chocolatey]를 쓰는 경우에도 해당됩니다.
+  이런 경우 개발자들이 종종 해당 플랫폼의 패키지 관리자로 Rust를 설치하길 원할 수 있습니다.
 
-## Other ways to install `rustup`
+- `curl | sh`를 쓰지 않고자 할 경우. 유닉스에서 `rustup`은 보통 `curl`을 통해
+  셸 스크립트를 실행하여 설치합니다. 이 접근의 보안성에 문제를 제기하는 사람들은
+  인스톨러를 직접 내려 받아 실행하길 원할 수 있습니다.
+
+- 서명을 검증하고자 할 경우. `rustup`에서 내려받기는 HTTPS를 통해 이루어지지만,
+  현재로선 Rust 인스톨러의 서명을 검증하는 유일한 방법은
+  자기 완결 인스톨러를 받아서 수동으로 하는 수 밖에 없습니다.
+
+- 윈도에서 "프로그램 설치/삭제"와 연동하여 GUI 설치를 하고자 할 경우.
+  `rustup`은 콘솔에서 실행되며 일반적인 윈도 프로그램처럼 설치를 등록하지 않습니다.
+  윈도에서 좀 더 일반적인 GUI 설치를 원한다면 자기 완결 `.msi` 인스톨러도 제공됩니다.
+  미래에는 `rustup` 자체적으로 윈도에서 GUI 인스톨러를 제공할 수도 있습니다.
+
+Rust의 플랫폼 지원은 [세 단계][three tiers]로 구성되어 있는데
+이는 어떤 설치 방법을 쓸 수 있느냐와 밀접하게 연관되어 있습니다.
+일반적으로 Rust 프로젝트는 모든 1단계 및 2단계 플랫폼에서 바이너리 빌드를 제공하며,
+`rustup`으로 설치할 수 있습니다.
+단 일부 2단계 플랫폼에서는 컴파일러는 제공하지 않으며 표준 라이브러리만 제공하는데,
+이 경우 크로스플랫폼 타겟으로만 쓰일 수 있기 때문에
+Rust 코드를 실행할 수는 있지만 컴파일러를 실행할 수는 없게 됩니다.
+이러한 타겟은 `rustup target add` 명령으로 설치할 수 있습니다.
+
+## `rustup`을 설치하는 다른 방법
 <span id="rustup"></span>
 
-The way to install `rustup` differs by platform:
+`rustup`을 설치하는 방법은 플랫폼마다 다릅니다:
 
-* On Unix, run `curl https://sh.rustup.rs -sSf | sh` in your
-  shell. This downloads and runs [`rustup-init.sh`], which in turn
-  downloads and runs the correct version of the `rustup-init`
-  executable for your platform.
-* On Windows, download and run [`rustup-init.exe`].
+* 유닉스에서는 셸에서 `curl https://sh.rustup.rs -sSf | sh`을 입력합니다.
+  이렇게 하면 [`rustup-init.sh`]가 받아지고 실행되는데,
+  이 스크립트는 다시 현재 플랫폼에 알맞은 `rustup-init` 실행파일을 내려받아 실행합니다.
+* 윈도에서는 [`rustup-init.exe`]를 내려받아 실행합니다.
 
-`rustup-init` can be configured interactively, and all options can additionally
-be controlled by command-line arguments, which can be passed through the shell
-script. Pass `--help` to `rustup-init` as follows to display the arguments
-`rustup-init` accepts:
+`rustup-init`은 사용자 문답으로 설정할 수도 있으며,
+명령줄 인자를 통해 모든 인자를 제어할 수도 있는데 셸 스크립트를 통해서도 전달할 수 있습니다.
+`rustup-init`에 `--help`를 다음과 같이 전달하면 `rustup-init`이 받는 인자들을 볼 수 있습니다:
 
 ```
 curl https://sh.rustup.rs -sSf | sh -s -- --help
 ```
 
-If you prefer not to use the shell script, you may directly download
-`rustup-init` for the platform of your choice:
+셸 스크립트를 쓰지 않고자 한다면 원하는 플랫폼의 `rustup-init`을 직접 받을 수 있습니다:
 
 <div class="rustup-init-table">
   {% for column in site.data.platforms.rustup %}
@@ -89,31 +93,31 @@ If you prefer not to use the shell script, you may directly download
   {% endfor %}
 </div>
 
-## Standalone installers
+## 자기 완결 인스톨러
 <span id="standalone"></span>
 
-The official Rust standalone installers contain a single release of Rust, and
-are suitable for offline installation. They come in three forms: tarballs
-(extension `.tar.gz`), that work in any Unix-like environment, Windows
-installers (`.msi`), and Mac installers (`.pkg`). These installers come with
-`rustc`, `cargo`, `rustdoc`, the standard library, and the standard
-documentation, but do not provide access to additional cross-targets like
-`rustup` does.
+공식 Rust 자기 완결(스탠드얼론) 인스톨러는 Rust의 한 릴리스를 담고 있으며 오프라인 설치에 적합합니다.
+세 가지 형태가 있는데,
+타르볼(확장자 `.tar.gz`)은 아무 유닉스 계열 환경에서나 동작하며,
+윈도 인스톨러(`.msi`)와 맥 인스톨러(`.pkg`)도 있습니다.
+이 인스톨러들은 `rustc`, `cargo`, `rustdoc`, 표준 라이브러리와 표준 문서를 담고 있지만,
+`rustup` 같이 크로스플랫폼 타겟을 더 제공하진 않습니다.
 
-The most common reasons to use these are:
+이들을 써야 하는 흔한 이유로는:
 
-- Offline installation
-- Prefering a more platform-integrated, graphical installer on Windows
+- 오프라인 설치가 필요하거나,
+- 윈도에서 좀 더 플랫폼에 연동된 그래픽 인스톨러를 선호할 경우가 있습니다.
 
-Each of these binaries is signed with the [Rust signing key], which is
-[available on keybase.io], by the Rust build infrastructure, with
-[GPG]. In the tables below, the `.asc` files are the signatures.
+각 바이너리는 Rust 빌드 설비를 통해,
+[keybase.io][available on keybase.io]에도 있는
+[Rust 서명 키][Rust signing key]로, [GPG]를 통해 서명되어 있습니다.
+아래 표에서 `.asc` 파일들이 서명입니다.
 
-Past releases can be found in [the archives].
+이전 릴리스는 [보관소][the archives]에서 찾을 수 있습니다.
 
 {% for channel in site.channels %}
 
-### {{ channel.name | capitalize }} ({{ channel.vers }})
+### {{ page.localized-channels[channel.name] | capitalize }} ({{ channel.vers }})
 <span id="{{ channel.name }}"></span>
 
 <div class="installer-table {{ channel.name }}">
@@ -145,27 +149,27 @@ Past releases can be found in [the archives].
 
 {% endfor %}
 
-## Source code
+## 소스 코드
 <span id="source"></span>
 
 <div class="installer-table">
   <div>
     <div>
-      <span>Stable</span>
+      <span>안정</span>
       <a href="https://static.rust-lang.org/dist/rustc-{{ site.stable }}-src.tar.gz">.tar.gz</a>
       <a href="https://static.rust-lang.org/dist/rustc-{{ site.stable }}-src.tar.gz.asc">.asc</a>
     </div>
   </div>
   <div>    
     <div>
-      <span>Beta</span>
+      <span>베타</span>
       <a href="https://static.rust-lang.org/dist/rustc-beta-src.tar.gz">.tar.gz</a>
       <a href="https://static.rust-lang.org/dist/rustc-beta-src.gz.asc">.asc</a>
     </div>
   </div>
   <div>    
     <div>
-      <span>Nightly</span>
+      <span>나이틀리</span>
       <a href="https://static.rust-lang.org/dist/rustc-nightly-src.tar.gz">.tar.gz</a>
       <a href="https://static.rust-lang.org/dist/rustc-nightly-src.tar.gz.asc">.asc</a>
     </div>

--- a/ko-KR/user-groups.md
+++ b/ko-KR/user-groups.md
@@ -21,6 +21,10 @@ Rust 사용자들은 주기적으로 Rust 사용자 그룹에 모입니다.
 
 [Klagenfurt Rust Programmers](https://www.meetup.com/Klagenfurt-Rust/), Klagenfurt.
 
+## 벨기에
+
+[Belgium Rust User Group](http://www.rust-lang.be/)
+
 ## 볼리비아
 
 [Rust Bolivia](http://www.mozillabolivia.org/rust/), Santa Cruz, Bolivia.
@@ -41,6 +45,10 @@ Rust 사용자들은 주기적으로 Rust 사용자 그룹에 모입니다.
 
 [Rust Paris](https://www.meetup.com/Rust-Paris/), Paris.
 
+## 핀란드
+
+[Finland Rust Meetup](https://www.meetup.com/Finland-Rust-Meetup/), Helsinki.
+
 ## 독일
 
 [Rust Cologne/Bonn User Group](https://www.meetup.com/Rust-Cologne-Bonn/), Köln.
@@ -53,11 +61,15 @@ Rust 사용자들은 주기적으로 Rust 사용자 그룹에 모입니다.
 
 [Rust Munich](https://www.meetup.com/rust-munich/), München.
 
+[Rust Rhein-Main](https://www.meetup.com/Rust-Rhein-Main/), Frankfurt / Darmstadt.
+
 ## 인도
 
 [Hyderabad Rust Meetup](https://www.meetup.com/Hyderabad-Rust-Meetup/), Hyderabad.
 
 [Rust Group Bangalore](https://www.facebook.com/groups/RustBLR/1579069959026339/), Bangalore.
+
+[Rust Group Coimbatore](https://github.com/dvigneshwer/Rust_Group_Coimbatore), Coimbatore.
 
 ## 인도네시아
 
@@ -70,6 +82,8 @@ Rust 사용자들은 주기적으로 Rust 사용자 그룹에 모입니다.
 ## 이탈리아
 
 [Rust lang Milano](https://www.meetup.com/Rust-lang-Milano/), Milano.
+
+[Rust Rome](https://www.meetup.com/it-IT/Rust-Roma/), Rome.
 
 ## 일본
 
@@ -170,6 +184,12 @@ Rust 사용자들은 주기적으로 Rust 사용자 그룹에 모입니다.
 ### 콜로라도
 
 [Rust Boulder/Denver](https://www.meetup.com/Rust-Boulder-Denver/), Boulder, CO.
+
+### 플로리다
+
+[Rust Tampa](https://www.meetup.com/Rust-Tampa/), Tampa, FL.
+
+[South Florida Rust](https://www.meetup.com/South-Florida-Rust-Meetup/), Fort Lauderdale, FL.
 
 ### 일리노이
 


### PR DESCRIPTION
Most significantly, this PR fully re-translates `install.html` and `other-installers.md`.

Nit: I'm very unsure about the addition of Weibo links to the localized pages, as I believe Weibo is virtually alien to Korean speakers. I have temporarily commented the paragraph out for that reason but I have no other problem to make it visible.