### PR TITLE
Fixed Italian è vs é; better .gitignore for macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _site
 serve/
 *~
+**/.DS_Store

--- a/it-IT/index.html
+++ b/it-IT/index.html
@@ -6,7 +6,7 @@ title: Il linguaggio di programmazione Rust
     <div class="row pitch-row">
       <div class="col-md-8">
         <p class="pitch">
-          <b>Rust</b> é un linguaggio di programmazione per sistemi 
+          <b>Rust</b> è un linguaggio di programmazione per sistemi 
           ad altissime prestazioni
           che previene errori di segmentazione
           e garantisce la sicurezza dei dati tra i thread.


### PR DESCRIPTION
The 3rd person of Italian "essere" (= to be) verb is è, not é. It's a serious error.