### PR TITLE
Fixed all Italian stressed letters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _site
 serve/
 *~
 **/.DS_Store
+**/*.bak*

--- a/it-IT/community.md
+++ b/it-IT/community.md
@@ -1,25 +1,25 @@
 ---
 layout: it-IT/default
-title: La comunitá di Rust &middot; Il linguaggio di programmazione Rust
+title: La comunità di Rust &middot; Il linguaggio di programmazione Rust
 ---
 
-# La comunitá di Rust
+# La comunità di Rust
 
-Il linguaggio di programmazione Rust ha molte qualitá ma la forza piú
-grande di Rust sta nella comunitá di persone che si sono unite per 
+Il linguaggio di programmazione Rust ha molte qualità ma la forza più
+grande di Rust sta nella comunità di persone che si sono unite per 
 rendere il lavorare in Rust un'esperienza appagante.
 
 Noi ci impegniamo a allestire un ambiente amichevole, sicuro
 e accomondante per tutti, a prescindere da sesso, orientamento
-sessuale, disabilitá, etnia, religione o altre caratteristiche
+sessuale, disabilità, etnia, religione o altre caratteristiche
 personali. Il nostro [codice di comportamento][coc] definisce
 gli standard comportamentali in tutti i forum di Rust.
 
 Se sei stato o sei in questo momento vittima di attacchi
-o disturbato da un membro della comunitá, per favore 
+o disturbato da un membro della comunità, per favore 
 [contatta][mod_team_email] qualcuno dal [team di moderazione di Rust]
 [mod_team] immediatamente. Che tu sia un regolare frequentatore o
-un nuovo arrivato, ci impegniamo per rendere la comunitá uno spazio
+un nuovo arrivato, ci impegniamo per rendere la comunità uno spazio
 sicuro per te.
 
 [coc]: conduct.html
@@ -27,22 +27,22 @@ sicuro per te.
 
 ## Per iniziare
 
-Le risorse piú importanti della comunitá per coloro che sono nuovi a Rust sono:
+Le risorse più importanti della comunità per coloro che sono nuovi a Rust sono:
 
 - [#rust-beginners][beginners_irc], un canale IRC che
-  ama rispondere a domande di qualsiasi difficoltá.
+  ama rispondere a domande di qualsiasi difficoltà.
 - Il [Forum Utenti][users_forum], per parlare di tutto
-  ció che riguarda Rust.
+  ciò che riguarda Rust.
 
 Potresti anche trovare aiuto sul sito di domande e risposte [Stack Overflow][stack_overflow].
 
 [stack_overflow]: https://stackoverflow.com/questions/tagged/rust
 
-## Novitá
+## Novità
 
 [This Week in Rust][twir] raccoglie le ultime news, eventi futuri
 e racconta su base settimanale dei cambiamenti in Rust e le
-sue librerie. [Il Blog di Rust][rust_blog] é dove il team di Rust
+sue librerie. [Il Blog di Rust][rust_blog] è dove il team di Rust
 annuncia sviluppi importanti del linguaggio. Quasi ogni cosa
 viene discussa anche nel subreddit non ufficiale [/r/rust][reddit].
 
@@ -60,8 +60,8 @@ Se non conosci l'inglese, puoi anche seguire il nostro [Weibo][weibo] per gli ut
 
 I Rustacchiani mantengono un numero di canali [IRC] amichevoli e molto frequentati sulla rete IRC di Mozilla, irc.mozilla.org. 
 
-Il canale [#rust][rust_irc] é dedicato alle discussioni
-generali su Rust ed é anche un buon posto per cercare aiuto. 
+Il canale [#rust][rust_irc] è dedicato alle discussioni
+generali su Rust ed è anche un buon posto per cercare aiuto. 
 Troverai persone disposte a rispondere a qualsiasi domanda
 su Rust, tipicamente in poco tempo.
 
@@ -69,9 +69,9 @@ Gli sviluppatori di Rust si organizzano su [#rust-internals][internals_irc]. Ded
 
 ### Canali principali
 
-- [#rust][rust_irc] per tutto ció che riguarda Rust
-- [#rust-beginners][beginners_irc] per coloro che sono nuovi al linguaggio, é meno trafficato di #rust
-- [#rust-internals][internals_irc] per discutere sui dettagli di come é fatto Rust e la sua implementazione
+- [#rust][rust_irc] per tutto ciò che riguarda Rust
+- [#rust-beginners][beginners_irc] per coloro che sono nuovi al linguaggio, è meno trafficato di #rust
+- [#rust-internals][internals_irc] per discutere sui dettagli di come è fatto Rust e la sua implementazione
 - [#rustc][rustc_irc] dove parla il [team di sviluppo del compilatore][compiler_team]
 - [#rust-libs][libs_irc] dove parla il  [team di sviluppo delle librerie][library_team]
 - [#rust-tools][tools_irc] dove parla il [team di sviluppo degli strumenti][tool_team]
@@ -142,7 +142,7 @@ Abbiamo due forum per le discussioni sul lungo periodo:
 
 Rust ha un [Canale YouTube][youtube_channel] dove viene caricato del materiale
 sul linguaggiodi programmazione. Si trovano qui registrazioni di varie conferenze
-tenute da membri della comunitá Rust.
+tenute da membri della comunità Rust.
 
 [youtube_channel]: https://www.youtube.com/channel/UCaYhcUwRBNscFNUKTjgPFiA
 
@@ -151,11 +151,11 @@ tenute da membri della comunitá Rust.
 Ci sono oltre 50 [Gruppi Utenti Rust][user_group] nel mondo fra oltre 20
 countries che contano oltre 7,000 membri. I Rustacchiani si incontrano periodicamente
 nei Gruppi Utenti Rust.
-Un ottimo modo per entrare nella comunitá, per imparare e per socializzare
+Un ottimo modo per entrare nella comunità, per imparare e per socializzare
 con persone che hanno interessi simili. Gli incontri sono tenuti su base mensile
 e sono molto informali. Gli incontri sono aperti a tutti.
 
-C'é un [calendario][calendar] globale per organizzare gli eventi Rust.
+C'è un [calendario][calendar] globale per organizzare gli eventi Rust.
 Contatta il [team di moderazione][community_team] per aggiungere il tuo.
 
 [user_group]: ./user-groups.html
@@ -163,17 +163,17 @@ Contatta il [team di moderazione][community_team] per aggiungere il tuo.
 
 ## Il team di Rust
 
-Rust ha un modello di sviluppo guidato dalla comunitá dove la maggior parte
+Rust ha un modello di sviluppo guidato dalla comunità dove la maggior parte
 delle decisioni sono fatte in discussioni aperte e condivise, sotto la
 supervisione di diversi [team][teams]:
 
 * Il [Team Base][core_team] si occupa di guidare il processo di design
-e sviluppo, controllando l'introduzione delle nuove funzionalitá e 
+e sviluppo, controllando l'introduzione delle nuove funzionalità e 
 come ultima voce in capitolo per risolvere le controversie per le
-quali non vi é un chiaro consenso(ció succede raramente).
+quali non vi è un chiaro consenso(ciò succede raramente).
 
 * Il [Team della sintassi][language_team] si occupa di progettare le nuove
-funzionalitá del linguaggio.
+funzionalità del linguaggio.
 
 * Il [Team delle librerie][library_team] si occupa della libreria standard,
 i pacchetti gestiti da rust-lang e le convenzioni da tenere.
@@ -189,7 +189,7 @@ rilascio continuo del progetto.
 [rustup]: https://www.rustup.rs
 [rustfmt]: https://github.com/rust-lang-nursery/rustfmt
 
-* Il [Team della comunitá][community_team] coordina gli eventi,
+* Il [Team della comunità][community_team] coordina gli eventi,
 la portata pubblica, l'utilizzo commerciale, il materiale didattico e l'immagine. 
 Possono anche rivolgersi direttamente ai membri dell'organizzazione nel caso
 in cui non sia chiaro chi contattare in delle discussioni riguardanti Rust.
@@ -220,7 +220,7 @@ che ti possa aiutare a partecipare.
 Rust ha avuto oltre [1'200 diversi sviluppatori][authors], un numero che cresce
 di settimana in settimana. [Vorremmo che tu ti unissi a quella lista][contribute]!
 
-Come menzionato sopra, il [Forum Sviluppo][internals_forum] é dedicato alla discussione
+Come menzionato sopra, il [Forum Sviluppo][internals_forum] è dedicato alla discussione
 sul design e implementazione di Rust. Molte discussioni avvengono anche su 
 GitHub:
 
@@ -230,8 +230,8 @@ GitHub:
   una tua pull request!
 
 - Il [repository per le RFC][rfcs] traccia il nostro processo di Request for Comment, 
-  il modo principale in cui la comunitá Rust e il team raggiungono il consenso
-  sulle nuove funzionalitá proposte per il linguaggio, le librerie ufficiali e gli strumenti.
+  il modo principale in cui la comunità Rust e il team raggiungono il consenso
+  sulle nuove funzionalità proposte per il linguaggio, le librerie ufficiali e gli strumenti.
 
 Circa settimanalmente, il team di Rust emana un [rapporto dei team][team_reports]
 che indica su cosa sono impegnati i team, inclusa l'analisi delle RFC e il

--- a/it-IT/conduct.md
+++ b/it-IT/conduct.md
@@ -9,31 +9,31 @@ title: Il codice di comportamento di Rust &middot; Il linguaggio di programmazio
 
 **Contatto**: [rust-mods@rust-lang.org](mailto:rust-mods@rust-lang.org)
 
-* Noi ci impegniamo a fornire un ambiente amichevole, sicuro e accomodante per tutti, a prescindere dal livello di esperienza, sesso, identitá ed espressione sessuale, orientamento sessuale, disabilitá, aspetto estetico, dimensione corporea, razza, etnia, etá, religione, nazionalitá o altre caratteristiche personali.
+* Noi ci impegniamo a fornire un ambiente amichevole, sicuro e accomodante per tutti, a prescindere dal livello di esperienza, sesso, identità ed espressione sessuale, orientamento sessuale, disabilitá, aspetto estetico, dimensione corporea, razza, etnia, etá, religione, nazionalitá o altre caratteristiche personali.
 * Su IRC, evita di utilizzare pseudonimi troppo sessualizzanti o altri pseudonimi che potrebbero rovinare un ambiente amichevole, sicuro e accomodante per tutti.
-* Sii gentile e servizievole. Non c'é alcun bisogno di essere cattivi o maleducati.
-* Rispetta le persone che non la pensano come te e che ogni scelta di design o implementazione porta molti compromessi e cosi. C'é raramente una vera risposta giusta.
+* Sii gentile e servizievole. Non c'è alcun bisogno di essere cattivi o maleducati.
+* Rispetta le persone che non la pensano come te e che ogni scelta di design o implementazione porta molti compromessi e cosi. C'è raramente una vera risposta giusta.
 * Per favore limita al minimo la critica non costruttiva. Se hai delle idee valide con cui vuoi sperimentare, fai un fork del progetto e guarda come funziona.
-* Ti impediremo di interagire se insulti, parodizzi o disturbi qualcuno. Quello non é un comportamento accettato. Con "disturbo" intendiamo la definizione che si puó trovare nel <a href="http://citizencodeofconduct.org/">Citizen Code of Conduct</a>; se hai qualche dubbio su cosa potrebbe essere incluso in tale concetto, per favore leggi la loro definizione. In particolare non tolleriamo comportamenti che escludono persone appartenenti a gruppi sociali emarginati.
-* La molestia privata é anch'essa inaccettabile. Non interessa chi sei, se stai o sei stato molestato o reso a disagio da un membro della comunitá, per favore contatta uno dei moderatori o qualcuno dal [Team di moderazione](/team.html#Moderation) immediatamente. Che tu sia un frequentatore abituale o un nuovo arrivato, ci interessa rendere questa comunitá un posto sicuro per te.
-* Ogni attivitá pubblicitaria, molesta, offensiva, volutamente provocatoria o ogni ricerca immotivata di attenzione non é benvenuta.
+* Ti impediremo di interagire se insulti, parodizzi o disturbi qualcuno. Quello non è un comportamento accettato. Con "disturbo" intendiamo la definizione che si può trovare nel <a href="http://citizencodeofconduct.org/">Citizen Code of Conduct</a>; se hai qualche dubbio su cosa potrebbe essere incluso in tale concetto, per favore leggi la loro definizione. In particolare non tolleriamo comportamenti che escludono persone appartenenti a gruppi sociali emarginati.
+* La molestia privata è anch'essa inaccettabile. Non interessa chi sei, se stai o sei stato molestato o reso a disagio da un membro della comunità, per favore contatta uno dei moderatori o qualcuno dal [Team di moderazione](/team.html#Moderation) immediatamente. Che tu sia un frequentatore abituale o un nuovo arrivato, ci interessa rendere questa comunitá un posto sicuro per te.
+* Ogni attività pubblicitaria, molesta, offensiva, volutamente provocatoria o ogni ricerca immotivata di attenzione non è benvenuta.
 
 ## Moderazione
 
 Queste sono le politiche per mantenere fede al nostro codice di comportamento. Se pensi che una discussione abbia bisogno di moderazione, per favore contatta il [team di Moderazione](/team.html#Moderation).
 
-1. Frasi che violano gli standard del codice di comportamento di Rust, includendo frasi di odio, offensive, oppressive o emarginanti non sono ammesse. (Sono ammesse le imprecazioni ma non se rivolte a altri utenti o con finalitá di odio.)
+1. Frasi che violano gli standard del codice di comportamento di Rust, includendo frasi di odio, offensive, oppressive o emarginanti non sono ammesse. (Sono ammesse le imprecazioni ma non se rivolte a altri utenti o con finalità di odio.)
 2. Frasi che i moderatori giudicano come inappropriate e inaccettabili, anche se non in esplicita violazione del codice di comportamento.
 3. I moderatori reagiranno alle frasi di cui sopra con un avvertimento iniziale.
-4. Se l'avvertimento viene ignorato, l'utente riceverá un allontanamento temporaneo per calmarsi e riflettere.
-5. Se l'utente ritorna e continua a essere problematico verrá allontanato permanentemente.
-6. I moderatori hanno facoltá a loro discrezione di annullare l'allontanamento qualora l'utente sia alla sua prima violazione e offra una sincera scusa alla parte offesa.
+4. Se l'avvertimento viene ignorato, l'utente riceverà un allontanamento temporaneo per calmarsi e riflettere.
+5. Se l'utente ritorna e continua a essere problematico verrà allontanato permanentemente.
+6. I moderatori hanno facoltà a loro discrezione di annullare l'allontanamento qualora l'utente sia alla sua prima violazione e offra una sincera scusa alla parte offesa.
 7. Se un moderatore allontana qualcuno e tu non condividi la sua decisione, per favore parlane direttamente con lui o con un altro moderatoe, **in privato**. Le lamentele sui provvedimenti disciplinari non sono ammesse nei luoghi di discussione pubblica.
-8. I moderatori sono impegnati a dare il buon esempio, qualora creassero una situazione inappropriata saranno soggetti a reazioni piú decise.
+8. I moderatori sono impegnati a dare il buon esempio, qualora creassero una situazione inappropriata saranno soggetti a reazioni più decise.
 
-Nella comunitá di Rust cerchiamo di andare oltre e di prenderci cura l'uno dell'altro, Non cercare solo di essere tecnicamente inattaccabile, cerca di tirare fuori il meglio che hai in te. In particolare evita di dare corda a discussioni offensive, specialmente se fuori argomento; questo troppo spesso conduce a combattimenti inutili, sentimenti offesi e orgoglio ferito. Inoltre puó condurre alcune persone ad abbandonare la comunitá per sempre.
+Nella comunità di Rust cerchiamo di andare oltre e di prenderci cura l'uno dell'altro, Non cercare solo di essere tecnicamente inattaccabile, cerca di tirare fuori il meglio che hai in te. In particolare evita di dare corda a discussioni offensive, specialmente se fuori argomento; questo troppo spesso conduce a combattimenti inutili, sentimenti offesi e orgoglio ferito. Inoltre può condurre alcune persone ad abbandonare la comunitá per sempre.
 
-Se qualcuno si fa un problema per qualcosa che hai detto o fatto, resisti all'impulso di essere difensivo. Smetti di fare ció e scusati. Anche se ti senti incompreso o accusato ingiustamente, c'é una discreta possibilitá che tu non ti sia spiegato correttamente - ricordati che é una tua responsabilitá di far sentire gli altri Rustacchiani a loro agio. Tutti vogliono stare insieme e siamo qui in primo luogo perché vogliamo parlare di alta tecnologia. Troverai persone pronte a perdonarti e prenderti in buona fede se otterrai la loro fiducia. 
+Se qualcuno si fa un problema per qualcosa che hai detto o fatto, resisti all'impulso di essere difensivo. Smetti di fare ciò e scusati. Anche se ti senti incompreso o accusato ingiustamente, c'è una discreta possibilità che tu non ti sia spiegato correttamente - ricordati che é una tua responsabilitá di far sentire gli altri Rustacchiani a loro agio. Tutti vogliono stare insieme e siamo qui in primo luogo perché vogliamo parlare di alta tecnologia. Troverai persone pronte a perdonarti e prenderti in buona fede se otterrai la loro fiducia. 
 
 Le politiche di cui sopra si applicano a tutti i luoghi ufficiali di Rust; includendo i canali IRC ufficiali(#rust, #rust-internals, #rust-tools, #rust-libs, #rustc, #rust-beginners, #rust-docs, #rust-community, #rust-lang, and #cargo); i repositories GitHub sotto rust-lang, rust-lang-nursery e rust-lang-deprecated; tutti i forum di rust-lang.org(sers.rust-lang.org, internals.rust-lang.org). Qualora un altro progetto volesse adottare il codice di comportamento di Rust, per favore contatti uno sviluppatore di questi progetti per assistenza. Se volessi usare questo codice di comportamento per il tuo progetto personale ti suggeriamo di menzionare esplicitamente la tua politica di moderazione o di fare una copia includendo la tua politica di moderazione per evitare confusione.
 

--- a/it-IT/contribute-bugs.md
+++ b/it-IT/contribute-bugs.md
@@ -7,10 +7,10 @@ title: Contribuire a Rust &mdash; trovare, analizzare e risolvere problemi &midd
 
 La manutenzione giorno per giorno del progetto ruota attorno al 
 [controllo bug][issue tracker] e alle [richieste di unione][PR],
-una mano in piú é sempre richiesta.
-Il modo piú semplice per iniziare a contribuire a Rust é guardare
+una mano in più è sempre richiesta.
+Il modo più semplice per iniziare a contribuire a Rust è guardare
 i bug caratterizzati dalle etichette [E-easy] o [E-mentor].
-Questi bug sono stati raccolti con la finalitá di essere accessibili
+Questi bug sono stati raccolti con la finalità di essere accessibili
 anche per i programmatori di Rust alla loro prima contribuzione.
 
 Nelle problematiche identificate da `E-mentor` uno sviluppatore di Rust
@@ -27,26 +27,26 @@ facili, includendo il browser web [Servo], la libreria [hyper], il suggeritore
 di sintassi [rustfmt], la libreria di supporto a Unix[nix] e la collezione
 di aiuti automatici alla programmazione [clippy].
 
-Anche se Rust possiede una [comprensiva suite di prova][test] c'é 
-sempre di piú da controllare.
+Anche se Rust possiede una [comprensiva suite di prova][test] c'è 
+sempre di più da controllare.
 I problemi classificati come [E-needstest] indicano le problematiche
 che si pensano risolte ma non possiedono ancora delle verifiche automatiche.
-Scrivere queste verifiche é un ottimo modo per comprendere un nuovo progetto
+Scrivere queste verifiche è un ottimo modo per comprendere un nuovo progetto
 e per iniziare a contribuire ad esso.
 
-Rust é continuamente alla ricerca di persone che [analizzino][triage] problemi:
+Rust è continuamente alla ricerca di persone che [analizzino][triage] problemi:
 riprodurli, ridurre la suite di prove automatiche, applicare etichette, chiudere
 i problemi risolti.
-Nota che per applicare etichette é richiesta un'autorizzazione elevata su GitHub
+Nota che per applicare etichette è richiesta un'autorizzazione elevata su GitHub
 facilmente ottenibile per coloro che hanno un po' di esperienza con il progetto.
 Chiedi a un [membro del team][team].
 
 Una volta orientato nel progetto e create una serie di richieste di unione 
 in una particolare area, considera di iniziare a visionare le richieste altrui:
-la capacitá di saper valutare il codice altrui é un'abilitá rara e sempre
-apprezzata. Non é richiesta alcuna autorizzazione &mdash; inizia semplicemente
+la capacità di saper valutare il codice altrui è un'abilitá rara e sempre
+apprezzata. Non è richiesta alcuna autorizzazione &mdash; inizia semplicemente
 a commentare gentilmente e costruttivamente sulle richieste di unione che ti interessano.
-Se vuoi piú informazioni su come fare una buona valutazione del codice altrui
+Se vuoi più informazioni su come fare una buona valutazione del codice altrui
 segui [questa guida][reviews].
 
 <!--

--- a/it-IT/contribute-community.md
+++ b/it-IT/contribute-community.md
@@ -1,29 +1,29 @@
 ---
 layout: it-IT/default
-title: Contribuire a Rust &mdash; creazione di una comunitá &middot; Linguaggio di programmazione Rust
+title: Contribuire a Rust &mdash; creazione di una comunità &middot; Linguaggio di programmazione Rust
 ---
 
-# Contribuire a Rust &mdash; creazione di una comunitá
+# Contribuire a Rust &mdash; creazione di una comunità
 
 Aiuta i novizi, spargi la voce, incontra persone interessanti.
 Rendi Rust un esempio brillante di sviluppo open source nel 
 modo in cui tutti noi desideriamo che sia.
 
 Controlla il canale [#rust-beginners].
-Qui é dove dirigiamo i nuovi programmatori Rust per chiedere aiuto,
-é quindi vitale che quando succede, venga impartita una risposta
+Qui è dove dirigiamo i nuovi programmatori Rust per chiedere aiuto,
+è quindi vitale che quando succede, venga impartita una risposta
 rapida, accurata e gentile.
 Similarmente su [Stack Overflow], [users.rust-lang.org] e [/r/rust],
 dove i programmatori generalmente richiedono assistenza.
 Se vuoi un aiuto su come rispondere a domande di programmazione
 [consulta questa guida][helpful].
 
-Se sei giá esperto in qualche area del progetto, per favore controlla
+Se sei già esperto in qualche area del progetto, per favore controlla
 per dei potenziali problemi marcati come [E-easy].
 Quando vedi un problema di cui conosci la soluzione, scrivi una descrizione
 della tua idea e apponi l'etichetta E-easy.
 Nota che quello che potrebbe apparirti come ovvio potrebbe non esserlo
-per nuovo sviluppatore Rust, é quindi importante descrivere chiaramente
+per nuovo sviluppatore Rust, è quindi importante descrivere chiaramente
 il problema e la soluzione.
 Questo risulta utile anche per analizzare i problemi etichettati come E-easy 
 dotati di descrizioni incomplete per migliorarli.
@@ -38,29 +38,29 @@ Manutenere piccoli impegni non solo fa bene al progetto Rust ma
 anche al suo ecosistema.
 Se un progetto ha un flusso costante di piccoli impegni potresti considerare
 di adottare una soluzione simile anche tu.
-***Questa attivitá di manutenzione é uno dei modi piú efficaci per portare
+***Questa attività di manutenzione è uno dei modi più efficaci per portare
 nuovi sviluppatori al progetto***. Se hai bisogno di aiuto su come 
 assistere i nuovi utenti [leggi questa guida][mentor-guide].
 
-Parla di ció a cui stai lavorando nella rubrica settimanale
+Parla di ciò a cui stai lavorando nella rubrica settimanale
 "what's everyone working on this week" su [/r/rust] e [users.rust-lang.org] e
 indica di cosa hai bisogno.
 Questi sono degli ottimi punti di partenza per collaborare.
 
-Diffondi Rust nella tua comunitá locale. I [gruppi utenti][user groups] Rust e 
+Diffondi Rust nella tua comunità locale. I [gruppi utenti][user groups] Rust e 
 gli [eventi][events] sono una componente unica ed eccitante dell'esperienza Rust:
 sono tantissimi e sono ovunque!
 Se non ci sei ancora stato, vai e goditi delle nuove esperienze.
-Se non c'é niente riguardante Rust attorno a te, puoi anche considerare di 
+Se non c'è niente riguardante Rust attorno a te, puoi anche considerare di 
 organizzare qualcosa. Puoi verificare l'interesse e annunciare gli eventi 
-su [/r/rust] o [users.rust-lang.org]. Contatta il [team della comunitá][community team]
-per inserire il tuo evento nel calendario che verrá annunciato anche su 
+su [/r/rust] o [users.rust-lang.org]. Contatta il [team della comunità][community team]
+per inserire il tuo evento nel calendario che verrà annunciato anche su 
 [Questa Settimana In Rust][This Week in Rust].
 
 Ricordati mentre pubblicizzi Rust di tenere in conto le idee altrui &mdash;
-non tutti saranno colpiti da Rust e va bene cosí.
+non tutti saranno colpiti da Rust e va bene così.
 
-Incontra alti creatori di comunitá Rust su [#rust-community].
+Incontra alti creatori di comunità Rust su [#rust-community].
 
 <!--
 Other ideas:

--- a/it-IT/contribute-compiler.md
+++ b/it-IT/contribute-compiler.md
@@ -17,16 +17,16 @@ dedicati all'espansione della sintassi e [A-typesystem] per parlare dei tipi.
 Non esiste alcuna guida ben mantenuta all'architettura del compilatore 
 ma ne [esiste una piccola carrellata nel repository principale][rustc-guide].
 La [documentazione delle API che compongono il compilatore][internals-docs]
-possono aiutarti a navigare il codice, come puó farlo  anche il navigatore di codice
+possono aiutarti a navigare il codice, come può farlo  anche il navigatore di codice
 [Rust DXR]. La [guida per Rust e la sua piattaforma di controllo][testsuite]
-ti insegnerá come utilizzare al meglio il sistema di compilazione di Rust,
+ti insegnerà come utilizzare al meglio il sistema di compilazione di Rust,
 come farebbe anche il comando [`make tips`][tips] da riga di comando.
 
 Per il futuro prossimo, una delle maggiori spinte per il compilatore Rust 
-é convertire le sue componenti interne per lavorare direttamente dall'Albero
+è convertire le sue componenti interne per lavorare direttamente dall'Albero
 di Sintassi Astratto, per elaborare su una [rappresentazione intermedia chiamata MIR][mir].
-Questo lavoro si preannuncia come l'inizio di molte nuove possibilitá
-per semplificare il compilatore ed é richiesto dell'aiuto per esempio
+Questo lavoro si preannuncia come l'inizio di molte nuove possibilità
+per semplificare il compilatore ed è richiesto dell'aiuto per esempio
 creare una fase di traduzione basata su MIR, ottimizzare la MIR e implementare
 la compilazione incrementale.
 Non esiste una fonte unica per informazioni sul lavoro richiesto ma chiedi
@@ -37,36 +37,36 @@ su [internals.rust-lang.org] o su
 nefasto 'errore interno di compilazione' ('internal compiler error' ICE). 
 L'etichetta [I-ICE] tiene traccia di questi problemi e spesso sono molti.
 Questi sono usualmente degli ottimi problemi per iniziare a contribuire
-perché é facile comprendere quando vengono riparati e sono relativamente
+perchè é facile comprendere quando vengono riparati e sono relativamente
 isolati dal resto del codice.
 
-Le prestazioni di Rust é uno dei suoi piú grossi vantaggi; e quella
-del suo compilatore é uno dei suoi piú grossi problemi.
+Le prestazioni di Rust è uno dei suoi più grossi vantaggi; e quella
+del suo compilatore è uno dei suoi più grossi problemi.
 Ogni miglioramento della prestazione degli eseguibili or &mdash; specialmente &mdash;
 delle prestazioni del compilatore sono largamente celebrati.
 Le etichette [I-slow] e [A-optimization] si occupano delle prestazioni
 degli eseguibili e [I-compiletime] di quella del compilatore. Abbiamo un
 [sito che tiene traccia delle prestazioni del compilatore][rustc-perf] 
 durante alcuni carichi di lavoro.
-L'opzione da riga di comando `-Z time-passes` puó aiutare a ispezionare
-le prestazioni del compilatore e il codice di Rust puó essere profilato
+L'opzione da riga di comando `-Z time-passes` può aiutare a ispezionare
+le prestazioni del compilatore e il codice di Rust può essere profilato
 da tutti i profilatori standard come `perf` su Linux.
 
-Funzionalitá importanti passano attraverso il processo di [Request for Comments (RFC)][rfc]
-dal quale ci si accorda sul design. Anche se aperto a tutti é un'interazione tra
-sviluppatori che giá hanno un discreto quantitivo di esperienza in comune ed é 
+Funzionalità importanti passano attraverso il processo di [Request for Comments (RFC)][rfc]
+dal quale ci si accorda sul design. Anche se aperto a tutti è un'interazione tra
+sviluppatori che già hanno un discreto quantitivo di esperienza in comune ed è 
 consigliato prendere parte al processo lentamente &mdash;
 inviare una RFC ostica senza comprendere il contesto storico, tecnico o sociale
-é un modo facile per dare una cattiva impressione e andarsene delusi.
+è un modo facile per dare una cattiva impressione e andarsene delusi.
 Leggi il collegamento sopra per comprendere al meglio come tutto il sistema funziona.
-Molte idee sono giá state discusse durante il passato di Rust, alcune sono state
+Molte idee sono già state discusse durante il passato di Rust, alcune sono state
 rifiutate, altre rimandate al futuro e la [portale delle RFC][rfc-issues]
 elenca alcune idee desiderate che non sono ancora riuscite a entrare
 nel linguaggio.
 Poco prima che una RFC venga accettata per l'implementazione, entra in 
 una 'fase finale di commento' indicata dall'etichetta
 [final-comment-period sul repository rust-lang/rfcs][rfc-fcp].
-Similarmente, prima che una funzionalitá venga abilitata nel compilatore
+Similarmente, prima che una funzionalità venga abilitata nel compilatore
 stabile (procedura definita 'ungating') essa entra nella [final-comment-period sul repository rust-lang/rust][issue-fcp]. 
 Entrambe le fasi di commento finale sono momenti critici per essere coinvolti
 ed esprimere opinioni sulla direzione del linguaggio e sono indicate

--- a/it-IT/contribute-docs.md
+++ b/it-IT/contribute-docs.md
@@ -5,40 +5,40 @@ title: Contribuire a Rust &mdash; documentazione &middot; Linguaggio di programm
 
 # Contribuire a Rust &mdash; documentazione
 
-La documentazione non é mai abbastanza buona e non ce n'é mai troppa.
+La documentazione non è mai abbastanza buona e non ce n'é mai troppa.
 Molti aspetti della documentazione di Rust non richiedono una profonda conoscenza
 per essere migliorati, scritti, corretti o modificati, inoltre modificare la documentazione
-é un ottimo modo per imparare Rust.
+è un ottimo modo per imparare Rust.
 Ulteriormente i miglioramenti sono semplici da identificare e potenzialmente infiniti:
-non ti piace come suona una frase? Hai scoperto qualcosa che nella documentazione non é presente?
-La tua richiesta di modifica verrá calorosamente accolta.
+non ti piace come suona una frase? Hai scoperto qualcosa che nella documentazione non è presente?
+La tua richiesta di modifica verrà calorosamente accolta.
 
-***La documentazione piú importante che tu possa scrivere é per [i pacchetti
+***La documentazione più importante che tu possa scrivere è per [i pacchetti
 che fanno parte dell'ecosistema di Rust][crate_docs]***.
-Mentre la documentazione principale é relativamente esaustiva, ció non é vero
+Mentre la documentazione principale è relativamente esaustiva, ciò non é vero
 per [molti pacchetti e strumenti popolari][awesome-rust] con cui gli sviluppatori
 Rust interagiscono ogni giorno.
-Contribuire alla documentazione delle API per un progetto popolare ti garantirá
+Contribuire alla documentazione delle API per un progetto popolare ti garantirà
 l'amore da parte dello sviluppatore del progetto.
 
-[Il libro][The Book] é la documentazione base per Rust, 
+[Il libro][The Book] è la documentazione base per Rust, 
 scritto nel repository principale.
 Possiede anche la sua etichetta per le problematiche, [A-book] ed
-é continuamente in miglioramento.
+è continuamente in miglioramento.
 Ulteriore documentazione nel repository principale include [il riferimento di Rust][The Rust Reference], 
 la [documentazione della libreria standard][std], [Il Rustonomico][The Rustonomicon] (un guida su come usare `unsafe`
-correttamente). Le [guide di stile di Rust][Rust Style Guidelines] sono cosí incomplete che non vengono elencate spesso;
-uno sviluppatore ambizioso puó sicuramente fare molta strada contribuendo lí.
+correttamente). Le [guide di stile di Rust][Rust Style Guidelines] sono così incomplete che non vengono elencate spesso;
+uno sviluppatore ambizioso può sicuramente fare molta strada contribuendo lì.
 L'[indice degli errori][err] fornisce spiegazioni dettagliate agli errori del compilatore. 
 Quando vengono aggiunti nuovi errori, essi devono essere [inclusi nella documentazione][err-issue], quindi ci sono
-sempre errori non presenti ancora ma con la necessitá di essere aggiunti.
+sempre errori non presenti ancora ma con la necessità di essere aggiunti.
 La maggior parte della documentazione nel repository principale risiede nella cartella [src/doc].
 Tutti i problemi di documentazione sono sotto all'etichetta [A-docs] sul portale delle problematiche.
 Finalmente questo documento e altri correlati con il sito web sono mantenuti nel [repository Git del sito][Rust website Git repository].
 Per contribuire modificalo e manda una pull request.
 
-Una buona quantitá di documentazione importante per Rust non si trova
-nel repository principale o non é mantenuta dal progetto Rust ma é 
+Una buona quantità di documentazione importante per Rust non si trova
+nel repository principale o non è mantenuta dal progetto Rust ma é 
 comunque importantissima per il successo di Rust.
 Esempi di documentazione eccellente sotto attivo sviluppo con domanda
 per altri sviluppatori includono [Rust By Example], [Rust Design Patterns] e [rust-rosetta].

--- a/it-IT/contribute-libs.md
+++ b/it-IT/contribute-libs.md
@@ -6,11 +6,11 @@ title: Contribuire a Rust &mdash; librerie &middot; Linguaggio di programmazione
 # Contribuire a Rust &mdash; librerie
 
 Se vuoi contribuire a Rust scrivendo molto codice,
-le librerie sono il modo per farlo: visto che Rust é ancora
+le librerie sono il modo per farlo: visto che Rust è ancora
 un linguaggio giovane, ci sono ancora molti tipi di librerie che 
 o non esistono ancora o sono incompleti e necessitano di miglioramenti o competizione.
 
-Decidere cosa scrivere per avere un impatto ed essere divertenti sono due difficoltá comuni.
+Decidere cosa scrivere per avere un impatto ed essere divertenti sono due difficoltà comuni.
 Ecco alcune idee:
 * Leggi e partecipa ai "what's everyone working on this week" su [/r/rust]
   e [users.rust-lang.org]. Questi forum sono pieni di annunci emozionanti
@@ -23,14 +23,14 @@ Ecco alcune idee:
   come 'easy' specifiche per i nuovi sviluppatori.
 * Fatti coinvolgere in una delle organizzazioni Rust-centriche su GitHub
   tipo [PistonDevelopers], [servo], [redox-os],
-  [iron], [contain-rs], [hyperium]. Spesso é piú facile ricavarsi un posto
-  in queste comunitá, che hanno ancora piú bisogno di rust-lang stesso.
+  [iron], [contain-rs], [hyperium]. Spesso è più facile ricavarsi un posto
+  in queste comunità, che hanno ancora più bisogno di rust-lang stesso.
   Sono anche piene di sviluppatori Rust esperti che possono aiutarti.
 * Aiuta il passaggio delle librerie da [rust-lang-nursery] a rust-lang.
-  Sfortunatamente non vi é ancora molta documentazione su cosa sia necessario fare.
+  Sfortunatamente non vi è ancora molta documentazione su cosa sia necessario fare.
   Puoi comunque chiedere su [#rust-libs].
 * Ispeziona le RFC di una [libreria richiesta dalla community][requested] e creala.
-* Guarda [ció che é in voga su Github][trending] per vedere altri progetti Rust attivi.
+* Guarda [ciò che è in voga su Github][trending] per vedere altri progetti Rust attivi.
 
 Come autore di librerie potresti desiderare di essere a conoscenza dei
 [migliori consigli su come implementare una libreria Rust][lib-prac].

--- a/it-IT/contribute-tools.md
+++ b/it-IT/contribute-tools.md
@@ -11,7 +11,7 @@ e rimangono ancora molte cose da implementare.
 sul [migliorare l'esperienza con gli ambienti di sviluppo][ides]***.
 Questo richiede impegno da parte di tutto l'ecosistema Rust, dal compilatore
 stesso fino al tuo ambiente di sviluppo preferito.
-Segui il link per saperne di piú.
+Segui il link per saperne di più.
 
 Sia Cargo, il gestore di pacchetti di Rust e rustdoc
 il generatore di documentazione per Rust, sebbene
@@ -20,7 +20,7 @@ validamente funzionanti, soffrono di una carenza di sviluppatori.
 Rustdoc ha molte problematiche aperte sotto l'etichetta
 [A-rustdoc] del repository principale.
 Queste problematiche sono principalmente composte da
-errori e contribuire é semplicmente una questione di 
+errori e contribuire è semplicmente una questione di 
 risolverli e inviare una richiesta di unione.
 Cargo, possiede [il suo personale repository con relativi problemi][Cargo],
 coloro fossero interessati a contribuire possono anche presentarsi

--- a/it-IT/contribute-translations.md
+++ b/it-IT/contribute-translations.md
@@ -3,6 +3,6 @@ layout: it-IT/default
 title: Tradurre rust-lang.org in altri linguaggi per adottare l'internazionalizzazione 
 ---
 
-# Rust é universale
+# Rust è universale
 
 Manca la documentazione su come contribuire a tradurre!

--- a/it-IT/contribute.md
+++ b/it-IT/contribute.md
@@ -6,11 +6,11 @@ title: Contribuire a Rust &middot; Linguaggio di programmazione Rust
 # Contribuire a Rust
 
 Una volta iniziato a imparare Rust. Lo amerai e vorrai divenire parte di esso.
-Se non sei sicuro su come essere coinvolto, questa pagina ti aiuterá.
+Se non sei sicuro su come essere coinvolto, questa pagina ti aiuterà.
 
 **Trovato un problema e vuoi notificarlo?** [segui la guida su come riportare i problemi][bugs]. Grazie in anticipo!
 
-Rust é un espanso sistema di progetti, in cui i piú prominenti di questions
+Rust è un espanso sistema di progetti, in cui i più prominenti di questions
 sono mantenuti dagli [sviluppatori del progetto Rust][devs] nella [organizzazione
 rust-lang su GitHub][rust-lang]. 
 I nuovi arrivati potrebbero essere interessati al file [CONTRIBUTING.md]
@@ -24,15 +24,15 @@ Questa guida indica alcune strade per i nuovi arrivati:
 * [Documentazione](contribute-docs.html). Non solo
   documentazione ufficiale ma anche per pacchetti, post sul blog
   e altre fonti non ufficiali.
-* [Creazione di comunitá](contribute-community.html). Aiutare gli altri
+* [Creazione di comunità](contribute-community.html). Aiutare gli altri
   Rustacchiani e espandendo le frontiere di Rust.
 * [Strumenti, ambienti di sviluppo e infrastrutture](contribute-tools.html). Gli
   importanti pezzi che rendono un linguaggio pratico e piacevole.
-* [Librerie](contribute-libs.html). L'idoneitá di Rust a un compito
-  é subordinata alla presenza di librerie di alta qualitá.
+* [Librerie](contribute-libs.html). L'idoneità di Rust a un compito
+  è subordinata alla presenza di librerie di alta qualità.
 * [Liguaggio, compilatore e la libreria
   standard](contribute-compiler.html). Design del linguaggio, implementazione
-  funzionalitá, ottimizzazioni.
+  funzionalità, ottimizzazioni.
 * [Internazionalizzazione](contribute-translations.html). Aiuta a spargere
   l'amore per Rust traducendo il nostro sito in altre lingue.
 
@@ -41,7 +41,7 @@ Se hai bisogno di ulteriore aiuto chiedi su [#rust-internals] o su
 
 Siamo orgogliosi di mantenere discussioni civili e con questo scopo
 i nostri sviluppatori sono tenuti a seguire il [codice di comportamento][coc].
-If hai delle domande a questo proposito per favore parlane con il [Team comunitá][community team].
+If hai delle domande a questo proposito per favore parlane con il [Team comunità][community team].
 
 <!--
 TODO: Write a guide to rust processes and governance to link from here

--- a/it-IT/documentation.md
+++ b/it-IT/documentation.md
@@ -6,8 +6,8 @@ title:  Documentazione di Rust &middot; Linguaggio di programmazione Rust
 # Documentazione di Rust
 
 Se non hai proprio mai visto Rust, la prima cosa che dovresti leggere
-é l'introduzione del [Libro di Rust][book].
-Ti dará una buona idea di com'é Rust, ti mostrerá come installarlo,
+è l'introduzione del [Libro di Rust][book].
+Ti darà una buona idea di com'è Rust, ti mostrerá come installarlo,
 illustrando anche la sua sintassi e i suoi concetti.
 Una volta letto sarai uno sviluppatore Rust discreto e avrai una
 buona idea dei concetti fondamentali di Rust.
@@ -15,7 +15,7 @@ buona idea dei concetti fondamentali di Rust.
 ## Imparare Rust
 
 [Il Libro di Rust][book]. Conosciuto anche come "Il libro",
-é la risorsa piú completa per tutti gli argomenti correlati a Rust e
+è la risorsa più completa per tutti gli argomenti correlati a Rust e
 rappresenta il documento primario ufficiale del linguaggio.
 
 [Rust per Esempi][rbe]. Una collezione di diversi problemi indipendenti
@@ -27,7 +27,7 @@ commentati e eseguibili dal browser.
 Un intero libro dedicato a scrivere codice Rust insicuro.
 Dedicato ai programmatori Rust esperti.
 
-[rust-learning]. Una risorsa fornita dalla comunitá di fonti dove imparare Rust.
+[rust-learning]. Una risorsa fornita dalla comunità di fonti dove imparare Rust.
 
 [book]: https://doc.rust-lang.org/book/
 [rbe]: http://rustbyexample.com
@@ -44,7 +44,7 @@ Dedicato ai programmatori Rust esperti.
 [Riferimento del linguaggio Rust][ref]. 
 Anche se Rust non ha una specifica, il riferimento
 prova a spiegare il suo funzionamento nel dettaglio.
-Spesso non é aggiornato.
+Spesso non è aggiornato.
 
 [Indice sintassi][syn]. 
 Questa appendice del Libro di Rust contiene esempi di tutte 
@@ -69,12 +69,12 @@ errori emessi dal compilatore Rust.
 
 ## Politiche del progetto
 
-[Politica rilascio vulnerabilitá][security]. Le politiche del progetto
+[Politica rilascio vulnerabilità][security]. Le politiche del progetto
 per notificare, risolvere e rivelare problematiche di sicurezza.
 
 [Diritti sul nome e marchio di Rust][legal]. I diritti di Rust
 appartengono agli sviluppatori del Progetto Rust, i suoi marchi 
-sono proprietá di Mozilla. Nel collegamento si possono trovare le 
+sono proprietà di Mozilla. Nel collegamento si possono trovare le 
 norme di utilizzo.
 
 [Codice di comportamento][coc]. Si applica all' organizzazione rust-lang
@@ -86,7 +86,7 @@ su GitHub, i forum ufficiali, i canali IRC e in diversi angoli del mondo di Rust
 
 ## Documentazione versioni nightly e beta
 
-La maggior parte della documentazione ufficiale di Rust é disponibile
+La maggior parte della documentazione ufficiale di Rust è disponibile
 anche per le versioni [nightly] e [beta], in aggiunta alla documentazione
 menzionata sopra.
 

--- a/it-IT/faq.md
+++ b/it-IT/faq.md
@@ -8,11 +8,11 @@ title: Domande Frequenti &middot; Linguaggio di programmazione Rust
 <p class="faq-intro">
 Questa pagina esiste per rispondere a domande comuni inerenti il linguaggio di programmazione Rust.
 Non rappresenta una guida completa al linguaggio e nemmeno uno strumento per insegnarlo.
-Costituisce invece un riferimento per rispondere alle domande piú frequenti concernenti le scelte di progettazione dietro a Rust.
+Costituisce invece un riferimento per rispondere alle domande più frequenti concernenti le scelte di progettazione dietro a Rust.
 </p>
 
 <p class="faq-intro">
-Se c'é una domanda comune o importante che pensi sia ingiustamente non inclusa qui, sentiti libero di <a href="https://github.com/rust-lang/rust-www/blob/master/CONTRIBUTING.md">aiutarci ad aggiungerla</a>.
+Se c'è una domanda comune o importante che pensi sia ingiustamente non inclusa qui, sentiti libero di <a href="https://github.com/rust-lang/rust-www/blob/master/CONTRIBUTING.md">aiutarci ad aggiungerla</a>.
 </p>
 
 <div id="toc">
@@ -48,29 +48,29 @@ Se c'é una domanda comune o importante che pensi sia ingiustamente non inclusa 
 <h2 id="project">Il progetto Rust</h2>
 
 <h3><a href="#what-is-this-projects-goal" name="what-is-this-projects-goal">
-Qual'é lo scopo del progetto?
+Qual'è lo scopo del progetto?
 </a></h3>
 
 Progettare e implementare un linguaggio sicuro, concorrente e pratico per la programmazione di sistemi.
 
-Rust nasce perché altri linguaggi a questo livello di astrazione e efficienza non sono soddisfacenti. In particolare:
+Rust nasce perchè altri linguaggi a questo livello di astrazione e efficienza non sono soddisfacenti. In particolare:
 
 1. Non viene posta la dovuta attenzione alla sicurezza.
 2. Supportano malamente la concorrenza.
-3. Vi é una carenza di ergonomia.
+3. Vi è una carenza di ergonomia.
 4. Offrono un controllo limitato delle risorse.
 
 Rust esiste come un'alternativa che fornisce sia codice efficiente che un livello confortevole di astrazione, contemporaneamente migliorando tutti questi quattro punti.
 <h3><a href="#is-this-project-controlled-by-mozilla" name="is-this-project-controlled-by-mozilla">
-Questo progetto é controllato da Mozilla?
+Questo progetto è controllato da Mozilla?
 </a></h3>
-No. Rust é iniziato come un progetto hobbystico da parte di Graydon Hoare nel 2006 ed é rimasto cosí per oltre 3 anni. La Mozilla é entrata nel 2009, dopo che il linguaggio si é dimostrato abbastanza maturo per eseguire una serie di basici test automatizzati e dimostrare la valenza dei suoi principi base. Anche se sponsorizzato da Mozilla, Rust é un progetto sviluppato da
-una variegata comunitá di appassionati da molti paesi del mondo. Il [Team di Rust](team.html) é composto sia da membri Mozilla che da esterni e `rust` su GitHub ha avuto oltre [1,500 sviluppatori diversi](https://github.com/rust-lang/rust/) fino ad oggi.
+No. Rust è iniziato come un progetto hobbystico da parte di Graydon Hoare nel 2006 ed é rimasto così per oltre 3 anni. La Mozilla é entrata nel 2009, dopo che il linguaggio si é dimostrato abbastanza maturo per eseguire una serie di basici test automatizzati e dimostrare la valenza dei suoi principi base. Anche se sponsorizzato da Mozilla, Rust é un progetto sviluppato da
+una variegata comunità di appassionati da molti paesi del mondo. Il [Team di Rust](team.html) è composto sia da membri Mozilla che da esterni e `rust` su GitHub ha avuto oltre [1,500 sviluppatori diversi](https://github.com/rust-lang/rust/) fino ad oggi.
 
-Finché concesso [dalla politica di gestione del progetto](https://github.com/rust-lang/rfcs/blob/master/text/1068-rust-governance.md), Rust é amministrato da un team base che imposta
-la visione e le prioritá del progetto, guidandolo globalmente.
-Esistono anche dei sottogruppi per guidare e incoraggiare lo sviluppo in alcune aree di interesse, inclusi il linguaggio, il compilatore, le librerie, gli strumenti, la moderazione delle comunitá ufficiali.
-La progettazione é guidata da un processo [RFC](https://github.com/rust-lang/rfcs). 
+Finchè concesso [dalla politica di gestione del progetto](https://github.com/rust-lang/rfcs/blob/master/text/1068-rust-governance.md), Rust é amministrato da un team base che imposta
+la visione e le priorità del progetto, guidandolo globalmente.
+Esistono anche dei sottogruppi per guidare e incoraggiare lo sviluppo in alcune aree di interesse, inclusi il linguaggio, il compilatore, le librerie, gli strumenti, la moderazione delle comunità ufficiali.
+La progettazione è guidata da un processo [RFC](https://github.com/rust-lang/rfcs). 
 Per cambiamenti che non richiedono una RFC, le decisioni sono fatte attraverso richieste di unione sul [repository `rustc`](https://github.com/rust-lang/rust).
 
 <h3><a href="#what-are-some-non-goals" name="what-are-some-non-goals">
@@ -78,10 +78,10 @@ WQuali sono i non-obiettivi di Rust?
 </a></h3>
 
 1. Non impieghiamo nessuna tecnologia particolarmente nuova. Le vecchie tecniche ben consolidate sono meglio.
-2. Non ci preme incentivare l'espressivitá, il minimalismo o l'eleganza sopra ogni altra cosa. Sono obiettivi desiderati ma non fondamentali.
-3. Non ci interessa coprire tutte le funzionalitá del C++ o di qualsiasi altro linguaggio. Rust dovrebbe fornire le funzionalitá piú richieste.
+2. Non ci preme incentivare l'espressività, il minimalismo o l'eleganza sopra ogni altra cosa. Sono obiettivi desiderati ma non fondamentali.
+3. Non ci interessa coprire tutte le funzionalità del C++ o di qualsiasi altro linguaggio. Rust dovrebbe fornire le funzionalitá più richieste.
 4. Non vogliamo essere immobili al 100%, sicuri al 100%, riflessivi al 100% o troppo dogmatici in qualche modo. Esistono dei compromessi.
-5. Non domandiamo che Rust funzioni "su ogni piattaforma possibile". Dovrá eventualmente funzionare senza inutili compromessi sulle piattaforme hardware e software piú diffuse.
+5. Non domandiamo che Rust funzioni "su ogni piattaforma possibile". Dovrà eventualmente funzionare senza inutili compromessi sulle piattaforme hardware e software più diffuse.
 
 <h3><a href="#how-does-mozilla-use-rust" name="how-does-mozilla-use-rust">
 In quali progetti Mozilla utilizza Rust?
@@ -93,7 +93,7 @@ Principalmente in [Servo](https://github.com/servo/servo), un motore di navigazi
 Che esempi ci sono di grandi progetti in Rust?
 </a></h3>
 
-I due piú grandi progetti open source sono al momento [Servo](https://github.com/servo/servo) e il [compilatore Rust](https://github.com/rust-lang/rust) stesso.
+I due più grandi progetti open source sono al momento [Servo](https://github.com/servo/servo) e il [compilatore Rust](https://github.com/rust-lang/rust) stesso.
 
 <h3><a href="#who-else-is-using-rust" name="who-else-is-using-rust">
 Chi altro utilizza Rust?
@@ -111,7 +111,7 @@ TODO: Write this answer.
 Come posso provare Rust facilmente?
 </a></h3>
 
-Il modo piú facile per provare Rust é sulla [playpen](https://play.rust-lang.org/), un'applicazione online per scrivere e provare codice Rust. Se invece desideri provare Rust sul tuo computer, [installalo](https://www.rust-lang.org/install.html) e prova a seguire la guida al [gioco dell'indovino](https://doc.rust-lang.org/stable/book/guessing-game.html) dal libro.
+Il modo più facile per provare Rust è sulla [playpen](https://play.rust-lang.org/), un'applicazione online per scrivere e provare codice Rust. Se invece desideri provare Rust sul tuo computer, [installalo](https://www.rust-lang.org/install.html) e prova a seguire la guida al [gioco dell'indovino](https://doc.rust-lang.org/stable/book/guessing-game.html) dal libro.
 
 <h3><a href="#how-do-i-get-help-with-rust-issues" name="how-do-i-get-help-with-rust-issues">
 Come posso ricevere aiuto con Rust?
@@ -125,13 +125,13 @@ Ci sono diversi modi. Puoi:
 - Scrivere su [/r/rust](https://www.reddit.com/r/rust), il subreddit non ufficiale di Rust
 
 <h3><a href="#why-has-rust-changed-so-much" name="why-has-rust-changed-so-much">
-Perché Rust é cambiato cosí tanto col tempo?
+Perchè Rust é cambiato così tanto col tempo?
 </a></h3>
 
-Rust é iniziato con l'obiettivo di creare un linguaggio di programmazione per sistemi stabile e utilizzabile. Per perseguire questo scopo ha esplorato molte idee, alcune sono state preservate(campi di esistenza, tratti) mentre altre sono state scartate (il sistema di stati dei tipi, il green threading).
-Inoltre durante la transizione verso la versione 1.0, buona parte della libreria standard é stata riscritta per consentire al codice passato di sfruttare al meglio le funzionalitá di Rust,
-fornendo interfacce di programmazione di qualitá, stabili e multipiattaforma.
-Ora che Rust é alla versione 1.0, il linguaggio é garantito come "stabile"; e mentre potrebbe continuare ad evolversi, il codice funzionante sulla versione attuale dovrebbe continuare a farlo
+Rust è iniziato con l'obiettivo di creare un linguaggio di programmazione per sistemi stabile e utilizzabile. Per perseguire questo scopo ha esplorato molte idee, alcune sono state preservate(campi di esistenza, tratti) mentre altre sono state scartate (il sistema di stati dei tipi, il green threading).
+Inoltre durante la transizione verso la versione 1.0, buona parte della libreria standard è stata riscritta per consentire al codice passato di sfruttare al meglio le funzionalità di Rust,
+fornendo interfacce di programmazione di qualità, stabili e multipiattaforma.
+Ora che Rust è alla versione 1.0, il linguaggio é garantito come "stabile"; e mentre potrebbe continuare ad evolversi, il codice funzionante sulla versione attuale dovrebbe continuare a farlo
 anche nelle versioni future.
 
 <h3><a href="#how-does-rust-language-versioning-work" name="how-does-rust-language-versioning-work">
@@ -140,72 +140,72 @@ Come funziona il numero di versione di Rust?
 
 Rust segue lo standard [SemVer](http://semver.org/), dove cambiamenti non compatibili con le versioni passate sono ammesse nelle versioni minori se questi cambiamenti
 risolvono errori del compilatore, risolvono problemi di sicurezza o cambiano le regole di dichiarazione o inferenza dei tipi in modo da richiedere ulteriore specifica.
-Linee guida piú dettagliate per cambi di versione minori sono disponibili come RFC approvate sia per il [linguaggio](https://github.com/rust-lang/rfcs/blob/master/text/1122-language-semver.md) che per la [libreria standard](https://github.com/rust-lang/rfcs/blob/master/text/1105-api-evolution.md).
+Linee guida più dettagliate per cambi di versione minori sono disponibili come RFC approvate sia per il [linguaggio](https://github.com/rust-lang/rfcs/blob/master/text/1122-language-semver.md) che per la [libreria standard](https://github.com/rust-lang/rfcs/blob/master/text/1105-api-evolution.md).
 
 Rust mantiene tre canali di rilascio: stabile, beta e "nightly".
 I canali stabile e beta sono aggiornati ogni sei settimane, con la nightly che diviene la nuova beta e la beta che diviene la nuova stabile.
-Le funzionalitá del linguaggio e della libreria standard indicate come non stabili o nascoste dietro a blocchi di implementazione possono essere utilizzati solo 
-nel canale di rilascio "nightly". Le nuove funzionalitá arrivano come instabili ma sono "liberate" una volta approvate dal team di sviluppo e relativi sottogruppi.
-Questo approccio consente di sperimentare e di contemporaneamente fornire una forte garanzia di retrompatibilitá del canale stabile.
+Le funzionalità del linguaggio e della libreria standard indicate come non stabili o nascoste dietro a blocchi di implementazione possono essere utilizzati solo 
+nel canale di rilascio "nightly". Le nuove funzionalità arrivano come instabili ma sono "liberate" una volta approvate dal team di sviluppo e relativi sottogruppi.
+Questo approccio consente di sperimentare e di contemporaneamente fornire una forte garanzia di retrompatibilità del canale stabile.
 
 Per dettagli ulteriori, leggi il post sul blog di Rust ["Stability as a Deliverable."](http://blog.rust-lang.org/2014/10/30/Stability.html)
 
 <h3><a href="#can-i-use-unstable-features-on-the-beta-or-stable-channel" name="can-i-use-unstable-features-on-the-beta-or-stable-channel">
-Posso utilizzare funzionalitá non stabili nei canali stabile e beta?
+Posso utilizzare funzionalità non stabili nei canali stabile e beta?
 </a></h3>
 
-No, non puoi. Rust cerca duramente di fornire garanzie sulla stabilitá delle funzioni incluse nei canali beta e stabile.
-Quando qualcosa é non stabile significa che non é possibile ancora garantire il suo utilizzo e quindi non desideriamo che ci 
-si basi su queste funzionalitá o che queste non vengano modificate.
-Questo ci permette di provare i cambiamenti nel canale nightly, preservando le promesse di stabilitá.
+No, non puoi. Rust cerca duramente di fornire garanzie sulla stabilità delle funzioni incluse nei canali beta e stabile.
+Quando qualcosa è non stabile significa che non é possibile ancora garantire il suo utilizzo e quindi non desideriamo che ci 
+si basi su queste funzionalità o che queste non vengano modificate.
+Questo ci permette di provare i cambiamenti nel canale nightly, preservando le promesse di stabilità.
 
 Molte cose vengono incluse nella stabile e i canali beta e stabile vengono aggiornati ogni sei settimane, con occasionali modifiche dirette anche al canale beta a volte.
-Se stai aspettando la disponbilitá di una funzionalitá e non vuoi usufruire del canale nighly, puoi seguirne lo stato controllando l'etichetta [`B-unstable`](https://github.com/rust-lang/rust/issues?q=is%3Aissue+is%3Aopen+tracking+label%3AB-unstable) sulla bacheca dei problemi.
+Se stai aspettando la disponbilità di una funzionalitá e non vuoi usufruire del canale nighly, puoi seguirne lo stato controllando l'etichetta [`B-unstable`](https://github.com/rust-lang/rust/issues?q=is%3Aissue+is%3Aopen+tracking+label%3AB-unstable) sulla bacheca dei problemi.
 
 <h3><a href="#what-are-feature-gates" name="what-are-feature-gates">
 Cosa sono i "Feature Gates"?
 </a></h3>
 
-I "Feature gates" sono il modo con cui Rust stabilizza funzionalitá del compilatore, del linguaggio e della libreria standard. 
-Una funzione protetta é accessibile esclusivamente nel canale di rilascio "nighly" e solo quando abilitata esplicitamente con la direttiva `#[feature]` o con l'argomento a linea di comando `-Z unstable-options`. 
-Quando una funzione é stabilizzata diviene disponbile sul canale di rilascio stabile e non é necessario abilitarla esplicitamente. 
-A quel punto la funzione é considerata "libera". 
-I "Feature gates" consentono agli sviluppatori di provare funzionalitá sperimentali mentre sono in fase di implementazione, prima che giungano nel linguaggio stabile.
+I "Feature gates" sono il modo con cui Rust stabilizza funzionalità del compilatore, del linguaggio e della libreria standard. 
+Una funzione protetta è accessibile esclusivamente nel canale di rilascio "nighly" e solo quando abilitata esplicitamente con la direttiva `#[feature]` o con l'argomento a linea di comando `-Z unstable-options`. 
+Quando una funzione è stabilizzata diviene disponbile sul canale di rilascio stabile e non é necessario abilitarla esplicitamente. 
+A quel punto la funzione è considerata "libera". 
+I "Feature gates" consentono agli sviluppatori di provare funzionalità sperimentali mentre sono in fase di implementazione, prima che giungano nel linguaggio stabile.
 
 <h3><a href="#why-a-dual-mit-asl2-license" name="why-a-dual-mit-asl2-license">
-Perché la doppia licenza MIT/ASL2?
+Perchè la doppia licenza MIT/ASL2?
 </a></h3>
 
-La licenza Apache include importanti protezioni contro le aggressioni legali ma non é compatibile con la GPL versione 2.
-Per evitare problemi nell'utilizzo di Rust e GPL2 é aggiunta la licenza alternativa MIT.
+La licenza Apache include importanti protezioni contro le aggressioni legali ma non è compatibile con la GPL versione 2.
+Per evitare problemi nell'utilizzo di Rust e GPL2 è aggiunta la licenza alternativa MIT.
 
 <h3><a href="#why-a-permissive-license" name="why-a-permissive-license">
-Perché una licenza simil-BSD aperta invece che la MPL o la tri-licenza?
+Perchè una licenza simil-BSD aperta invece che la MPL o la tri-licenza?
 </a></h3>
 
-Questo é parzialmente dovuto alla preferenza dello sviluppatore originario (Graydon) e parzialmente al fatto che i linguaggi tendono ad avere un pubblico piú vasto e una serie piú variegata di implementazioni e utilizzi di altri prodotti come i browser web. Noi vorremmo appellarci al maggior numero possibile di sviluppatori.
+Questo è parzialmente dovuto alla preferenza dello sviluppatore originario (Graydon) e parzialmente al fatto che i linguaggi tendono ad avere un pubblico più vasto e una serie piú variegata di implementazioni e utilizzi di altri prodotti come i browser web. Noi vorremmo appellarci al maggior numero possibile di sviluppatori.
 
 <h2 id="performance">Prestazioni</h2>
 
 <h3><a href="#how-fast-is-rust" name="how-fast-is-rust">
-Quanto é performante Rust?
+Quanto è performante Rust?
 </a></h3>
 
-Molto! Rust é giá competitivo con programmi C e C++ ben scritti in una serie di prove (come nel [Benchmarks Game](https://benchmarksgame.alioth.debian.org/u64q/compare.php?lang=rust&lang2=gpp) e [altri](https://github.com/kostya/benchmarks)).
+Molto! Rust è già competitivo con programmi C e C++ ben scritti in una serie di prove (come nel [Benchmarks Game](https://benchmarksgame.alioth.debian.org/u64q/compare.php?lang=rust&lang2=gpp) e [altri](https://github.com/kostya/benchmarks)).
 
 Come il C++, il Rust possiede [astrazioni a costo zero](http://blog.rust-lang.org/2015/05/11/traits.html) come uno dei suoi principi chiave: nessuna delle astrazioni di Rust impone un rallentamento, in qualsiasi caso.
 
-Dato che Rust utilizza LLVM e cerca di assomigliare a Clang dal punto di vista dell'interazione con LLVM, ogni miglioramento di LLVM é condiviso da Rust.
-Nel lungo periodo, la quantitá elevata di informazioni presente nel sistema dei tipi di Rust dovrebbe permettere ottimizzazioni difficili o impossibili da implementare in C/C++.
+Dato che Rust utilizza LLVM e cerca di assomigliare a Clang dal punto di vista dell'interazione con LLVM, ogni miglioramento di LLVM è condiviso da Rust.
+Nel lungo periodo, la quantità elevata di informazioni presente nel sistema dei tipi di Rust dovrebbe permettere ottimizzazioni difficili o impossibili da implementare in C/C++.
 
 <h3><a href="#is-rust-garbage-collected" name="is-rust-garbage-collected">
-Rust é un linguaggio dotato di garbage collection?
+Rust è un linguaggio dotato di garbage collection?
 </a></h3>
 
-No. Una delle innovazioni fondamentali di Rust é il garantire la sicurezza della memoria (nessun errore di segmentazione) *senza* richiedere un garbage collector.
+No. Una delle innovazioni fondamentali di Rust è il garantire la sicurezza della memoria (nessun errore di segmentazione) *senza* richiedere un garbage collector.
 
 Evitando di utilizzare un GC, Rust offre numerosi vantaggi: liberazione prevedibile delle risorse, gestione della memoria meno onerosa e soprattutto nessun sistema aggiuntivo operante durante l'esecuzione.
-Tutte queste caratteristiche rendono Rust leggero e facile da implementare in contesti arbitrari e rendono piú facile [integrare Rust con i linguaggi in possesso di un GC](http://calculist.org/blog/2015/12/23/neon-node-rust/).
+Tutte queste caratteristiche rendono Rust leggero e facile da implementare in contesti arbitrari e rendono più facile [integrare Rust con i linguaggi in possesso di un GC](http://calculist.org/blog/2015/12/23/neon-node-rust/).
 
 Rust non necessita di un GC grazie al suo sistema di possesso e passaggio ma lo stesso sistema aiuta con una moltitudine di altri problemi, inclusi [la gestione delle risorse in generale](http://blog.skylight.io/rust-means-never-having-to-close-a-socket/)
 e la [concorrenza](http://blog.rust-lang.org/2015/04/10/Fearless-Concurrency.html).
@@ -213,65 +213,65 @@ e la [concorrenza](http://blog.rust-lang.org/2015/04/10/Fearless-Concurrency.htm
 Per quando il possesso di un valore non fosse abbastanza, i programmi Rust fanno riferimento al tipo puntatore intelligente standard a conteggio dei riferimenti [`Rc`](https://doc.rust-lang.org/std/rc/struct.Rc.html) e alla sua versione sicura in contesti paralleli [`Arc`](https://doc.rust-lang.org/std/sync/struct.Arc.html), invece di affidarsi a un GC.
 
 Stiamo comunque investigando una garbage collection *opzionale* come estensione futura.
-L'obiettivo é integrarsi fluidamente con ambienti garbage-collected, come quelli offerti dai
+L'obiettivo è integrarsi fluidamente con ambienti garbage-collected, come quelli offerti dai
 motori di Javascript [Spidermonkey](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey) e [V8](https://developers.google.com/v8/?hl=en).
 Inoltre, qualcuno sta investigando l'implementazione di un garbage collector
 [interamente in Rust](https://manishearth.github.io/blog/2015/09/01/designing-a-gc-in-rust/)
 senza supporto del compilatore.
 
 <h3><a href="#why-is-my-program-slow" name="why-is-my-program-slow">
-Perché il mio programma é lento?
+Perchè il mio programma é lento?
 </a></h3>
 
 Il compilatore di Rust non compila con le ottimizzazioni se non esplicitamente istruito [considerato che le ottimizzazioni rallentano la compilazione e sono scosigliate durante lo sviluppo](https://users.rust-lang.org/t/why-does-cargo-build-not-optimise-by-default/4150/3).
 
 Se compili con `cargo` usa il parametro `--release`.
 Se compili direttamente con `rustc`, usa il parametro `-O`.
-Ciascuno di questi abiliterá le ottimizzazioni. 
+Ciascuno di questi abiliterà le ottimizzazioni. 
 
 <h3><a href="#why-is-rustc-slow" name="why-is-rustc-slow">
-Rust compila lentamente. Perché?
+Rust compila lentamente. Perchè?
 </a></h3>
 
 Principalmente per la traduzione del codice e le ottimizzazioni.
 Rust fornisce delle astrazioni ad alto livello che vengono compilate in un codice macchina efficiente e queste trasformazioni richiedono molto tempo per essere effettuate, specialmente se in combinazione con le ottimizzazioni.
 
-Ma il tempo di compilazione di Rust non é male come sembra e c'é da essere fiduciosi in un suo miglioramento futuro.
-Comparando progetti di dimensioni simili tra il C++ e Rust il tempo di compilazione é generalmente comparabile.
-La percezione di lentezza é largamente dovuta alle differenze tra il *modello di compilazione* del C++ da quello di Rust, l'unitá base del C++ é il file mentre in Rust é l'intero pacchetto, composto da molti file.
+Ma il tempo di compilazione di Rust non è male come sembra e c'é da essere fiduciosi in un suo miglioramento futuro.
+Comparando progetti di dimensioni simili tra il C++ e Rust il tempo di compilazione è generalmente comparabile.
+La percezione di lentezza è largamente dovuta alle differenze tra il *modello di compilazione* del C++ da quello di Rust, l'unità base del C++ é il file mentre in Rust é l'intero pacchetto, composto da molti file.
 Di conseguenza durante lo sviluppo la modifica di un file causa molta meno ricompilazione che in Rust.
-In questo momento é in corso uno sforzo per implementare una ristrutturazione del compilatore che permetta di effettuare la
-[compilazione incrementale](https://github.com/rust-lang/rfcs/blob/master/text/1298-incremental-compilation.md), che consentirá a Rust di implementare un modello piú rapido e simile al C++.
+In questo momento è in corso uno sforzo per implementare una ristrutturazione del compilatore che permetta di effettuare la
+[compilazione incrementale](https://github.com/rust-lang/rfcs/blob/master/text/1298-incremental-compilation.md), che consentirà a Rust di implementare un modello più rapido e simile al C++.
 
 Oltre al modello di compilazione, ci sono molti altri aspetti dell'implementazione di Rust e il suo compilatore che ne impattano le prestazioni in fase di compilazione.
 
 Inizialmente, Rust has un sistema di tipi moderatamente complesso e deve spendere un discreto quantitativo di tempo durante la compilazione a verificarne limitazioni e utilizzi, rendendo Rust sicuro durante la sua esecuzione.
 
-Secondariamente, il compilatore di Rust soffre di un debito tecnico di lunga data e risaputamente genera una rappresentazione intermedia per LLVM di bassa qualitá a cui LLVM deve porre rimedio.
-Si spera che i futuri passaggi di trasformazione e ottimizzazione [basati su MIR](https://github.com/rust-lang/rfcs/blob/master/text/1211-mir.md) riducano la quantitá di lavoro che Rust impone a LLVM.
+Secondariamente, il compilatore di Rust soffre di un debito tecnico di lunga data e risaputamente genera una rappresentazione intermedia per LLVM di bassa qualità a cui LLVM deve porre rimedio.
+Si spera che i futuri passaggi di trasformazione e ottimizzazione [basati su MIR](https://github.com/rust-lang/rfcs/blob/master/text/1211-mir.md) riducano la quantità di lavoro che Rust impone a LLVM.
 
-Terziariamente, l'utilizzo da parte di Rust di LLVM per la generazione del codice macchina é una spada a doppio taglio: se da un lato questo permette a Rust di avere prestazioni degne di nota,
-LLVM é un insieme di strumenti non focalizzato alla velocitá di compilazione, specialmente con input di bassa qualitá.
+Terziariamente, l'utilizzo da parte di Rust di LLVM per la generazione del codice macchina è una spada a doppio taglio: se da un lato questo permette a Rust di avere prestazioni degne di nota,
+LLVM è un insieme di strumenti non focalizzato alla velocità di compilazione, specialmente con input di bassa qualitá.
 
-Inoltre, mentre la strategia preferita da Rust per monomorfizzare i generici (simil C++) produca codice performante, domanda di generare molto piú codice rispetto ad altre strategie di implementazione.
+Inoltre, mentre la strategia preferita da Rust per monomorfizzare i generici (simil C++) produca codice performante, domanda di generare molto più codice rispetto ad altre strategie di implementazione.
 I programmatori Rust possono utilizzare i tratti per rimuovere questo codice extra e utilizzando un dispacciamento dinamico.
 
 <h3><a href="#why-are-rusts-hashmaps-slow" name="why-are-rusts-hashmaps-slow">
-Perché le <code>HashMap</code> di Rust sono cosílente?
+Perchè le <code>HashMap</code> di Rust sono cosìlente?
 </a></h3>
 
-Di base, le [`HashMap`][HashMap] di Rust utilizzano l'algoritmo di hashing [SipHash](https://131002.net/siphash/), progettato per prevenire [attacchi basati sulla collisione di hash](http://programmingisterrible.com/post/40620375793/hash-table-denial-of-service-attacks-revisited) fornendo comunque [un livello di prestazione accettabile in una varietá di compiti](https://www.reddit.com/r/rust/comments/3hw9zf/rust_hasher_comparisons/cub4oh6).
+Di base, le [`HashMap`][HashMap] di Rust utilizzano l'algoritmo di hashing [SipHash](https://131002.net/siphash/), progettato per prevenire [attacchi basati sulla collisione di hash](http://programmingisterrible.com/post/40620375793/hash-table-denial-of-service-attacks-revisited) fornendo comunque [un livello di prestazione accettabile in una varietà di compiti](https://www.reddit.com/r/rust/comments/3hw9zf/rust_hasher_comparisons/cub4oh6).
 
-Mentre SipHash [dimostra prestazioni competitive](http://cglab.ca/%7Eabeinges/blah/hash-rs/) in molti casi, un caso in cui é conclamatamente lento é in presenza di chiavi corte, come ad esempio i numeri interi.
-Questo é perché i programmatori Rust spesso incontrano problemi prestazionali con [`HashMap`][HashMap]. 
-[FNV hasher](https://crates.io/crates/fnv) é spesso consigliato per queste casistiche, tenendo comunque in considerazione che non possiede le stesse caratteristiche di protezione dagli attacchi a collisione di SipHash.
+Mentre SipHash [dimostra prestazioni competitive](http://cglab.ca/%7Eabeinges/blah/hash-rs/) in molti casi, un caso in cui è conclamatamente lento é in presenza di chiavi corte, come ad esempio i numeri interi.
+Questo è perché i programmatori Rust spesso incontrano problemi prestazionali con [`HashMap`][HashMap]. 
+[FNV hasher](https://crates.io/crates/fnv) è spesso consigliato per queste casistiche, tenendo comunque in considerazione che non possiede le stesse caratteristiche di protezione dagli attacchi a collisione di SipHash.
 
 <h3><a href="#why-is-there-no-integrated-benchmarking" name="why-is-there-no-integrated-benchmarking">
-Perché non esiste una piattaforma integrata di misurazione delle prestazioni?
+Perchè non esiste una piattaforma integrata di misurazione delle prestazioni?
 </a></h3>
 
-Esiste ma é riservata al canale di rilascio "nightly".
-Progettiamo di costituire un sistema integrato e modulare di misurazione delle prestazioni ma nel frattempo il sistema attuale é [considerato instabile](https://github.com/rust-lang/rust/issues/29553).
+Esiste ma è riservata al canale di rilascio "nightly".
+Progettiamo di costituire un sistema integrato e modulare di misurazione delle prestazioni ma nel frattempo il sistema attuale è [considerato instabile](https://github.com/rust-lang/rust/issues/29553).
 
 <h3><a href="#does-rust-do-tail-call-optimization" name="does-rust-do-tail-call-optimization">
 Rust ottimizza le tail-call?
@@ -279,34 +279,34 @@ Rust ottimizza le tail-call?
 
 In generale, no.
 Le ottimizzazioni delle tail-call sono riservate ad alcune [condizioni particolari](http://llvm.org/docs/CodeGenerator.html#sibling-call-optimization)
-ma [non é assicurato](https://mail.mozilla.org/pipermail/rust-dev/2013-April/003557.html). 
-Siccome é sempre stata una funzionalitá desiderata, Rust ha riservato l'identificatore (`become`), 
-anche se non é ancora chiaro se sia possibile questa ottimizzazione o se verrá implementata.
-Era stata [proposta un'estensione](https://github.com/rust-lang/rfcs/pull/81) che avrebbe permesso di eliminare le tail-call in alcuni casi ma al momento é stata rimandata.
+ma [non è assicurato](https://mail.mozilla.org/pipermail/rust-dev/2013-April/003557.html). 
+Siccome è sempre stata una funzionalità desiderata, Rust ha riservato l'identificatore (`become`), 
+anche se non è ancora chiaro se sia possibile questa ottimizzazione o se verrà implementata.
+Era stata [proposta un'estensione](https://github.com/rust-lang/rfcs/pull/81) che avrebbe permesso di eliminare le tail-call in alcuni casi ma al momento è stata rimandata.
 
 <h3><a href="#does-rust-have-a-runtime" name="does-rust-have-a-runtime">
 Rust ha un ambiente di esecuzione?
 </a></h3>
 
 Non nel senso tipico utilizzato da linguaggi come il Java ma componenti della libreria standard di Rust possono essere considerati un "ambiente di esecuzione", fornendo controlli per heap, backtrace, unwinding, e stack.
-C'é un piccolo quantitativo [di codice di inizializzazione](https://github.com/rust-lang/rust/blob/33916307780495fe311fe9c080b330d266f35bfb/src/libstd/rt.rs#L43) che viene eseguito prima della funzione `main`. 
-La libreria standard di Rust inoltre é collegata alla libreria standard del C, che effettua una simile [inizializzazione](http://www.embecosm.com/appnotes/ean9/html/ch05s02.html). 
-Il codice di Rust puó essere compilato anche senza la libreria standard, in questo caso il suo ambiente é circa equivalente a quello del C.
+C'è un piccolo quantitativo [di codice di inizializzazione](https://github.com/rust-lang/rust/blob/33916307780495fe311fe9c080b330d266f35bfb/src/libstd/rt.rs#L43) che viene eseguito prima della funzione `main`. 
+La libreria standard di Rust inoltre è collegata alla libreria standard del C, che effettua una simile [inizializzazione](http://www.embecosm.com/appnotes/ean9/html/ch05s02.html). 
+Il codice di Rust può essere compilato anche senza la libreria standard, in questo caso il suo ambiente è circa equivalente a quello del C.
 
 <h2 id="syntax">Sintassi</h2>
 
 <h3><a href="#why-curly-braces" name="why-curly-braces">
-Perché le parentesi graffe? La sintassi di Rust non poteva ispirarsi a Haskell o a Python?
+Perchè le parentesi graffe? La sintassi di Rust non poteva ispirarsi a Haskell o a Python?
 </a></h3>
 
-L'utilizzo delle graffe per indicare blocchi di codice é una scelta comune in una moltitudine di linguaggi di programmazione e l'adesione di Rust allo standard é utile per le persone giá familiari con lo stile.
+L'utilizzo delle graffe per indicare blocchi di codice è una scelta comune in una moltitudine di linguaggi di programmazione e l'adesione di Rust allo standard é utile per le persone già familiari con lo stile.
 
-Le graffe consentono inoltre una sintassi piú flessibile per il programmatore e per un preprocessore piú semplice nel compilatore.
+Le graffe consentono inoltre una sintassi più flessibile per il programmatore e per un preprocessore piú semplice nel compilatore.
 
 <h3><a href="#why-brackets-around-blocks" name="why-brackets-around-blocks">
 Posso omettere le parentesi nelle condizioni degli <code>if</code>, 
-perché allora devo mettere delle parentesi attorno a righe di codice singole?
-Perché non é ammesso lo stile del C?
+perchè allora devo mettere delle parentesi attorno a righe di codice singole?
+Perchè non é ammesso lo stile del C?
 </a></h3>
 
 Mentre il C richiede parentesi obbligatorie per le condizioni dell'istruzione `if` ma rende le parentesi del corpo opzionali,
@@ -315,25 +315,25 @@ Questo lascia la condizione separata chiaramente dal corpo e evita il pericolo d
 che possono condurre in inganno durante la modifica del codice, come il famoso errore [goto fail](https://gotofail.com/) commesso da Apple.
 
 <h3><a href="#why-no-literal-syntax-for-dictionaries" name="why-no-literal-syntax-for-dictionaries">
-Perché non c'é una sintassi letterale per i dizionari?
+Perchè non c'é una sintassi letterale per i dizionari?
 </a></h3>
 
 Le scelte stilistiche di Rust sono per limitare la dimensione del *linguaggio* contemporaneamente sfruttando potenti *librerie*.
 Anche se Rust fornisce una sintassi per inizializzare array e costanti letterali stringa, questi sono gli unici tipi collezione inseriti nel linguaggio.
 Tutti gli altri tipi definiti da librerie, incluso l'onnipresente [`Vec`][Vec] utilizzano macro per la loro inizializzazione, ad esempio la macro [`vec!`][VecMacro].
 
-La scelta di utilizzare le macro di Rust per facilitare l'inizializzazione di collezioni verrá probabilmente estesa a altre collezioni in futuro, permettendo inizializzazioni semplici non solo di 
+La scelta di utilizzare le macro di Rust per facilitare l'inizializzazione di collezioni verrà probabilmente estesa a altre collezioni in futuro, permettendo inizializzazioni semplici non solo di 
 [`HashMap`][HashMap] e [`Vec`][Vec], ma anche altri tipi di collezioni come [`BTreeMap`][BTreeMap]. 
-Nel frattempo, se vuoi una sintassi piú comoda per inizializzare le collezioni, puoi [creare la tua macro](https://stackoverflow.com/questions/27582739/how-do-i-create-a-hashmap-literal) per fornirla.
+Nel frattempo, se vuoi una sintassi più comoda per inizializzare le collezioni, puoi [creare la tua macro](https://stackoverflow.com/questions/27582739/how-do-i-create-a-hashmap-literal) per fornirla.
 
 <h3><a href="#when-should-i-use-an-implicit-return" name="when-should-i-use-an-implicit-return">
 Quando dovrei utilizzare un ritorno implicito?
 </a></h3>
 
-Rust é un linguaggio molto espression-centrico e i ritorni impliciti fanno parte del suo design.
+Rust è un linguaggio molto espression-centrico e i ritorni impliciti fanno parte del suo design.
 Costrutti come gli `if`, i `match`e i normali blocchi sono tutte espressioni in Rust. 
 
-Ad esempio, il codice seguente controlla se un [`i64`][i64] é dispari, ritornando il risultato semplicamente fornendone il risultato:
+Ad esempio, il codice seguente controlla se un [`i64`][i64] è dispari, ritornando il risultato semplicamente fornendone il risultato:
 
 ```rust
 fn dispari(x: i64) -> bool {
@@ -341,7 +341,7 @@ fn dispari(x: i64) -> bool {
 }
 ```
 
-Anche se puó essere ulteriormente semplificato come qui:
+Anche se può essere ulteriormente semplificato come qui:
 
 
 ```rust
@@ -351,35 +351,35 @@ fn dispari(x: i64) -> bool {
 ```
 
 In ciascun esempio, l'ultima riga rappresenta il valore di ritorno della funzione.
-Risulta importante specificare che se una funzione termina con un punto e virgola il suo tipo di ritorno sará `()`, indicando nessun valore di ritorno. 
+Risulta importante specificare che se una funzione termina con un punto e virgola il suo tipo di ritorno sarà `()`, indicando nessun valore di ritorno. 
 I ritorni impliciti funzionano quindi esclusivamente in assenza del punto e virgola.
 
-I ritorni espliciti sono utilizzati solo se un ritorno implicito risulta impossibile perché si desidera ritornare un valore prima della fine del corpo della funzione.
+I ritorni espliciti sono utilizzati solo se un ritorno implicito risulta impossibile perchè si desidera ritornare un valore prima della fine del corpo della funzione.
 Mentre ciascuna delle funzioni sopra avrebbe potuto includere un `return` e un punto e virgola, questa aggiunta sarebbe inutilmente prolissa e inconsistente con le convenzioni del codice Rust.
 
 <h3><a href="#why-arent-function-signatures-inferred" name="why-arent-function-signatures-inferred">
-Perché i tipi delle funzioni non sono dedotti automaticamente?
+Perchè i tipi delle funzioni non sono dedotti automaticamente?
 </a></h3>
 
 In Rust le dichiarazioni sono tendelzialmente accompagnate da un tipo esplicito, mentre nel codice i tipi vengono dedotti.
 Ci sono multiple ragioni per questa scelta:
 
 - Dichiarazioni obbligatorie dei tipi obbligano a mantenere un'interfaccia stabile a livello di modulo e di pacchetto.
-- I tipi facilitano la comprensione del codice per il programmatore, eliminando la necessitá di un ambiente di sviluppo che possa desumere il tipo analizzando il codice dell'intero pacchetto:
-il tipo é sempre disponibile nelle vicinanze e in modo esplicito.
-- Semplifica gli algoritmi che gesticono la deduzione dei tipi, visto che puó essere analizzata una funzione alla volta.
+- I tipi facilitano la comprensione del codice per il programmatore, eliminando la necessità di un ambiente di sviluppo che possa desumere il tipo analizzando il codice dell'intero pacchetto:
+il tipo è sempre disponibile nelle vicinanze e in modo esplicito.
+- Semplifica gli algoritmi che gesticono la deduzione dei tipi, visto che può essere analizzata una funzione alla volta.
 
 <h3><a href="#why-does-match-have-to-be-exhaustive" name="why-does-match-have-to-be-exhaustive">
-Perché <code>match</code> deve essere cosí completo?
+Perchè <code>match</code> deve essere così completo?
 </a></h3>
 
 Per assistere nelle modifiche e in chiarezza.
 
-Prima di tutto, se ogni possibilitá viene coperta da un `match`, l'aggiunta di varianti a un `enum` causerá un errore di compilazione, invece che un problema durante l'esecuzione.
+Prima di tutto, se ogni possibilità viene coperta da un `match`, l'aggiunta di varianti a un `enum` causerá un errore di compilazione, invece che un problema durante l'esecuzione.
 Questo tipo di assistenza permette di modificare il codice Rust liberamente e senza paura.
 
 Secondariamente, il controllo dettagliato rende esplicito il caso predefinito: in generale l'unico modo per creare un `match` non esaustivo sarebbe di far andare in errore il processo se non viene incontrato alcun valore previsto.
-Le versioni iniziali di Rust non prevedevano la completezza di `match` ed é stato accertato che questa scelta ha causato una moltitudine di problematiche.
+Le versioni iniziali di Rust non prevedevano la completezza di `match` ed è stato accertato che questa scelta ha causato una moltitudine di problematiche.
 
 
 Risulta comunque semplice ignorare tutti i casi non specificati usando il carattere speciale `_`: 
@@ -399,15 +399,15 @@ Quale dovrei scegliere tra <code>f32</code> e <code>f64</code> per i calcoli in 
 
 La scelta dipende dallo scopo del programma.
 
-Se ció che conta é la precisione massima, [`f64`][f64] é da preferire. 
-Se invece si vuole minimizzare l'impatto in memoria e l'efficienza, ignorando la precisione persa, [`f32`][f32] é piú appropriato. 
-Svolgere operazioni sugli [`f32`][f32] é generalmente piú veloce, anche in piattaforme a 64-bit. 
-Come esempio, la grafica sfrutta tipicamente gli [`f32`][f32] perché richiede alte prestazioni e i numeri in virgola mobile a 32-bit bastano per rappresentare i pixel a schermo.
+Se ciò che conta è la precisione massima, [`f64`][f64] é da preferire. 
+Se invece si vuole minimizzare l'impatto in memoria e l'efficienza, ignorando la precisione persa, [`f32`][f32] è più appropriato. 
+Svolgere operazioni sugli [`f32`][f32] è generalmente più veloce, anche in piattaforme a 64-bit. 
+Come esempio, la grafica sfrutta tipicamente gli [`f32`][f32] perchè richiede alte prestazioni e i numeri in virgola mobile a 32-bit bastano per rappresentare i pixel a schermo.
 
 Nel dubbio, scegli [`f64`][f64] per una maggiore precisione.
 
 <h3><a href="#why-cant-i-compare-floats" name="why-cant-i-compare-floats">
-Perché non posso comparare i numeri a virgola mobile o usarli come chiave per un <code>HashMap</code> o un <code>BTreeMap</code>?
+Perchè non posso comparare i numeri a virgola mobile o usarli come chiave per un <code>HashMap</code> o un <code>BTreeMap</code>?
 </a></h3>
 
 I numeri a virgola mobile si possono comparare con gli operatori `==`, `!=`, `<`, `<=`, `>`, e `>=` , e attraverso la funzione `partial_cmp()`. 
@@ -416,10 +416,10 @@ I numeri a virgola mobile si possono comparare con gli operatori `==`, `!=`, `<`
 I numeri a virgola mobile non sono confrontabili con la funzione `cmp()`, possidente il tratto [`Ord`][Ord], dato che i numeri a virgola mobile non costituiscono insieme totalmente ordinato. 
 Inoltre non esiste relazione di uguaglianza completa numeri a virgola mobile e quindi non implementano il tratto[`Eq`][Eq].
 
-Non esiste l'ordinamento totale o l'uguaglianza tra numeri a virgola mobile a causa del valore [`NaN`](https://en.wikipedia.org/wiki/NaN) che non é minore, maggiore o uguale di alcun altro numero o sé stesso.
+Non esiste l'ordinamento totale o l'uguaglianza tra numeri a virgola mobile a causa del valore [`NaN`](https://en.wikipedia.org/wiki/NaN) che non è minore, maggiore o uguale di alcun altro numero o sé stesso.
 
 Visto che i numeri a virgola mobile non implementano i tratti [`Eq`][Eq] o [`Ord`][Ord], non sono utilizzabili nei tipi le cui limitazioni esigono l'implementazione di queste caratteristiche, come [`BTreeMap`][BTreeMap] o [`HashMap`][HashMap]. 
-Questo é importante perché questi tipi *suppongono* che le chiavi forniscano relazioni di ordinamento totale o di uguaglianza, a pena di malfunzionamenti.
+Questo è importante perché questi tipi *suppongono* che le chiavi forniscano relazioni di ordinamento totale o di uguaglianza, a pena di malfunzionamenti.
 
 Esiste [un pacchetto](https://crates.io/crates/ordered-float) che racchiude [`f32`][f32] e [`f64`][f64] in modo da fornire i tratti [`Ord`][Ord] e [`Eq`][Eq] che potrebbe assistere in certi casi.
 
@@ -430,16 +430,16 @@ Come posso convertire tra i tipi numerici?
 Ci sono due modi: la parola chiave `as`, che esegue una semplice conversione per tipi primitivi e i tratti [`Into`][Into] e [`From`][From], 
 che sono implementati per una serie di conversioni tra tipi numerici (e che anche tu puoi implementare sui tuoi tipi).
 I tratti [`Into`][Into] e [`From`][From] sono implementati esclusivamente per le conversioni prive di perdita, qundi ad esempio, `f64::from(0f32)` funziona mentre `f32::from(0f64)` no. 
-D'altro canto, `as` convertirá tra qualsiasi coppia di tipi primitivi, effettuando i necessari troncamenti..
+D'altro canto, `as` convertirà tra qualsiasi coppia di tipi primitivi, effettuando i necessari troncamenti..
 
 
 <h3><a href="#why-doesnt-rust-have-increment-and-decrement-operators" name="why-doesnt-rust-have-increment-and-decrement-operators">
-Perché Rust non possiede operatori per il decremento e incremento?
+Perchè Rust non possiede operatori per il decremento e incremento?
 </a></h3>
 
-Gli operatori di preincremento e postincremento (e relativi opposti equivalenti), anche se convenienti presentano una discreta complessitá;
+Gli operatori di preincremento e postincremento (e relativi opposti equivalenti), anche se convenienti presentano una discreta complessità;
 Richiedono una conoscenza dell'ordine di esecuzione e spesso conducono a piccoli problemi e comportamenti anormali in C e C++.
-`x = x + 1` o `x += 1` é leggermente piú prolisso ma chiaro.
+`x = x + 1` o `x += 1` è leggermente più prolisso ma chiaro.
 
 <h2 id="strings">Stringhe</h2>
 
@@ -451,9 +451,9 @@ Solitamente, puoi passare un riferimento a una `String` o ad un `Vec<T>` ovunque
 Utilizzando le [costrizione da de-riferimento](https://doc.rust-lang.org/stable/book/deref-coercions.html), [`String`][String] e [`Vec`][Vec] verrano automaticamente ridotti alle rispettive partizioni quando passate come riferimento tramite `&` o `& mut`.
 
 I metodi implementati su `&str` e `&[T]` possono essere utilizzati direttamente su `String` e `Vec<T>`.
-Ad esempio `una_stringa.char_at(0)` funzionerá anche se `char_at` é un metodo su `&str` e `una_stringa` é una `String`.
+Ad esempio `una_stringa.char_at(0)` funzionerà anche se `char_at` è un metodo su `&str` e `una_stringa` é una `String`.
 
-In alcuni casi, come nella programmazione generica é necessario convertire manualmente, questa operazione é effettuabile utilizzando l'operatore di partizione, in questo modo: `&mio_vettore[..]`.
+In alcuni casi, come nella programmazione generica è necessario convertire manualmente, questa operazione é effettuabile utilizzando l'operatore di partizione, in questo modo: `&mio_vettore[..]`.
 
 <h3><a href="#how-to-convert-between-str-and-string" name="how-to-convert-between-str-and-string">
 Come posso convertire una <code>&amp;str</code> in <code>String</code> e viceversa?
@@ -477,57 +477,57 @@ fn saluta(nome: &str) {
 In cosa differiscono i due tipi stringa?
 </a></h3>
 
-[`String`][String] é un'area di memoria allocata nel heap di byte UTF-8. 
+[`String`][String] è un'area di memoria allocata nel heap di byte UTF-8. 
 Le [`String`][String] mutabili possono essere modificate, espanendosi se necessario. 
-[`&str`][str] é una "vista" di capacitá fissata in una [`String`][String] allocata altrove, generalmente nel heap, in caso di partizioni riferite a [`String`][String], o in memoria statica, per le costanti letterali.
+[`&str`][str] è una "vista" di capacità fissata in una [`String`][String] allocata altrove, generalmente nel heap, in caso di partizioni riferite a [`String`][String], o in memoria statica, per le costanti letterali.
 
-[`&str`][str] é un tipo primitivo implementato nel linguaggio Rust, mentre [`String`][String] é implementato dalla libreria standard.
+[`&str`][str] è un tipo primitivo implementato nel linguaggio Rust, mentre [`String`][String] é implementato dalla libreria standard.
 
 <h3><a href="#how-do-i-do-o1-character-access-in-a-string" name="how-do-i-do-o1-character-access-in-a-string">
-Come accedo ai caratteri di una <code>String</code> con complessitá asintottica O(1)?
+Come accedo ai caratteri di una <code>String</code> con complessità asintottica O(1)?
 </a></h3>
 
-Non é possibile. Senza una chiara comprensione di cosa intendi per "carattere" e una pre-elaborazione della stringa per ritrovare l'indice del carattere desiderato.
+Non è possibile. Senza una chiara comprensione di cosa intendi per "carattere" e una pre-elaborazione della stringa per ritrovare l'indice del carattere desiderato.
 
 Le stringhe in Rust sono codificate in UTF-8.
-Un singolo carattere UTF-8 non é obbligatoriamente grande un singolo byte come sarebbe una stringa codificata in ASCII.
-Ogni byte é chiamato una "unitá di codice" (nello UTF-16, le unitá di codice sono di 2 byte, nello UTF-32 sono di 4 byte).
-I "punti di codice" sono composti di una o piú unitá di codice, combinate in "gruppi di grafemi" che fedelmente ricalcano il concetto tradizionale di caratteri.
+Un singolo carattere UTF-8 non è obbligatoriamente grande un singolo byte come sarebbe una stringa codificata in ASCII.
+Ogni byte è chiamato una "unità di codice" (nello UTF-16, le unitá di codice sono di 2 byte, nello UTF-32 sono di 4 byte).
+I "punti di codice" sono composti di una o più unità di codice, combinate in "gruppi di grafemi" che fedelmente ricalcano il concetto tradizionale di caratteri.
 
-Anche con la possibilitá di indicizzare i byte in una stringa UTF-8, non puoi accedere all'`i`-esimo elemento del gruppo di grafemi in un tempo costante.
+Anche con la possibilità di indicizzare i byte in una stringa UTF-8, non puoi accedere all'`i`-esimo elemento del gruppo di grafemi in un tempo costante.
 Ad ogni modo, se conosci a quale byte si trova il punto di codice o gruppo di grafemi desiderato, quindi _puoi_ accedervi in tempo costante.
 Le funzioni, incluse [`str::find()`][str__find] e le espressioni regolari ritornano indici dei byte, facilitando questo tipo di accesso.
 
 <h3><a href="#why-are-strings-utf-8" name="why-are-strings-utf-8">
-Perché le stringhe sono UTF-8?
+Perchè le stringhe sono UTF-8?
 </a></h3>
 
-Le [`str`][str] sono UTF-8 perché nel mondo questa codifica é frequente - specialmente in trasmissioni di rete, che ignorano l'ordine di bit della piattaforma - pensiamo quindi sia meglio che il trattamento standard dell'I/O non preveda la ricodifica in entrambe le direzioni.
+Le [`str`][str] sono UTF-8 perchè nel mondo questa codifica é frequente - specialmente in trasmissioni di rete, che ignorano l'ordine di bit della piattaforma - pensiamo quindi sia meglio che il trattamento standard dell'I/O non preveda la ricodifica in entrambe le direzioni.
 
-Questo significa che individuare un particolare punto di codice Unicode dentro una stringa é un'operazione O(n), anche se, conoscendo l'indice del byte ci si puó accedere in un tempo O(1) come previsto.
-Sotto un certo punto di vista questo é chiaramente sconveniente; ma d'altro canto questo problema é pieno di compromessi e vorremmo sottolineare alcune precisazioni importanti:
+Questo significa che individuare un particolare punto di codice Unicode dentro una stringa è un'operazione O(n), anche se, conoscendo l'indice del byte ci si può accedere in un tempo O(1) come previsto.
+Sotto un certo punto di vista questo è chiaramente sconveniente; ma d'altro canto questo problema é pieno di compromessi e vorremmo sottolineare alcune precisazioni importanti:
 
-Scorrere una [`str`][str] per valori della codifica ASCII puó essere fatto in sicurezza byte per byte,
+Scorrere una [`str`][str] per valori della codifica ASCII può essere fatto in sicurezza byte per byte,
 utilizzando [`.as_bytes()`][str__as_bytes] ed estraendo [`u8`][u8] con un costo `O(1)` e producendo valori che possono essere trasformati e comparati con la codifica ASCII con il tipo [`char`][char]. 
-Quindi se per (ad esempio) vogliamo andare a capo ad ogni `'\n'`, una ricerca byte a byte continua a essere funzionante, grazie alla flessibilitá dello standard UTF-8.
+Quindi se per (ad esempio) vogliamo andare a capo ad ogni `'\n'`, una ricerca byte a byte continua a essere funzionante, grazie alla flessibilità dello standard UTF-8.
 
 La maggior parte delle operazioni orientate ai caratteri sul testo funzionano su presupposti molto ristretti come ad esempio l'esclusione dei caratteri non ASCII.
-Anche in questo caso all'esterno della codifica ASCII si tende a utilizzare comunque un algoritmo complesso(con complessitá non costante) per determinare i bordi di caratteri, parole e paragrafi.
+Anche in questo caso all'esterno della codifica ASCII si tende a utilizzare comunque un algoritmo complesso(con complessità non costante) per determinare i bordi di caratteri, parole e paragrafi.
 Noi consigliamo di utilizzare un algoritmo "onesto", approvato da Unicode e adattato al linguaggio da considerare.
 
-Il tipo [`char`][char] é UTF-32. 
-Se hai la certezza di dover richiedere l'analisi di un "punto di codice" alla volta é semplicissimo scrivere `type wstr = [char]` e caricarci dentro una [`str`][str] in un solo passaggio, per poi lavorare con il nuovo `wstr`. 
+Il tipo [`char`][char] è UTF-32. 
+Se hai la certezza di dover richiedere l'analisi di un "punto di codice" alla volta è semplicissimo scrivere `type wstr = [char]` e caricarci dentro una [`str`][str] in un solo passaggio, per poi lavorare con il nuovo `wstr`. 
 In altre parole: il fatto che il linguaggio non decodifichi a UTF32 come prima opzione non ti deve inibire da decodificare(o ri-codificare per il processo inverso) i caratteri se necessiti di lavorare in quella codifica.
 
-Per una spiegazione piú dettagliata su perché UTF-8 é preferibile rispetto a UTF-16 o UTF-32, leggi il [manifesto di UTF-8 Everywhere](http://utf8everywhere.org/).
+Per una spiegazione più dettagliata su perchè UTF-8 é preferibile rispetto a UTF-16 o UTF-32, leggi il [manifesto di UTF-8 Everywhere](http://utf8everywhere.org/).
 
 <h3><a href="#what-string-type-should-i-use" name="what-string-type-should-i-use">
 Quale tipo stringa dovrei usare?
 </a></h3>
 
 Rust ha quattro paia di tipi stringa, [ciascuno assolve un ruolo distinto](http://www.suspectsemantics.com/blog/2016/03/27/string-types-in-rust/).
-In ciascun paio, c'é un tipo stringa "posseduto" e un tipo stringa "partizione".
-I tipi sono suddivisi cosí:
+In ciascun paio, c'è un tipo stringa "posseduto" e un tipo stringa "partizione".
+I tipi sono suddivisi così:
 
 |                       | tipo "Partizione" | tipo "Posseduto" |
 |:----------------------|:------------------|:-----------------|
@@ -545,11 +545,11 @@ I diversi tipi di stringa di Rust assolvono ruoli diversi.
 Come faccio a scrivere una funzione che accetti sia <code>&str</code> che <code>String</code>?
 </a></h3>
 
-Ci sono diverse opzioni, a seconda delle necessitá della funzione:
+Ci sono diverse opzioni, a seconda delle necessità della funzione:
 
 - Se la funzione richiede una stringa posseduta ma vuole accettare una qualsiasi stringa utilizza la restrizione al tratto `Into<String>`.
 - Se la funzione richiede una partizione di stringa ma vuole accettare una qualsiasi stringa utilizza la restrizione al tratto `AsRef<str>`.
-- Se alla funzione non interessa del tipo di stringa e vuole gestire uniformemente le due possibilitá utilizza il tipo `Cow<str>.`
+- Se alla funzione non interessa del tipo di stringa e vuole gestire uniformemente le due possibilità utilizza il tipo `Cow<str>.`
 
 __Usare `Into<String>`__
 
@@ -576,7 +576,7 @@ fn accetta_entrambe<S: AsRef<str>>(s: &S) {
 
 __Usare `Cow<str>`__
 
-In questo esempio, la funzione accetta un `Cow<str>`, che non é un tipo generico ma un contenitore, contenente o una stringa posseduta o una partizione di stringa all'occorrenza.
+In questo esempio, la funzione accetta un `Cow<str>`, che non è un tipo generico ma un contenitore, contenente o una stringa posseduta o una partizione di stringa all'occorrenza.
 
 ```rust
 fn accetta_cow(s: Cow<str>) {
@@ -591,21 +591,21 @@ fn accetta_cow(s: Cow<str>) {
 Posso implementare efficientemente strutture dati come vettori e liste concatenate in Rust?
 </a></h3>
 
-If vuoi implementare queste strutture dati per utilizzarle in altri programmi non é necessario, essendo implementazioni efficienti di queste strutture giá disponibili nella libreria standard.
+If vuoi implementare queste strutture dati per utilizzarle in altri programmi non è necessario, essendo implementazioni efficienti di queste strutture già disponibili nella libreria standard.
 
 Se invece, [vuoi solo imparare](http://cglab.ca/~abeinges/blah/too-many-lists/book/), probabilmente dovrai entrare nel codice insicuro.
-Anche se é _possibile_ implementarle solo con codice sicuro, le prestazioni sarebbero probabilmente peggiori di come sarebbe stato lo stesso codice con l'utilizzo di codice insicuro.
-La semplice ragione per ció é che le strutture dati come vettori e liste concatenate fanno affidamento a operazioni su puntatori e memoria che sono proibiti nel Rust sicuro.
+Anche se è _possibile_ implementarle solo con codice sicuro, le prestazioni sarebbero probabilmente peggiori di come sarebbe stato lo stesso codice con l'utilizzo di codice insicuro.
+La semplice ragione per ciò è che le strutture dati come vettori e liste concatenate fanno affidamento a operazioni su puntatori e memoria che sono proibiti nel Rust sicuro.
 
-Per esempio, una lista concatenata doppia richiede due riferimenti mutabili a ciascun nodo ma questo viola le regole di Rust sull'esclusivitá dei riferimenti mutabili.
-Si puó risolvere il problema utilizzando [`Weak<T>`][Weak], ma le prestazioni sarebbero probabilmente peggiori di quanto desiderato.
-Con il codice insicuro puoi ignorare le regole di esclusivitá ma devi verificare manualmente che il tuo codice non introduca violazioni nella sua gestione della memoria.
+Per esempio, una lista concatenata doppia richiede due riferimenti mutabili a ciascun nodo ma questo viola le regole di Rust sull'esclusività dei riferimenti mutabili.
+Si può risolvere il problema utilizzando [`Weak<T>`][Weak], ma le prestazioni sarebbero probabilmente peggiori di quanto desiderato.
+Con il codice insicuro puoi ignorare le regole di esclusività ma devi verificare manualmente che il tuo codice non introduca violazioni nella sua gestione della memoria.
 
 <h3><a href="#how-can-i-iterate-over-a-collection-without-consuming-it" name="how-can-i-iterate-over-a-collection-without-consuming-it">
 Come posso iterare una collezione senza muoverla o consumarla?
 </a></h3>
 
-Il modo piú semplice é utilizzare l'implementazione del tratto [`IntoIterator`][IntoIterator]. 
+Il modo più semplice è utilizzare l'implementazione del tratto [`IntoIterator`][IntoIterator]. 
 Ecco qui un esempio con [`&Vec`][Vec]:
 
 ```rust
@@ -617,21 +617,21 @@ println!("\nLunghezza: {}", v.len());
 ```
 
 I cicli `for` in Rust chiamano la funzione `into_iter()` (definita dal tratto [`IntoIterator`][IntoIterator]) per qualsiasi cosa stiano analizzando. 
-Tutto ció che implementa il tratto [`IntoIterator`][IntoIterator] puó essere traversato con un ciclo `for`. 
-[`IntoIterator`][IntoIterator] é implementato per [`&Vec`][Vec] e [`&mut Vec`][Vec], obbligando l'iteratore generato da `into_iter()` a prendere in prestito i contenuti della collezione, al posto di consumarli o muoverli. 
-Lo stesso é vero per le altre collezioni della libreria standard.
+Tutto ciò che implementa il tratto [`IntoIterator`][IntoIterator] puó essere traversato con un ciclo `for`. 
+[`IntoIterator`][IntoIterator] è implementato per [`&Vec`][Vec] e [`&mut Vec`][Vec], obbligando l'iteratore generato da `into_iter()` a prendere in prestito i contenuti della collezione, al posto di consumarli o muoverli. 
+Lo stesso è vero per le altre collezioni della libreria standard.
 
 Se si desidera un iteratore che muova/consumi i valori, basta scrivere lo stesso ciclo `for` omettendo `&` o `&mut`.
 
-Se si necessita accesso diretto all'iteratore, vi si puó usualmente accedere invocando il metodo `iter()`.
+Se si necessita accesso diretto all'iteratore, vi si può usualmente accedere invocando il metodo `iter()`.
 
 <h3><a href="#why-do-i-need-to-type-the-array-size-in-the-array-declaration" name="why-do-i-need-to-type-the-array-size-in-the-array-declaration">
-Perché devo inserire la dimensione del vettore alla sua dichiarazione?
+Perchè devo inserire la dimensione del vettore alla sua dichiarazione?
 </a></h3>
 
-Non é necessario. Se dichiari direttamente un vettore, la dimensione é dedotta dal numero di elementi. Se invece dichiari una funzione che accetta un vettore di dimensione prefissata il compilatore deve avere modo di sapere quale sará la dimensione di quel vettore.
+Non è necessario. Se dichiari direttamente un vettore, la dimensione é dedotta dal numero di elementi. Se invece dichiari una funzione che accetta un vettore di dimensione prefissata il compilatore deve avere modo di sapere quale sarà la dimensione di quel vettore.
 
-Una cosa da notare é che attualmente Rust non offere generici su array di dimensioni diverse.
+Una cosa da notare è che attualmente Rust non offere generici su array di dimensioni diverse.
 Se desideri quindi accettare un contenitore continuo di un numero variabile di valori, utilizza [`Vec`][Vec] o una partizione (a seconda che tu richieda il possesso o no).
 
 <h2 id="ownership">Possesso</h2>
@@ -653,8 +653,8 @@ Anche se efficiente questo metodo ignora i paradigmi di sicurezza di Rust.
 Come posso definire una struttura che contiene un riferimento a un suo campo?
 </a></h3>
 
-Si puó fare ma é inutile.
-La struttura diventa permanentemente prestata a sé stessa e quindi non puó essere copiata.
+Si può fare ma è inutile.
+La struttura diventa permanentemente prestata a sè stessa e quindi non può essere copiata.
 Ecco del codice per capire meglio:
 
 ```rust
@@ -676,34 +676,34 @@ fn main() {
 ```
 
 <h3><a href="#what-is-the-difference-between-consuming-and-moving" name="what-is-the-difference-between-consuming-and-moving">
-Che differenza sussiste tra passare per valore, consumare, spostare e trasferire la proprietá?
+Che differenza sussiste tra passare per valore, consumare, spostare e trasferire la proprietà?
 </a></h3>
 
 Sono parole diverse per dire la stessa cosa.
-In tutti i casi significa che il valore é stato trasferito a un nuovo proprietario, o che la proprietá é stata trasferita dal possessore originario, che quindi non puó piú accedervi.
-Se un tipo implementa il tratto `Copy`, il valore del proprietario originale non viene invalidato e puó essere utilizzato nuovamente.
+In tutti i casi significa che il valore è stato trasferito a un nuovo proprietario, o che la proprietà é stata trasferita dal possessore originario, che quindi non può più accedervi.
+Se un tipo implementa il tratto `Copy`, il valore del proprietario originale non viene invalidato e può essere utilizzato nuovamente.
 
 <h3><a href="#why-can-values-of-some-types-by-reused-while-others-are-consumed" name="why-can-values-of-some-types-by-reused-while-others-are-consumed">
-Perché alcuni valori di alcuni tipi possono essere utilizzati dopo il passaggio a una funzione mentre il riutilizzo di valori di altri tipi genera errori?
+Perchè alcuni valori di alcuni tipi possono essere utilizzati dopo il passaggio a una funzione mentre il riutilizzo di valori di altri tipi genera errori?
 </a></h3>
 
-Se un tipo implementa il tratto [`Copy`][Copy], esso verrá copiato durante il suo passaggio a una funzione. 
+Se un tipo implementa il tratto [`Copy`][Copy], esso verrà copiato durante il suo passaggio a una funzione. 
 Tutti i tipi numerici in Rust implementano [`Copy`][Copy] ma le strutture in maniera predefinita non implementano [`Copy`][Copy], quindi invece di essere copiate sono mosse. 
-Ció implica che la struttura non possa piú essere utilizzata altrove, se non viene ritornata dalla funzione tramite un `return`.
+Ciò implica che la struttura non possa più essere utilizzata altrove, se non viene ritornata dalla funzione tramite un `return`.
 
 <h3><a href="#how-do-you-deal-with-a-use-of-moved-value-error" name="how-do-you-deal-with-a-use-of-moved-value-error">
 Come si gestice l'errore "utilizzo di un valore spostato"?
 </a></h3>
 
-Questo errore significa che il valore che stai cercando di utilizzare é stato trasferito a un nuovo proprietario.
-La prima cosa da controllare in questo caso é se il trasferimento era davvero necessario: se il valore era stato mosso a una funzione, potrebbe essere possibile riscriverla per utilizzare un riferimento invece che il trasferimento, ad esempio.
-Altrimenti se il tipo mosso implementa il tratto [`Clone`][Clone], chiamare `clone()` su di esso prima di muoverlo trasferirá una sua copia, mantenendo l'originale disponibile per utilizzi futuri. 
+Questo errore significa che il valore che stai cercando di utilizzare è stato trasferito a un nuovo proprietario.
+La prima cosa da controllare in questo caso è se il trasferimento era davvero necessario: se il valore era stato mosso a una funzione, potrebbe essere possibile riscriverla per utilizzare un riferimento invece che il trasferimento, ad esempio.
+Altrimenti se il tipo mosso implementa il tratto [`Clone`][Clone], chiamare `clone()` su di esso prima di muoverlo trasferirà una sua copia, mantenendo l'originale disponibile per utilizzi futuri. 
 Nota che la clonazione di un valore dovrebbe essere l'ultima spiaggia, essendo la procedura di clonazione costosa e causa di allocazioni di memoria.
 
-Se il valore mosso é uno dei tuoi tipi personalizzati, considera implementare il tratto [`Copy`][Copy] (per la copia implicita al posto del trasferimento) o [`Clone`][Clone] (copia esplicita). 
-[`Copy`][Copy] é generalmente implementato con la direttiva `#[derive(Copy, Clone)]` ([`Copy`][Copy] richiede [`Clone`][Clone]), e [`Clone`][Clone] con la direttiva `#[derive(Clone)]`.
+Se il valore mosso è uno dei tuoi tipi personalizzati, considera implementare il tratto [`Copy`][Copy] (per la copia implicita al posto del trasferimento) o [`Clone`][Clone] (copia esplicita). 
+[`Copy`][Copy] è generalmente implementato con la direttiva `#[derive(Copy, Clone)]` ([`Copy`][Copy] richiede [`Clone`][Clone]), e [`Clone`][Clone] con la direttiva `#[derive(Clone)]`.
 
-Se nulla di tutto questo é possibile, probabilmente devi modificare la funzione che ha acquisito il possesso per fare in modo che restituisca la proprietá alla sua uscita.
+Se nulla di tutto questo è possibile, probabilmente devi modificare la funzione che ha acquisito il possesso per fare in modo che restituisca la proprietà alla sua uscita.
 
 <h3><a href="#what-are-the-rules-for-different-self-types-in-methods" name="what-are-the-rules-for-different-self-types-in-methods">
 Quali regole disciplinano l'utilizzo di <code>self</code>, <code>&amp;self</code> o <code>&amp;mut self</code> nella dichiarazione di un metodo?
@@ -723,28 +723,28 @@ Queste regole sono:
 > Prima cosa, ogni prestito deve durare per un periodo di tempo non superiore alla vita del possessore originale. 
 Seconda cosa, puoi avere accesso a uno o l'altro di questi due tipi di prestiti, ma non a entrambi contemporaneamente:
 >
-> - uno o piú riferimenti (&T) a una risorsa.
+> - uno o più riferimenti (&T) a una risorsa.
 > - esattamente un riferimento mutabile (&mut T)
 
-Nonostante le regole siano molto semplici, seguirle correttamente puó essere molto complicato, specialmente per coloro che non sono abitutati a ragionare in termini di campi di esistenza e possesso.
+Nonostante le regole siano molto semplici, seguirle correttamente può essere molto complicato, specialmente per coloro che non sono abitutati a ragionare in termini di campi di esistenza e possesso.
 
-La prima regola é comprendere che il gestore dei prestiti identifica veramente gli errori che produce: molto lavoro é stato profuso per renderlo un assistente di qualitá nella risoluzione delle problematiche che individua.
-Quando incontri un problema segnalato dal gestore dei prestiti, il primo passo é di leggere lentamente e con attenzione l'errore e poi approcciarsi al codice una volta compreso davvero l'errore descritto.
+La prima regola è comprendere che il gestore dei prestiti identifica veramente gli errori che produce: molto lavoro é stato profuso per renderlo un assistente di qualità nella risoluzione delle problematiche che individua.
+Quando incontri un problema segnalato dal gestore dei prestiti, il primo passo è di leggere lentamente e con attenzione l'errore e poi approcciarsi al codice una volta compreso davvero l'errore descritto.
 
-Il secondo passo é cercare di familiarizzare con i tipi contenitore associati con i concetti di possesso e mutabilitá forniti dalla libreria standard di Rust, includendo [`Cell`][Cell], [`RefCell`][RefCell] e [`Cow`][Cow]. 
-Questi utili e necessari strumenti possono aiutare ad esprimere efficientemente alcune situazioni complesse di possesso e mutabilitá.
+Il secondo passo è cercare di familiarizzare con i tipi contenitore associati con i concetti di possesso e mutabilità forniti dalla libreria standard di Rust, includendo [`Cell`][Cell], [`RefCell`][RefCell] e [`Cow`][Cow]. 
+Questi utili e necessari strumenti possono aiutare ad esprimere efficientemente alcune situazioni complesse di possesso e mutabilità.
 
-La singola cosa piú importante nella comprensione del gestore dei prestiti é la pratica.
-La potente analisi statica fatta da Rust é particolare e molto differente da molte esperienze di programmazione precedente.
-Ci vorrá un po' di tempo per acquisire la giusta tranquillitá.
+La singola cosa più importante nella comprensione del gestore dei prestiti è la pratica.
+La potente analisi statica fatta da Rust è particolare e molto differente da molte esperienze di programmazione precedente.
+Ci vorrà un po' di tempo per acquisire la giusta tranquillitá.
 
-Se ti ritrovi in difficoltá con il gestore dei prestiti, oppure hai finito la pazienza, sentiti libero di chiedere un aiuto alla [comunitá di Rust](community.html).
+Se ti ritrovi in difficoltà con il gestore dei prestiti, oppure hai finito la pazienza, sentiti libero di chiedere un aiuto alla [comunitá di Rust](community.html).
 
 <h3><a href="#when-is-rc-useful" name="when-is-rc-useful">
-Quando puó venire utile utilizzare una <code>Rc</code>?
+Quando può venire utile utilizzare una <code>Rc</code>?
 </a></h3>
 
-Questo é coperto dalla documentazione ufficiale per [`Rc`][Rc] il tipo di puntatore non-atomico utilizzante il reference counting di Rust. 
+Questo è coperto dalla documentazione ufficiale per [`Rc`][Rc] il tipo di puntatore non-atomico utilizzante il reference counting di Rust. 
 In breve, [`Rc`][Rc] e il suo cugino, amico del multithreading [`Arc`][Arc] sono utili per indicare possesso condiviso e vengono deallocati automaticamente dal sistema quando nessuno vi accede.
 
 <h3><a href="#how-do-i-return-a-closure-from-a-function" name="how-do-i-return-a-closure-from-a-function">
@@ -753,27 +753,27 @@ Come posso ritornare una chiusura da una funzione?
 
 Per ritornare una chiusura da una funzione, essa deve essere una "chiusura da movimento", ovvero che essa deve essere dichiarata dalla parola `move`.
 Come [illustrato nel libro di Rust](https://doc.rust-lang.org/book/closures.html#move-closures), questo fornisce alla chiusura la sua copia delle variabili catturate, indipendentemente dal quadro di allocazione del chiamante. 
-Altrimenti, ritornare da una chiusura sarebbe insicuro, visto che permetterebbe di accedere a variabili non piú disponibili; detto in un altro modo: permetterebbe di leggere dati da locazioni di memoria errate.
+Altrimenti, ritornare da una chiusura sarebbe insicuro, visto che permetterebbe di accedere a variabili non più disponibili; detto in un altro modo: permetterebbe di leggere dati da locazioni di memoria errate.
 La chiusura deve anche essere racchiusa in un [`Box`][Box], in modo da essere allocata nella heap. 
-Puoi saperne di piú [nel libro](https://doc.rust-lang.org/book/closures.html#returning-closures).
+Puoi saperne di più [nel libro](https://doc.rust-lang.org/book/closures.html#returning-closures).
 
 <h3><a href="#what-are-deref-coercions" name="what-are-deref-coercions">
-Cos'é un deriferimento forzato e come funziona?
+Cos'è un deriferimento forzato e come funziona?
 </a></h3>
 
-Un [deriferimento forzato](https://doc.rust-lang.org/book/deref-coercions.html) é una pratica conversione automatica di delle referenze 
+Un [deriferimento forzato](https://doc.rust-lang.org/book/deref-coercions.html) è una pratica conversione automatica di delle referenze 
 a puntatori (es., `&Rc<T>` or `&Box<T>`) a referenze ai loro contenuti
 (es., `&T`).
-Il deriferimento forzato esiste per rendere l'utilizzo di Rust piú comodo e sono implementati dal tratto [`Deref`][Deref].
+Il deriferimento forzato esiste per rendere l'utilizzo di Rust più comodo e sono implementati dal tratto [`Deref`][Deref].
 
-Una implementazione di `Deref` indica che il tipo implementante potrebbe essere convertito in un valore con una chiamata al metodo `deref`, che prende un riferimento immutabile al tipo chiamante e ritorna un riferimento(senza violare peró il campo di esistenza) del tipo obiettivo. 
-L'operatore `*`, se utilizzato come prefisso é un metodo piú veloce per accedere a `deref`.
+Una implementazione di `Deref` indica che il tipo implementante potrebbe essere convertito in un valore con una chiamata al metodo `deref`, che prende un riferimento immutabile al tipo chiamante e ritorna un riferimento(senza violare però il campo di esistenza) del tipo obiettivo. 
+L'operatore `*`, se utilizzato come prefisso è un metodo più veloce per accedere a `deref`.
 
 Sono chiamate "forzature" a causa delle regole spiegate qui [nel libro di Rust](https://doc.rust-lang.org/stable/book/deref-coercions.html):
 
 > Se hai un tipo `U` ed esso implementa `Deref<Target=T>`, i valori `&U` verranno automaticamente convertiti in `&T`.
 
-Ad esempio, se hai un `&Rc<String>`, esso verrá forzato per questa regola a `&String`, che puó essere forzato anche a `&str` nello stesso modo. 
+Ad esempio, se hai un `&Rc<String>`, esso verrà forzato per questa regola a `&String`, che può essere forzato anche a `&str` nello stesso modo. 
 Quindi se una funzione accettasse un parametro `&str`, puoi passare direttamente un `&Rc<String>` e tutte le forzature e verranno gestite automaticamente dal tratto `Deref`.
 
 I tipici deriferimenti forzati sono:
@@ -787,7 +787,7 @@ I tipici deriferimenti forzati sono:
 <h2 id="lifetimes">Campi di esistenza</h2>
 
 <h3><a href="#why-lifetimes" name="why-lifetimes">
-Perché i campi di esistenza?
+Perchè i campi di esistenza?
 </a></h3>
 
 I campi di esistenza sono la soluzione di Rust al problema della sicurezza della memoria.
@@ -795,25 +795,25 @@ Questi consentono a Rust di assicurare la sicurezza della memoria senza i costi 
 Sono basati su una serie di articoli accademici che possono essere trovati nel [libro di Rust](https://doc.rust-lang.org/stable/book/bibliography.html#type-system).
 
 <h3><a href="#why-is-the-lifetime-syntax-the-way-it-is" name="why-is-the-lifetime-syntax-the-way-it-is">
-Perché la sintassi dei campi di esistenza é fatta cosí?
+Perchè la sintassi dei campi di esistenza é fatta così?
 </a></h3>
 
 La sintassi `'a` proviene dalla famiglia ML di linguaggi di programmazione, dove `'a` viene utilizzato per indicare un parametro di tipo generico.
 In Rust, la sintassi doveva rappresentare qualcosa di univoco, chiaramente visibile e integrato con le altre dichiarazioni dei tipi insieme ai vari tratti e riferimenti.
-Sono state prese in considerazione anche altre scelte ma nessuna sintassi alternativa si é dimostrata chiaramente migliore.
+Sono state prese in considerazione anche altre scelte ma nessuna sintassi alternativa si è dimostrata chiaramente migliore.
 
 <h3><a href="#how-do-i-return-a-borrow-to-something-i-created-from-a-function" name="how-do-i-return-a-borrow-to-something-i-created-from-a-function">
 Come posso ritornare un prestito a qualcosa che ho creato in una funzione?
 </a></h3>
 
-Devi assicurarti che il campo di esistenza del valore prestato sia piú lungo di quello della funzione.
+Devi assicurarti che il campo di esistenza del valore prestato sia più lungo di quello della funzione.
 Puoi ottenere questo effetto puoi assegnare il campo di esistenza dell'uscita a quello di un parametro di ingresso come qui:
 
 ```rust
 type Gruppo = TypedArena<Cosa>;
 
-// (Il campo di esistenza sotto é esplicitato esclusivamente
-/// per facilitarne la comprensione; esso puó essere omesso
+// (Il campo di esistenza sotto è esplicitato esclusivamente
+/// per facilitarne la comprensione; esso può essere omesso
 // tramite le regole di elisione consultabili in un'altra
 // risposta presente in questa pagina)
 
@@ -824,7 +824,7 @@ fn crea_prestato<'a>(gruppo: &'a Gruppo,
 }
 ```
 
-Un'alternativa é eliminare interamente il riferimento ritornando un valore posseduto come [`String`][String]:
+Un'alternativa è eliminare interamente il riferimento ritornando un valore posseduto come [`String`][String]:
 
 ```rust
 fn buon_compleanno(nome: &str, eta: i64) -> String {
@@ -832,13 +832,13 @@ fn buon_compleanno(nome: &str, eta: i64) -> String {
 }
 ```
 
-Questo approccio é piú semplice ma spesso genera allocazioni in memoria non necessarie.
+Questo approccio è più semplice ma spesso genera allocazioni in memoria non necessarie.
 
 <h3><a href="#when-are-lifetimes-required-to-be-explicit" name="when-are-lifetimes-required-to-be-explicit">
-Perché alcuni riferimenti hanno un campo di esistenza, come <code>&amp;'a T</code> e altri no, tipo <code>&amp;T</code>?
+Perchè alcuni riferimenti hanno un campo di esistenza, come <code>&amp;'a T</code> e altri no, tipo <code>&amp;T</code>?
 </a></h3>
 
-In realtá, *tutti* i riferimenti hanno un campo di esistenza ma nella maggior parte dei casi non 
+In realtà, *tutti* i riferimenti hanno un campo di esistenza ma nella maggior parte dei casi non 
 ti devi preoccupare di gestirlo esplicitamente. Le regole sono le seguenti:
 
 1. Nel corpo di una funzione non devi mai specificare un campo di esistenza esplicitamente;
@@ -849,81 +849,81 @@ ti devi preoccupare di gestirlo esplicitamente. Le regole sono le seguenti:
    ["elisione del campo di esistenza"](https://doc.rust-lang.org/book/lifetimes.html#lifetime-elision),
    che a sua volta consiste in queste tre regole:
   - Ciascun campo di esistenza eliso nei parametri di una funzione diviene un campo di esistenza distinto.
-  - Se vi é esattamente un singolo campo di esistenza in ingresso, eliso o no, quel campo di esistenza
+  - Se vi è esattamente un singolo campo di esistenza in ingresso, eliso o no, quel campo di esistenza
     viene assegnato a tutti i campi di esistenza elisi utilizzati per i valori di ritorno di quella funzione.
-  - Se ci sono piú campi di esistenza in ingresso ma uno di quelli é un `&self` o un `&mut self`, il campo di esistenza
+  - Se ci sono più campi di esistenza in ingresso ma uno di quelli è un `&self` o un `&mut self`, il campo di esistenza
     di `self` viene assegnato a tutti i campi di esistenza di uscita.
 3. Se si sta definendo una `struct` o `enum` i campi di esistenza sono da dichiarare espressamente.
 
-Se queste regole danno origine a un errore di compilazione, il compilatore di Rust fornirá un messaggio di errore indicante l'errore e anche una potenziale soluzione basata sugli algoritmi di deduzione.
+Se queste regole danno origine a un errore di compilazione, il compilatore di Rust fornirà un messaggio di errore indicante l'errore e anche una potenziale soluzione basata sugli algoritmi di deduzione.
 
 <h3><a href="#how-can-rust-guarantee-no-null-pointers" name="how-can-rust-guarantee-no-null-pointers">
-Come puó Rust garantire l'assenza di "puntatori nulli" e "puntatori sospesi"?
+Come può Rust garantire l'assenza di "puntatori nulli" e "puntatori sospesi"?
 </a></h3>
 
-L'unico modo di creare un valore `&Cosa` or `&mut Cosa` é di specificare un valore preesistente di tipo `Coso` a cui la referenza deve fare riferimento.
-Il riferimento in questo modo ottiene in prestito il valore originale per un determinato blocco di codice(il campo di esistenza del riferimento) e il valore prestato non puó essere spostato o distrutto per tutta la durata del prestito.
+L'unico modo di creare un valore `&Cosa` or `&mut Cosa` è di specificare un valore preesistente di tipo `Coso` a cui la referenza deve fare riferimento.
+Il riferimento in questo modo ottiene in prestito il valore originale per un determinato blocco di codice(il campo di esistenza del riferimento) e il valore prestato non può essere spostato o distrutto per tutta la durata del prestito.
 
 <h3><a href="#how-do-i-express-the-absense-of-a-value-without-null" name="how-do-i-express-the-absense-of-a-value-without-null">
 Come faccio a indicare l'assenza di un valore senza utilizzare <code>null</code>?
 </a></h3>
 
-Puoi fare ció con il tipo [`Option`][Option] che puó alternativamente essere `Some(T)` o `None`. 
-`Some(T)` indica che un valore di tipo `T` é contenuto all'interno, mentre `None` ne indica l'assenza.
+Puoi fare ciò con il tipo [`Option`][Option] che puó alternativamente essere `Some(T)` o `None`. 
+`Some(T)` indica che un valore di tipo `T` è contenuto all'interno, mentre `None` ne indica l'assenza.
 
 <h2 id="generics">Generici</h2>
 
 <h3><a href="#what-is-monomorphisation" name="what-is-monomorphisation">
-Cos'é la "monomorfizzazione"?
+Cos'è la "monomorfizzazione"?
 </a></h3>
 
 La monomorfizzazione specializza ciascun utilizzo di una funzione(o struttura) generica in base ai tipi di parametri di ciascuna chiamata(o agli utilizzi della struttura).
 
 Durante la monomorfizzazione viene generata una nuova versione specializzata della funzione per ciascun set univoco di tipi.
-Questa strategia, giá utilizzata nel C++, genera del codice macchina efficiente, specializzato per ciascuna chiamata e invocato staticamente, con lo svantaggio che una funzione istanziata con tanti tipi diversi 
-puó dare luogo a molta duplicazione nel codice generato, generando quindi eseguibili piú grandi rispetto ad altre strategie di traduzione.
+Questa strategia, già utilizzata nel C++, genera del codice macchina efficiente, specializzato per ciascuna chiamata e invocato staticamente, con lo svantaggio che una funzione istanziata con tanti tipi diversi 
+può dare luogo a molta duplicazione nel codice generato, generando quindi eseguibili più grandi rispetto ad altre strategie di traduzione.
 
 Le funzioni che accettano [oggetti caratterizzati solo da tratti](https://doc.rust-lang.org/book/trait-objects.html) invece dei tipi non sono soggette alla monomorfizzazione. 
 Invece, i metodi invocati su oggetti tratto sono gestiti dinamicamente durante l'esecuzione.
 
 <h3><a href="#whats-the-difference-between-a-function-and-a-closure-that-doesnt-capture" name="whats-the-difference-between-a-function-and-a-closure-that-doesnt-capture">
-Qual'é la differenza tra una funzione e una chiusura che non cattura nessuna variabile?
+Qual'è la differenza tra una funzione e una chiusura che non cattura nessuna variabile?
 </a></h3>
 
 Le funzioni e le chiusure si utilizzano allo stesso modo ma hanno una gestione differente in fase di esecuzione a causa di una implementazione diversa.
 
-Le funzioni sono un costrutto fondamentale del linguaggio, mentre le chiusure sono essenzialemente un modo piú semplice per indicare uno di questi tre tratti: [`Fn`][Fn], [`FnMut`][FnMut] e [`FnOnce`][FnOnce]. 
-Quando scrivi una chiusura, il compilatore di Rust automaticamente provvede a generare una struttura implementante il tratto piú idoneo tra quei tre e a catturare le variabili corrette come membri,
-generando anche la possibilitá di utilizzare la struttura come una funzione. Le strutture, al contrario, non catturano alcuna variabile.
+Le funzioni sono un costrutto fondamentale del linguaggio, mentre le chiusure sono essenzialemente un modo più semplice per indicare uno di questi tre tratti: [`Fn`][Fn], [`FnMut`][FnMut] e [`FnOnce`][FnOnce]. 
+Quando scrivi una chiusura, il compilatore di Rust automaticamente provvede a generare una struttura implementante il tratto più idoneo tra quei tre e a catturare le variabili corrette come membri,
+generando anche la possibilità di utilizzare la struttura come una funzione. Le strutture, al contrario, non catturano alcuna variabile.
 
-La fondamentale differenza tra questi tratti é come acquisiscono il parametro `self`.
+La fondamentale differenza tra questi tratti è come acquisiscono il parametro `self`.
 [`Fn`][Fn] prende `&self`, [`FnMut`][FnMut] prende `&mut self` mentre[`FnOnce`][FnOnce] prende `self`.
 
 Anche se una cattura non cattura alcuna variabile di ambiente, viene rappresentata in fase di esecuzione tramite due puntatori, come qualsiasi altra chiusura.
 
 <h3><a href="#what-are-higher-kinded-types" name="what-are-higher-kinded-types">
-Cosa sono i tipi di piú alto livello, perché sono richiesti e perché Rust non li implementa?
+Cosa sono i tipi di più alto livello, perchè sono richiesti e perché Rust non li implementa?
 </a></h3>
 
-I tipi di piú alto livello sono tipi con parametri non specificati. I costruttori di tipi come [`Vec`][Vec], [`Result`][Result] e [`HashMap`][HashMap] sono tutti esempi di tipi di piú alto livello: 
+I tipi di più alto livello sono tipi con parametri non specificati. I costruttori di tipi come [`Vec`][Vec], [`Result`][Result] e [`HashMap`][HashMap] sono tutti esempi di tipi di piú alto livello: 
 ciascuno richiede alcuni tipi aggiuntivi per poter denotare effettivamente il suo tipo, come nel caso di `Vec<u32>`. 
 Il supporto per i tipi di alto livello significa che questi tipi "incompleti" possono essere utilizzati ovunque possano essere utilizzati anche i tipi "completi", non escludendo le funzioni generiche.
 
-Ogni tipo completo, come [`i32`][i32], [`bool`][bool], o [`char`][char] é di tipo `*` (questa notazione deriva dalla teoria correlata con il sistema dei tipi). 
-Un tipo a parametro singolo, come [`Vec<T>`][Vec] é invece `* -> *`, ovvero che vec [`Vec<T>`][Vec] accetta un tipo completo come [`i32`][i32] e ritorna il tipo completo `Vec<i32>`. 
-Un tipo con tre parametri, come [`HashMap<K, V, S>`][HashMap] é di tipo `* -> * -> * -> *` perché accetta tre tipi completi (come [`i32`][i32], [`String`][String] e [`RandomState`][RandomState]) per generare un nuovo tipo completo `HashMap<i32, String, RandomState>`.
+Ogni tipo completo, come [`i32`][i32], [`bool`][bool], o [`char`][char] è di tipo `*` (questa notazione deriva dalla teoria correlata con il sistema dei tipi). 
+Un tipo a parametro singolo, come [`Vec<T>`][Vec] è invece `* -> *`, ovvero che vec [`Vec<T>`][Vec] accetta un tipo completo come [`i32`][i32] e ritorna il tipo completo `Vec<i32>`. 
+Un tipo con tre parametri, come [`HashMap<K, V, S>`][HashMap] è di tipo `* -> * -> * -> *` perché accetta tre tipi completi (come [`i32`][i32], [`String`][String] e [`RandomState`][RandomState]) per generare un nuovo tipo completo `HashMap<i32, String, RandomState>`.
 
 In aggiunta a questi esempi, i costruttori di tipo possono accettare dei parametri sul *campo di esistenza*, che denoteremo con `Lt`.
-Ad esempio `slice::Iter` ha il tipo `Lt -> * -> *`, perché va istanziato ad esempio come `Iter<'a, u32>`.
+Ad esempio `slice::Iter` ha il tipo `Lt -> * -> *`, perchè va istanziato ad esempio come `Iter<'a, u32>`.
 
-La mancanza di supporto per i tipi di piú alto livello rende difficile scrivere alcuni tipi di codice generico.
+La mancanza di supporto per i tipi di più alto livello rende difficile scrivere alcuni tipi di codice generico.
 Risulta particolarmente problematico astrarre su concetti come gli iteratori, dato che essi sono spesso parametrizzati nei confronti di uno specifico campo di esistenza.
 Queste premesse hanno impedito la creazione di tratti che astraggano ulteriormente le collezioni presenti in Rust.
 
-Un altro esempio frequente é da ricercare nei concetti di functor e monad, entrambi dei quali sono costruttori di tipi, invece che tipi individuali.
+Un altro esempio frequente è da ricercare nei concetti di functor e monad, entrambi dei quali sono costruttori di tipi, invece che tipi individuali.
 
-Rust al momento non possiede supporto per i tipi di piú alto livello perché non é stato prioritizzato lo sviluppo di questa funzione rispetto ad altre funzionalitá che rispecchiano meglio gli obiettivi del progetto.
-Essendo la progettazione di funzionalitá importanti come queste un campo minato, vorremmo procedere con cautela, non c'é un'altra ragione particolare sul perché Rust non possiede questa funzionalitá.
+Rust al momento non possiede supporto per i tipi di più alto livello perchè non é stato prioritizzato lo sviluppo di questa funzione rispetto ad altre funzionalità che rispecchiano meglio gli obiettivi del progetto.
+Essendo la progettazione di funzionalità importanti come queste un campo minato, vorremmo procedere con cautela, non c'è un'altra ragione particolare sul perché Rust non possiede questa funzionalitá.
 
 <h3><a href="#what-do-named-type-parameters-in-generic-types-mean" name="what-do-named-type-parameters-in-generic-types-mean">
 Cosa significano i parametri fatti tipo <code>&lt;T=Foo&gt;</code> nel codice generico?
@@ -931,15 +931,15 @@ Cosa significano i parametri fatti tipo <code>&lt;T=Foo&gt;</code> nel codice ge
 
 Questi sono chiamati [tipi associati](https://doc.rust-lang.org/stable/book/associated-types.html), permettono di indicare limitazioni di tratto non esprimibili con un costrutto `where`. 
 Ad esempio, una limitazione generica `X: Bar<T=Foo>` significa che `X` deve implementare il tratto `Bar` e in tale implementazione di bar `Bar`, `X` deve scegliere `Foo` come il tipo associato di `Bar`, `T`. 
-Gli esempi in cui una limitazione di tal genere non é esprimibile con un costrutto `where` includono i tipi tratto come `Box<Bar<T=Foo>>`.
+Gli esempi in cui una limitazione di tal genere non è esprimibile con un costrutto `where` includono i tipi tratto come `Box<Bar<T=Foo>>`.
 
-I tipi associati esistono perché spesso i generici riguardano famiglie di tipi, dove un tipo determina tutti gli altri membri. Per esempio, un tratto per grafi potrebbe avere per `Self` il grafo stesso e avere dei tipi correlati per i suoi nodi e vertici. Ciascun tipo grafo identifica univocamente i tipi associato, rendendo molto piú conciso lavorare con questi tipi di strutture e fornendo anche una migliore gestione sulla deduzione dei tipi in molti casi.
+I tipi associati esistono perchè spesso i generici riguardano famiglie di tipi, dove un tipo determina tutti gli altri membri. Per esempio, un tratto per grafi potrebbe avere per `Self` il grafo stesso e avere dei tipi correlati per i suoi nodi e vertici. Ciascun tipo grafo identifica univocamente i tipi associato, rendendo molto più conciso lavorare con questi tipi di strutture e fornendo anche una migliore gestione sulla deduzione dei tipi in molti casi.
 
 <h3><a href="#how-do-i-overload-operators" name="how-do-i-overload-operators">
-Posso sovrascrivere gli operatore? Se sí, quali? Come faccio?
+Posso sovrascrivere gli operatore? Se sì, quali? Come faccio?
 </a></h3>
 
-Puoi personalizzare l'implementazione di una varietá di operatori utilizzando i loro tratti associati: [`Add`][Add] per il  `+`, [`Mul`][Mul] per il `*` e via dicendo. Si puó fare cosí:
+Puoi personalizzare l'implementazione di una varietà di operatori utilizzando i loro tratti associati: [`Add`][Add] per il  `+`, [`Mul`][Mul] per il `*` e via dicendo. Si può fare così:
 
 ```rust
 use std::ops::Add;
@@ -989,12 +989,12 @@ I seguenti operatori possono essere sovrascritti:
 Cosa distingue <code>Eq</code>/<code>PartialEq</code> e <code>Ord</code>/<code>PartialOrd</code>?
 </a></h3>
 
-Ci sono alcuni tipi in Rust i cui valori sono solo parzialmente ordinati oppure hanno relazioni di equivalenza parziali. Ordinamento parziale significa che potrebbero esserci valori di quel tipo che non sono né piú piccoli né piú grandi di un altro. Uguaglianza parziale significa che ci potrebbero essere dei valori di un certo tipo che non sono uguali a loro stessi.
+Ci sono alcuni tipi in Rust i cui valori sono solo parzialmente ordinati oppure hanno relazioni di equivalenza parziali. Ordinamento parziale significa che potrebbero esserci valori di quel tipo che non sono nè più piccoli né piú grandi di un altro. Uguaglianza parziale significa che ci potrebbero essere dei valori di un certo tipo che non sono uguali a loro stessi.
 
-I tipi a virgola mobile ([`f32`][f32] e [`f64`][f64]) sono un buon esempio di questo. Ogni tipo in virgola mobile potrebbe avere il valore `NaN` (ovvero "non un numero"). `NaN` non é uguale a sé stesso (`NaN == NaN` é falso) e nemmeno piú grande o piú piccolo di un qualsiasi valore. 
+I tipi a virgola mobile ([`f32`][f32] e [`f64`][f64]) sono un buon esempio di questo. Ogni tipo in virgola mobile potrebbe avere il valore `NaN` (ovvero "non un numero"). `NaN` non è uguale a sé stesso (`NaN == NaN` é falso) e nemmeno più grande o piú piccolo di un qualsiasi valore. 
 Di conseguenza sia [`f32`][f32] che [`f64`][f64] implementano [`PartialOrd`][PartialOrd] e [`PartialEq`][PartialEq] ma non [`Ord`][Ord] e nemmeno [`Eq`][Eq].
 
-Come spiegato nella [precedente domanda sui numeri in virgola mobile](#why-cant-i-compare-floats), queste distinzioni sono importanti perché alcune collezioni fanno affidamento sul totale ordinamento/uguaglianza per funzionare.
+Come spiegato nella [precedente domanda sui numeri in virgola mobile](#why-cant-i-compare-floats), queste distinzioni sono importanti perchè alcune collezioni fanno affidamento sul totale ordinamento/uguaglianza per funzionare.
 
 <h2 id="input-output">Input / Output</h2>
 
@@ -1045,49 +1045,49 @@ Ci sono molte librerie che forniscono input / output asincroni in Rust, come [mi
 Come faccio a prendere parametri da riga di comando in Rust?
 </a></h3>
 
-Il modo piú semplice é utilizzare [`Args`][Args], che fornisce un iteratore sui parametri da riga di comando.
+Il modo più semplice è utilizzare [`Args`][Args], che fornisce un iteratore sui parametri da riga di comando.
 
-Se stai cercando qualcosa di piú potente, ci sono [una serie di librerie disponbili su crates.io](https://crates.io/keywords/argument).
+Se stai cercando qualcosa di più potente, ci sono [una serie di librerie disponbili su crates.io](https://crates.io/keywords/argument).
 
 <h2 id="error-handling">Gestione degli errori</h2>
 
 <h3><a href="#why-doesnt-rust-have-exceptions" name="why-doesnt-rust-have-exceptions">
-Perché Rust non ha le eccezioni?
+Perchè Rust non ha le eccezioni?
 </a></h3>
 
-Le eccezioni complicano la comprensione del flusso del programma, esprimono validitá o invaliditá all'infuori del sistema dei tipi e funzionano male in ambienti multicore(un obiettivo primario per Rust).
+Le eccezioni complicano la comprensione del flusso del programma, esprimono validità o invaliditá all'infuori del sistema dei tipi e funzionano male in ambienti multicore(un obiettivo primario per Rust).
 
 Rust preferisce un approccio alla gestione degli errori basato sui tipi come [spiegato nel dettaglio nel libro](https://doc.rust-lang.org/stable/book/error-handling.html). 
-Questo é piú compatibile con il flusso di controllo tipico di Rust, la concorrenza e tutto il resto.
+Questo è più compatibile con il flusso di controllo tipico di Rust, la concorrenza e tutto il resto.
 
 <h3><a href="#whats-the-deal-with-unwrap" name="whats-the-deal-with-unwrap">
-Perché c'é <code>unwrap()</code> ovunque?
+Perchè c'é <code>unwrap()</code> ovunque?
 </a></h3>
 
-`unwrap()` é una funzione che estrae il valore da una [`Option`][Option] o un [`Result`][Result] e va in errore se il valore non é presente.
+`unwrap()` è una funzione che estrae il valore da una [`Option`][Option] o un [`Result`][Result] e va in errore se il valore non é presente.
 
 `unwrap()` non dovrebbe essere il tuo modo principale per gestire gli errori prevedibili, tipo un errore nell'input dell'utente.
-Nel tuo codice, dovrebbe essere trattato come test per la non nullitá di un valore, pena il mandare in errore il programma.
+Nel tuo codice, dovrebbe essere trattato come test per la non nullità di un valore, pena il mandare in errore il programma.
 
 Viene utilizzato anche per provare velocemente quando non si vuole ancora gestire tutti i casi o negli articoli, quando la gestione degli errori potrebbe distrarre dal resto.
 
 <h3><a href="#why-do-i-get-errors-with-try" name="why-do-i-get-errors-with-try">
-Perché ottengo un errore quando provo a eseguire codice di esempio che utilizza la macro <code>try!</code>?
+Perchè ottengo un errore quando provo a eseguire codice di esempio che utilizza la macro <code>try!</code>?
 </a></h3>
 
-Quasi sicuramente é un problema con il tipo ritornato dalla funzione. La macro [`try!`][TryMacro] estrae un valore da [`Result`][Result] o ritorna con l'errore portato in [`Result`][Result]. 
-Ció significa che [`try`][TryMacro] vale solo per le funzioni che ritornano un [`Result`][Result], dove il tipo costruito `Err` implementa `From::from(err)`. 
-In particolare ció significa che la macro [`try!`][TryMacro] non é utlizzabile nella funzione `main`.
+Quasi sicuramente è un problema con il tipo ritornato dalla funzione. La macro [`try!`][TryMacro] estrae un valore da [`Result`][Result] o ritorna con l'errore portato in [`Result`][Result]. 
+Ciò significa che [`try`][TryMacro] vale solo per le funzioni che ritornano un [`Result`][Result], dove il tipo costruito `Err` implementa `From::from(err)`. 
+In particolare ciò significa che la macro [`try!`][TryMacro] non è utlizzabile nella funzione `main`.
 
 <h3><a href="#error-handling-without-result" name="error-handling-without-result">
-Esiste un modo piú semplice per gestire gli errori rispetto a inserire <code>Result</code> ovunque?
+Esiste un modo più semplice per gestire gli errori rispetto a inserire <code>Result</code> ovunque?
 </a></h3>
 
-Se stai cercando un modo per evitare di gestire i [`Result`][Result] nel codice di altre persone, puoi sempre utilizzare [`unwrap()`][unwrap] ma probabilmente non é ció che desideri. 
-[`Result`][Result] indica che una qualche operazione potrebbe fallire. Richiedere di gestire esplicitamente questi problemi é uno dei tanti modi in cui Rust incoraggia la scrittura di programmi affidabili.
+Se stai cercando un modo per evitare di gestire i [`Result`][Result] nel codice di altre persone, puoi sempre utilizzare [`unwrap()`][unwrap] ma probabilmente non è ciò che desideri. 
+[`Result`][Result] indica che una qualche operazione potrebbe fallire. Richiedere di gestire esplicitamente questi problemi è uno dei tanti modi in cui Rust incoraggia la scrittura di programmi affidabili.
 Rust fornisce degli strumenti come la [macro `try!`][TryMacro] per gestire in ergonomia queste situazioni.
 
-Se davvero desideri non gestire un errore, utilizza [`unwrap()`][unwrap] ma sappi che fare ció implica che il codice arresterá la sua esecuzione in caso di fallimento, usualmente terminando il processo.
+Se davvero desideri non gestire un errore, utilizza [`unwrap()`][unwrap] ma sappi che fare ciò implica che il codice arresterà la sua esecuzione in caso di fallimento, usualmente terminando il processo.
 
 <h2 id="concurrency">Concorrenza</h2>
 
@@ -1095,10 +1095,10 @@ Se davvero desideri non gestire un errore, utilizza [`unwrap()`][unwrap] ma sapp
 Posso utilizzare valori statici attraverso i thread senza utilizzare <code>unsafe</code>?
 </a></h3>
 
-La mutabilitá é sicura solo se sincronizzata. Mutare un [`Mutex`][Mutex] statico (inizializzato tramite il pacchetto [lazy-static](https://crates.io/crates/lazy_static/)) non richiede un blocco di codice `unsafe` come non lo richiede la modifica di un [`AtomicUsize`][AtomicUsize] 
+La mutabilità è sicura solo se sincronizzata. Mutare un [`Mutex`][Mutex] statico (inizializzato tramite il pacchetto [lazy-static](https://crates.io/crates/lazy_static/)) non richiede un blocco di codice `unsafe` come non lo richiede la modifica di un [`AtomicUsize`][AtomicUsize] 
 (inizializzabile anche senza lazy_static).
 
-Piú in generale, se un tipo implementa il tratto [`Sync`][Sync] e non implementa [`Drop`][Drop], esso [é utilizzabile in una `static`](https://doc.rust-lang.org/book/const-and-static.html#static).
+Più in generale, se un tipo implementa il tratto [`Sync`][Sync] e non implementa [`Drop`][Drop], esso [è utilizzabile in una `static`](https://doc.rust-lang.org/book/const-and-static.html#static).
 
 <h2 id="macros">Macro</h2>
 
@@ -1108,9 +1108,9 @@ Posso scrivere una macro per generare identificatori?
 
 Al momento no.
 Le macro di Rust sono ["hygienic macros"](https://en.wikipedia.org/wiki/Hygienic_macro) che intenzionalmente evitano la cattura o la creazione di identificatori che potrebbero collidere con altri. 
-Le loro capacitá sono significativamente differenti dagli stili delle macro normalmente associate ai preprocessori C. 
+Le loro capacità sono significativamente differenti dagli stili delle macro normalmente associate ai preprocessori C. 
 Le invocazioni delle macro possono comparire sono il luoghi dove sono esplicitamente supportate: oggetti, dichiarazioni, espressioni e motivi. 
-Dove per "dichiarazioni" si intende uno spazio dove é possibile inserire un metodo. 
+Dove per "dichiarazioni" si intende uno spazio dove è possibile inserire un metodo. 
 Non si possono utilizzare le macro per completare una dichiarazione avventura parzialmente e seguendo la stessa logica, nemmeno per completare dichiarazioni parziali di variabili.
 
 <h2 id="debugging">Debugging e strumentazione</h2>
@@ -1120,15 +1120,15 @@ Come si debuggano i programmi Rust?
 </a></h3>
 
 Si possono debuggare con [gdb](https://sourceware.org/gdb/current/onlinedocs/gdb/) o [lldb](http://lldb.llvm.org/tutorial.html), allo stesso modo di C e C++. 
-In realtá, ogni installazione di Rust viene fornita con uno o entrambi tra rust-gdb e rust-lldb(a seconda della piattaforma). Questi due componenti estendono gdb e lldb con funzioni per permettere una migliore esperienza.
+In realtà, ogni installazione di Rust viene fornita con uno o entrambi tra rust-gdb e rust-lldb(a seconda della piattaforma). Questi due componenti estendono gdb e lldb con funzioni per permettere una migliore esperienza.
 
 <h3><a href="#how-do-i-locate-a-panic" name="how-do-i-locate-a-panic">
-<code>rustc</code> ha detto che del codice della libreria standard é andato in crash, come faccio a trovare il problema?
+<code>rustc</code> ha detto che del codice della libreria standard è andato in crash, come faccio a trovare il problema?
 </a></h3>
 
-Questo errore é spesso causato dall'utilizzo di [`unwrap()`][unwrap] su un `None` o `Err`. 
+Questo errore è spesso causato dall'utilizzo di [`unwrap()`][unwrap] su un `None` o `Err`. 
 Abilitando la variabile di ambiente `RUST_BACKTRACE=1` potresti ottenere ulteriori informazioni. 
-Potrebbe essere di aiuto anche la compilazione in modalitá debug (predefinita per il comando `cargo build`). 
+Potrebbe essere di aiuto anche la compilazione in modalità debug (predefinita per il comando `cargo build`). 
 Si possono anche utilizzare i sopracitati `rust-gdb` o `rust-lldb`.
 
 <h3><a href="#what-ide-should-i-use" name="what-ide-should-i-use">
@@ -1138,10 +1138,10 @@ Quale ambiente di sviluppo integrato dovrei utilizzare?
 Ci sono molte opzioni per sviluppare in Rust, tutte illustrate sulla pagina ufficiale [sul supporto agli ambienti di sviluppo](https://forge.rust-lang.org/ides.html).
 
 <h3><a href="#wheres-rustfmt" name="wheres-rustfmt">
-<code>gofmt</code> é fantastico. Dov'é <code>rustfmt</code>?
+<code>gofmt</code> è fantastico. Dov'é <code>rustfmt</code>?
 </a></h3>
 
-`rustfmt` é [proprio qui](https://github.com/rust-lang-nursery/rustfmt), sta venendo sviluppato proprio per permettere di rendere il codice Rust il piú semplice e prevedibile possibile.
+`rustfmt` è [proprio qui](https://github.com/rust-lang-nursery/rustfmt), sta venendo sviluppato proprio per permettere di rendere il codice Rust il più semplice e prevedibile possibile.
 
 <h2 id="low-level">Low-Level</h2>
 
@@ -1156,17 +1156,17 @@ Per copiare byte non in conflitto usa [`copy_nonoverlapping`][copy_nonoverlappin
 Entrambe le funzioni elencate sono `unsafe`, visto che possono eludere le garanzie di sicurezza. Sono quindi da utilizzare con attenzione.
 
 <h3><a href="#does-rust-work-without-the-standard-library" name="does-rust-work-without-the-standard-library">
-Puó Rust operare senza la sua libreria standard?
+Può Rust operare senza la sua libreria standard?
 </a></h3>
 
-Sí. I programmi Rust possono scegliere di non caricare la libreria standard utilizzando l'attributo `#![no_std]`. 
-Una volta impostato, é ancora possibile utilizzare la libreria chiave di Rust, composta esclusivamente da primitivi indipendenti dalla piattaforma di esecuzione. Essa non include IO, concorrenza, allocazioni nella heap, ecc.
+Sì. I programmi Rust possono scegliere di non caricare la libreria standard utilizzando l'attributo `#![no_std]`. 
+Una volta impostato, è ancora possibile utilizzare la libreria chiave di Rust, composta esclusivamente da primitivi indipendenti dalla piattaforma di esecuzione. Essa non include IO, concorrenza, allocazioni nella heap, ecc.
 
 <h3><a href="#can-i-write-an-operating-system-in-rust" name="can-i-write-an-operating-system-in-rust">
 Posso scrivere un sistema operativo in Rust?
 </a></h3>
 
-Sí! In realtá al momento [ci sono molti progetti che stanno facendo proprio questo](http://wiki.osdev.org/Rust).
+Sì! In realtà al momento [ci sono molti progetti che stanno facendo proprio questo](http://wiki.osdev.org/Rust).
 
 <h3><a href="#how-can-i-write-endian-independent-values" name="how-can-i-write-endian-independent-values">
 Come faccio a scrivere o leggere tipi numerici come <code>i32</code> o <code>f64</code> in formato big-endian o little-endian in un file o un flusso di bit?
@@ -1193,7 +1193,7 @@ enum SimilC {
 
 L'attributo `#[repr(C)]` se applicato a tali `enum` gli fornisce la stessa rappresentazione che avrebbero avuto nel C. 
 Questo permette nella maggior parte dei casi di utilizzare le `enum` di Rust nella FFI insieme alle `enum` fornite dal C. 
-Tale attributo é applicabile alle `struct` per ottenere la stessa rappresentazione delle `struct` del C.
+Tale attributo è applicabile alle `struct` per ottenere la stessa rappresentazione delle `struct` del C.
 
 <h2 id="cross-platform">Multipiattaforma</h2>
 
@@ -1210,7 +1210,7 @@ TODO: Write this answer.
 -->
 
 <h3><a href="#how-do-i-express-platform-specific-behavior" name="how-do-i-express-platform-specific-behavior">
-Qual'é il modo consigliato per indicare comportamenti specifici a una piattaforma in Rust?
+Qual'è il modo consigliato per indicare comportamenti specifici a una piattaforma in Rust?
 </a></h3>
 
 I comportamenti specifici alla piattaforma sono esprimibili utilizzando [attributi di compilazione condizionale](https://doc.rust-lang.org/reference.html#conditional-compilation) come ad esempio `target_os`, `target_family`, `target_endian`, ecc.
@@ -1219,7 +1219,7 @@ I comportamenti specifici alla piattaforma sono esprimibili utilizzando [attribu
 Posso programmare per Android/iOS in Rust?
 </a></h3>
 
-Sí! Ci sono giá alcuni esempi utilizzanti Rust sia per [Android](https://github.com/tomaka/android-rs-glue) che per [iOS](https://www.bignerdranch.com/blog/building-an-ios-app-in-rust-part-1/). 
+Sì! Ci sono già alcuni esempi utilizzanti Rust sia per [Android](https://github.com/tomaka/android-rs-glue) che per [iOS](https://www.bignerdranch.com/blog/building-an-ios-app-in-rust-part-1/). 
 Richiede un pochino di lavoro di preparazione ma Rust funziona correttamente su entrambe le piattaforme.
 
 <h3><a href="#can-i-run-my-rust-program-in-a-web-browser" name="can-i-run-my-rust-program-in-a-web-browser">
@@ -1232,7 +1232,7 @@ Non ancora ma sono in corso degli sforzi per permettere di compilare Rust per il
 Come faccio a usare la compilazione incrociata in Rust?
 </a></h3>
 
-La compilazione incrociata é possibile in Rust ma richiede [alcune accortezze](https://github.com/japaric/rust-cross/blob/master/README.md) per essere impostata. 
+La compilazione incrociata è possibile in Rust ma richiede [alcune accortezze](https://github.com/japaric/rust-cross/blob/master/README.md) per essere impostata. 
 Ogni compilatore Rust permette anche la compilazione incrociata ma le librerie necessitano di essere ricompilate per ogni piattaforma obiettivo.
 
 Rust distribuisce [copie della libreria standard](https://static.rust-lang.org/dist/) per ciascuna delle piattaforme supportate, ritrovabili nei file `rust-std-*` presenti nella pagina citata ma ad oggi non esistono metodi automatizzati per installarle.
@@ -1243,16 +1243,16 @@ Rust distribuisce [copie della libreria standard](https://static.rust-lang.org/d
 Come si correlano moduli e pacchetti?
 </a></h3>
 
-- Un pacchetto é un'unitá compilabile, ovvero la minima quantitá di codice su cui il compilatore Rust puó ancora operare.
-- Un modulo é una organizzazione di unitá compilabili(anche annidate) all'interno di un pacchetto.
-- Un pacchetto contiene un modulo implicito e senza nome nel suo livello piú alto.
+- Un pacchetto è un'unità compilabile, ovvero la minima quantitá di codice su cui il compilatore Rust può ancora operare.
+- Un modulo è una organizzazione di unità compilabili(anche annidate) all'interno di un pacchetto.
+- Un pacchetto contiene un modulo implicito e senza nome nel suo livello più alto.
 - Le definizioni ricorsive sono propagabili ai moduli ma non ai pacchetti.
 
 <h3><a href="#why-cant-the-rust-compiler-find-a-library-im-using" name="why-cant-the-rust-compiler-find-a-library-im-using">
-Perché il compilatore Rust non riesce a trovare questa libreria che sto importando con <code>use</code>?
+Perchè il compilatore Rust non riesce a trovare questa libreria che sto importando con <code>use</code>?
 </a></h3>
 
-Ci sono diverse possibilitá ma un errore comune é non comprendere che le dichiarazioni `use` sono relative al livello base del pacchetto. 
+Ci sono diverse possibilità ma un errore comune è non comprendere che le dichiarazioni `use` sono relative al livello base del pacchetto. 
 Prova a riscrivere le tue dichiarazioni in modo che utilizzino i percorsi relativi alla cartella base del pacchett per provare a risolvere il problema.
 
 Ci sono anche `self` e `super`, che rendono i percorsi di `use` riferiti rispettivamente al modulo corrente o al modulo padre.
@@ -1260,7 +1260,7 @@ Ci sono anche `self` e `super`, che rendono i percorsi di `use` riferiti rispett
 Per ulteriori informazioni su come utilizzare  `use`, leggi il capitolo del libro di Rust ["Crates and Modules"](https://doc.rust-lang.org/stable/book/crates-and-modules.html).
 
 <h3><a href="#why-do-i-have-to-declare-modules-with-mod" name="why-do-i-have-to-declare-modules-with-mod">
-Perché devo dichiarare i file dei moduli con <code>mod</code> al posto di poterli invocare con <code>use</code> direttamente?
+Perchè devo dichiarare i file dei moduli con <code>mod</code> al posto di poterli invocare con <code>use</code> direttamente?
 </a></h3>
 
 Ci sono due modi per dichiarare i moduli in Rust, in linea o in un altro file. Ecco un esempio:
@@ -1292,7 +1292,7 @@ pub fn f() {
 }
 ```
 
-Nel primo esempio, il modulo é definito nello stesso file in cui é utilizzato, nel secondo, la dichiarazione del modulo dice al compilatore di cercare o il file `ciao.rs` o `ciao/mod.rs` e di caricarlo.
+Nel primo esempio, il modulo è definito nello stesso file in cui é utilizzato, nel secondo, la dichiarazione del modulo dice al compilatore di cercare o il file `ciao.rs` o `ciao/mod.rs` e di caricarlo.
 
 Notare la differenza tra `mod` e `use`: `mod` dichiara l'esistenza di un modulo, mentre `use` fa riferimento a un modulo dichiarato altrove, rendendone accessibili i suoi contenuti all'interno del modulo corrente.
 
@@ -1300,36 +1300,36 @@ Notare la differenza tra `mod` e `use`: `mod` dichiara l'esistenza di un modulo,
 Come configuro Cargo all'utilizzo di un proxy?
 </a></h3>
 
-Come spiegato nella [guida alla configurazione di Cargo](http://doc.crates.io/config.html), puó essere impostato un proxy impostando la variabile "proxy" sotto `[http]` nel file di configurazione.
+Come spiegato nella [guida alla configurazione di Cargo](http://doc.crates.io/config.html), può essere impostato un proxy impostando la variabile "proxy" sotto `[http]` nel file di configurazione.
 
 <h3><a href="#why-cant-the-compile-find-method-implementations" name="why-cant-the-compile-find-method-implementations">
-Perché il compilatore non riesce a trovare l'implementazione del metodo anche se ho giá specificato la direttiva <code>use</code> sul pacchetto che la contiene?
+Perchè il compilatore non riesce a trovare l'implementazione del metodo anche se ho già specificato la direttiva <code>use</code> sul pacchetto che la contiene?
 </a></h3>
 
-Per i metodi definiti su un tratto, devi esplicitamente importare la dichiarazione del tratto. Questo significa che non é sufficiente importare un modulo dove una `struct` implementa un tratto, bisogna importare anche il tratto stesso.
+Per i metodi definiti su un tratto, devi esplicitamente importare la dichiarazione del tratto. Questo significa che non è sufficiente importare un modulo dove una `struct` implementa un tratto, bisogna importare anche il tratto stesso.
 
 <h3><a href="#why-cant-the-compiler-infer-use-statements" name="why-cant-the-compiler-infer-use-statements">
-Perché il compilatore non puó capire gli <code>use</code> da solo?
+Perchè il compilatore non può capire gli <code>use</code> da solo?
 </a></h3>
 
-Probabilmente potrebbe ma non lo vorresti. Mentre in molti casi é probabile che il compilatore possa determinare correttamente il modulo da importare guardando le definizioni questo potrebbe non applicarsi a tutte le casistiche.
+Probabilmente potrebbe ma non lo vorresti. Mentre in molti casi è probabile che il compilatore possa determinare correttamente il modulo da importare guardando le definizioni questo potrebbe non applicarsi a tutte le casistiche.
 Ogni decisione fatta da `rustc` genererebbe sopresa e confusione in alcuni casi e Rust preferisce essere esplicito riguardo all'origine dei nomi.
 
-Ad esempio, il compilatore potrebbe decidere che nel casi due identificatori fossero in conflitto sia da preferire l'identificatore la cui dichiarazione é meno recente.
+Ad esempio, il compilatore potrebbe decidere che nel casi due identificatori fossero in conflitto sia da preferire l'identificatore la cui dichiarazione è meno recente.
 In questo caso sia il modulo `foo` che il modulo `bar` definiscono l'identificatore `baz` ma `foo` viene registrato per primo e quindi il compilatore inserirebbe `use foo::baz;`.
 
 ```rust
 mod foo;
 mod bar;
 
-// use foo::baz  // ció che sarebbe inserito.
+// use foo::baz  // ciò che sarebbe inserito.
 
 fn main() {
   baz();
 }
 ```
 
-Sapendo questa dinamica, probabilmente risparmieresti qualche carattere ma aumenteresti anche la possibilitá di generare degli errori imprevisti quando in realtá al posto di `baz()` intendevi `bar::baz()`, diminuendo anche la leggibilitá del codice,
+Sapendo questa dinamica, probabilmente risparmieresti qualche carattere ma aumenteresti anche la possibilità di generare degli errori imprevisti quando in realtá al posto di `baz()` intendevi `bar::baz()`, diminuendo anche la leggibilitá del codice,
 avendo reso la chiamata alla funzione dipendente dall'ordine di dichiarazione. Questi sono compromessi che Rust non ha intenzione di prendere.
 
 Ad ogni modo, in futuro, un ambiente di sviluppo integrato potrebbe assistere nella gestione delle dichiarazioni, fornendo il massimo di entrambi i mondi: assistenza automatica nelle dichiarazioni ma chiarezza sulle origini dei nomi importati.
@@ -1347,20 +1347,20 @@ Come carico dinamicamente librerie in Rust?
 Puoi importare librerie dinamiche in Rust con [libloading](https://crates.io/crates/libloading), che fornisce un sistema multipiattaforma per il link dinamico.
 
 <h3><a href="#why-doesnt-crates-io-have-namespaces" name="why-doesnt-crates-io-have-namespaces">
-Perché crates.io non ha uno spazio dei nomi?
+Perchè crates.io non ha uno spazio dei nomi?
 </a></h3>
 
 Citando la [spiegazione ufficiale](https://internals.rust-lang.org/t/crates-io-package-policies/1041) sul design di [https://crates.io](https://crates.io):
 
-> Nel primo mese di crates.io, un buon numero di persone hanno richiesto la possibilitá di introdurre [pacchetti con spazi dei nomi](https://github.com/rust-lang/crates.io/issues/58).<br><br>
+> Nel primo mese di crates.io, un buon numero di persone hanno richiesto la possibilità di introdurre [pacchetti con spazi dei nomi](https://github.com/rust-lang/crates.io/issues/58).<br><br>
 >
-> Mentre questi permettono a autori multipli di utilizzare un singolo nome generico, aggiungono complessitá su come i pacchetti vengono indicati nel codice Rust e nella comunicazione su di essi. A una prima occhiata questo permetterebbe a piú persone di associarsi al nome `http`, ma questo implicherebbe che per riferirsi a due pacchetti di autori diversi si debbe parlare ad esempio di `http di wycats` o di `http di reem`, offrendo pochi vantaggi rispetto a nomi come `wycats-http` o `reem-http`.<br><br>
+> Mentre questi permettono a autori multipli di utilizzare un singolo nome generico, aggiungono complessità su come i pacchetti vengono indicati nel codice Rust e nella comunicazione su di essi. A una prima occhiata questo permetterebbe a più persone di associarsi al nome `http`, ma questo implicherebbe che per riferirsi a due pacchetti di autori diversi si debbe parlare ad esempio di `http di wycats` o di `http di reem`, offrendo pochi vantaggi rispetto a nomi come `wycats-http` o `reem-http`.<br><br>
 >
-> Inoltre, osservando questa scelta abbiamo scoperto che le persone tendono a utilizzare nomi piú creativi (come `nokogiri` invece che "libxml2 di tendelove"). Questi nomi creativi tendono a essere brevi e memorabili, in parte anche grazie della mancanza di dipendenze da altri. Rendono anche piú semplice parlare in modo conciso e non ambiguo di pacchetti, creando nuovi nomi altisonanti. Esistono diversi ecosistemi da oltre 10,000 pacchetti come NPM e RubyGems le cui comunitá prosperano anche sotto un singolo spazio dei nomi.<br><br>
+> Inoltre, osservando questa scelta abbiamo scoperto che le persone tendono a utilizzare nomi più creativi (come `nokogiri` invece che "libxml2 di tendelove"). Questi nomi creativi tendono a essere brevi e memorabili, in parte anche grazie della mancanza di dipendenze da altri. Rendono anche piú semplice parlare in modo conciso e non ambiguo di pacchetti, creando nuovi nomi altisonanti. Esistono diversi ecosistemi da oltre 10,000 pacchetti come NPM e RubyGems le cui comunità prosperano anche sotto un singolo spazio dei nomi.<br><br>
 >
 > In breve, non pensiamo che l'ecosistema Cargo avrebbe giovamento se Piston scegliesse un nome come `bvssvni/game-engine` (permettendo ad altri di scegliere `wycats/game-engine`) invece che semplicemente `piston`.<br><br>
 >
-> Proprio perché gli spazi dei nomi sono piú complessi in diversi ambiti ed essendo la loro aggiunta possibile se necessario, per ora abbiamo intenzione di preservare un singolo spazio dei nomi condiviso.
+> Proprio perchè gli spazi dei nomi sono più complessi in diversi ambiti ed essendo la loro aggiunta possibile se necessario, per ora abbiamo intenzione di preservare un singolo spazio dei nomi condiviso.
 
 <h2 id="libraries">Librerie</h2>
 
@@ -1369,7 +1369,7 @@ Come faccio a fare una richiesta HTTP?
 </a></h3>
 
 La libreria standard non contiene un'implementazione di HTTP quindi dovrai utilizzare un pacchetto esterno.
-[Hyper](https://github.com/hyperium/hyper) é la piú popolare ma ce ne sono [tante altre](https://crates.io/keywords/http).
+[Hyper](https://github.com/hyperium/hyper) è la più popolare ma ce ne sono [tante altre](https://crates.io/keywords/http).
 
 <h3><a href="#how-can-i-write-a-gui-application" name="how-can-i-write-a-gui-application">
 Come faccio a scrivere un applicativo con interfaccia grafica in Rust?
@@ -1382,7 +1382,7 @@ Guarda questa lista di [librerie per realizzare interfacce grafiche](https://git
 Come faccio a deserializzare JSON/XML?
 </a></h3>
 
-[Serde](https://github.com/serde-rs/serde) é la libreria consigliata per serializzare e deserializzare di dati in Rust da e verso una moltitudine di formati.
+[Serde](https://github.com/serde-rs/serde) è la libreria consigliata per serializzare e deserializzare di dati in Rust da e verso una moltitudine di formati.
 
 <h3><a href="#is-there-a-standard-2d-vector-crate" name="is-there-a-standard-2d-vector-crate">
 Esiste una libreria standard per la geometria e vettoriali 2D+?
@@ -1394,42 +1394,42 @@ Non ancora! Puoi farne una tu?
 Come faccio a creare un applicativo OpenGL in Rust?
 </a></h3>
 
-[Glium](https://github.com/tomaka/glium) é la principale libreria per utilizzare OpenGL in Rust. [GLFW](https://github.com/bjz/glfw-rs) é un'altra opzione valida.
+[Glium](https://github.com/tomaka/glium) è la principale libreria per utilizzare OpenGL in Rust. [GLFW](https://github.com/bjz/glfw-rs) é un'altra opzione valida.
 
 <h3><a href="#can-i-write-a-video-game-in-rust" name="can-i-write-a-video-game-in-rust">
 Posso fare un videogioco in Rust?
 </a></h3>
 
-Certo! La principale libreria per programmare giochi in Rust é [Piston](http://www.piston.rs/) ci  sono sia un [subreddit per la creazione di videogiochi in Rust](https://www.reddit.com/r/rust_gamedev/) e un canale IRC (`#rust-gamedev` su [Mozilla IRC](https://wiki.mozilla.org/IRC)).
+Certo! La principale libreria per programmare giochi in Rust è [Piston](http://www.piston.rs/) ci  sono sia un [subreddit per la creazione di videogiochi in Rust](https://www.reddit.com/r/rust_gamedev/) e un canale IRC (`#rust-gamedev` su [Mozilla IRC](https://wiki.mozilla.org/IRC)).
 
 <h2 id="design-patterns">Paradigmi di programmazione</h2>
 
 <h3><a href="#is-rust-object-oriented" name="is-rust-object-oriented">
-Rust é orientato agli oggetti?
+Rust è orientato agli oggetti?
 </a></h3>
 
-Rust é multi paradigma. Molte cose possibili in linguaggi orientati agli oggetti sono possibili in Rust ma non proprio tutto e non sempre utilizzando un livello di astrazione uguale a quello a cui si é abituati.
+Rust è multi paradigma. Molte cose possibili in linguaggi orientati agli oggetti sono possibili in Rust ma non proprio tutto e non sempre utilizzando un livello di astrazione uguale a quello a cui si é abituati.
 
 <h3><a href="#how-do-i-map-object-oriented-concepts-to-rust" name="how-do-i-map-object-oriented-concepts-to-rust">
 Come converto concetti della programmazione orientata agli oggetti in Rust?
 </a></h3>
 
-Dipende. _Esistono_ modi per convertire concetti orientati agli oggetti come [ereditarietá multiple](https://www.reddit.com/r/rust/comments/2sryuw/ideaquestion_about_multiple_inheritence/) a Rust ma non essendo Rust orientato agli oggetti il risultato della conversione potrenne apparire sostanzialmente diverso dalla sua rappresentazione in un linguaggio orientato agli oggetti.
+Dipende. _Esistono_ modi per convertire concetti orientati agli oggetti come [ereditarietà multiple](https://www.reddit.com/r/rust/comments/2sryuw/ideaquestion_about_multiple_inheritence/) a Rust ma non essendo Rust orientato agli oggetti il risultato della conversione potrenne apparire sostanzialmente diverso dalla sua rappresentazione in un linguaggio orientato agli oggetti.
 
 <h3><a href="#how-do-i-configure-a-struct-with-optional-parameters" name="how-do-i-configure-a-struct-with-optional-parameters">
 Come gestisco la configurazione di una `struct` con parametri opzionali? 
 </a></h3>
 
-Il modo piú semplice é utilizzare il tipo [`Option`][Option] in qualsiasi funzione venga utilizzata per costruire istanze della struttura (generalmente `new()`). 
-Un altro modo é utilizzare il [metodo del costruttore](https://aturon.github.io/ownership/builders.html), dove alcune funzioni devono essere chiamate dopo la costruzione del tipo.
+Il modo più semplice è utilizzare il tipo [`Option`][Option] in qualsiasi funzione venga utilizzata per costruire istanze della struttura (generalmente `new()`). 
+Un altro modo è utilizzare il [metodo del costruttore](https://aturon.github.io/ownership/builders.html), dove alcune funzioni devono essere chiamate dopo la costruzione del tipo.
 
 <h3><a href="#how-do-i-do-global-variables" name="how-do-i-do-global-variables">
 Come faccio le variabili globali in Rust?
 </a></h3>
 
-Le globali in Rust possono essere fatte utilizzando la dichiarazione `const` per le globali computate al momento della compilazione, mentre `static` é utilizzabile per globali mutabili. 
+Le globali in Rust possono essere fatte utilizzando la dichiarazione `const` per le globali computate al momento della compilazione, mentre `static` è utilizzabile per globali mutabili. 
 Nota che la modifica di una variabile `static mut` richiede `unsafe`, visto che permette problemi di concorrenza, una cosa impossibile nel Rust sicuro. 
-Una differenza importante tra `const` e `static` é che si possono prendere riferimenti a valori `static` ma non a valori `const` se privi di posizione in memoria specificata. 
+Una differenza importante tra `const` e `static` è che si possono prendere riferimenti a valori `static` ma non a valori `const` se privi di posizione in memoria specificata. 
 Per ulteriori informazioni su `const` e `static`, leggi [il libro di Rust](https://doc.rust-lang.org/book/const-and-static.html).
 
 <h3><a href="#how-can-i-set-compile-time-constants-that-are-defined-procedurally" name="how-can-i-set-compile-time-constants-that-are-defined-procedurally">
@@ -1446,7 +1446,7 @@ Posso eseguire del codice di inizializzazione prima di main?
 </a></h3>
 
 Rust non consente l'esistenza di qualcosa prima di `main`.
-La cosa piú vicina puó essere fatta tramite il pacchetto [`lazy-static`](https://github.com/Kimundi/lazy-static.rs), simulante una situazione "pre-main" in cui le variabili statiche vengono inizializzate al loro primo utilizzo.
+La cosa più vicina può essere fatta tramite il pacchetto [`lazy-static`](https://github.com/Kimundi/lazy-static.rs), simulante una situazione "pre-main" in cui le variabili statiche vengono inizializzate al loro primo utilizzo.
 
 <!--
 
@@ -1470,16 +1470,16 @@ Rust has consistently worked to avoid having features with overlapping purposes,
 Rust permette di assegnare alle globali espressioni non costanti?
 </a></h3>
 
-No. Le globali non possono non avere un costruttore costante e non possiedono un destrutture. I costruttori statici sono sconvenienti perché assicurare un ordine di inizializzazione statico é complesso. Le situazioni "pre-main" sono spesso considerate sconvenienti e Rust non le consente.
+No. Le globali non possono non avere un costruttore costante e non possiedono un destrutture. I costruttori statici sono sconvenienti perchè assicurare un ordine di inizializzazione statico é complesso. Le situazioni "pre-main" sono spesso considerate sconvenienti e Rust non le consente.
 
 Leggi anche il [domande frequenti del C++](http://yosefk.com/c++fqa/ctors.html#fqa-10.12) che fa menzione del "problema dell'ordine di inizializzazione per le static" e il [blog di Eric Lippert](https://ericlippert.com/2013/02/06/static-constructors-part-one/) per le problematiche in C#, che anche esso possiede queste funzioni.
 
-Puoi emulare globali il cui valore non é costante con il pacchetto [lazy-static](https://crates.io/crates/lazy_static/).
+Puoi emulare globali il cui valore non è costante con il pacchetto [lazy-static](https://crates.io/crates/lazy_static/).
 
 <h2 id="other-languages">Altri linguaggi</h2>
 
 <h3><a href="#how-can-i-use-static-fields" name="how-can-i-use-static-fields">
-Come posso implementare in Rust quello che in C si puó ottenere con <code>struct X { static int X; };</code> ?
+Come posso implementare in Rust quello che in C si può ottenere con <code>struct X { static int X; };</code> ?
 </a></h3>
 
 Rust non possiede campi `static` come nel codice sopra. Al loro posto puoi dichiarare una varibile `static` a un determinato modulo, che viene preservata privata all'interno dello stesso.
@@ -1488,15 +1488,15 @@ Rust non possiede campi `static` come nel codice sopra. Al loro posto puoi dichi
 Come converto una enum simil-C a un intero e vice versa?
 </a></h3>
 
-Convertire una enum simil-C a un intero é possibile con l'espressione `as` come in `e as i64` (dove `e` é una enum).
+Convertire una enum simil-C a un intero è possibile con l'espressione `as` come in `e as i64` (dove `e` é una enum).
 
-La conversione in altre direzioni puó essere svolta tramite `match`, che associa differenti valori numerici a differenti potenziali valori per la enum.
+La conversione in altre direzioni può essere svolta tramite `match`, che associa differenti valori numerici a differenti potenziali valori per la enum.
 
 <h3><a href="#why-do-rust-programs-use-more-memory-than-c" name="why-do-rust-programs-use-more-memory-than-c">
-Perché i programmi in Rust sono piú grandi su disco di programmi C?
+Perchè i programmi in Rust sono più grandi su disco di programmi C?
 </a></h3>
 
-Ci sono diversi fattori che contribuiscono alla tendenza di Rust di avere in generale file binari piú grandi di programmi funzionalmente equivalenti in C.
+Ci sono diversi fattori che contribuiscono alla tendenza di Rust di avere in generale file binari più grandi di programmi funzionalmente equivalenti in C.
 In generale Rust si focalizza su ottimizzare le prestazioni di programmi reali, non le dimensioni di piccoli programmi.
 
 __Monomorfizzazione__
@@ -1519,26 +1519,26 @@ Questo permette un efficiente dispacciamento statico della funzione generica ma 
 
 __Simboli di debug__
 
-I programmi Rust sono compilati con i simboli di debug inclusi, anche se in modalitá rilascio. Questi sono utilizzabili per fornire informazioni in caso di crash e possono essere rimossi con `strip`, o un qualsiasi altro strumento per la rimozione di simboli di debug. 
-Risulta utile sapere anche che compilare in modalitá rilascio con Cargo equivale a impostare il livello di ottimizzazione 3 con rustc. 
+I programmi Rust sono compilati con i simboli di debug inclusi, anche se in modalità rilascio. Questi sono utilizzabili per fornire informazioni in caso di crash e possono essere rimossi con `strip`, o un qualsiasi altro strumento per la rimozione di simboli di debug. 
+Risulta utile sapere anche che compilare in modalità rilascio con Cargo equivale a impostare il livello di ottimizzazione 3 con rustc. 
 Un livello alternativo di ottimizzazione (chiamato `s` o `z`) [aggiunto recentemente](https://github.com/rust-lang/rust/pull/32386) indica al compilatore di focalizzarsi invece che sulle prestazioni, sulle dimensioni dell'eseguibile finale.
 
 __Jemalloc__
 
 Rust utilizza jemalloc come il suo allocatore predefinito, questo aumenta le dimensioni dei binari compilati.
-Jemalloc é stato scelto perché é un allocatore consistente e di qualitá con caratteristiche prestazionali preferibili rispetto agli allocatori forniti da molti sistemi. 
-Al momento si stanno facendo esperimenti su come [rendere piú facile l'utilizzo di allocatori personalizzati](https://github.com/rust-lang/rust/issues/32838) ma la funzionalitá non é stata ancora ultimata.
+Jemalloc è stato scelto perché é un allocatore consistente e di qualità con caratteristiche prestazionali preferibili rispetto agli allocatori forniti da molti sistemi. 
+Al momento si stanno facendo esperimenti su come [rendere più facile l'utilizzo di allocatori personalizzati](https://github.com/rust-lang/rust/issues/32838) ma la funzionalità non è stata ancora ultimata.
 
 __Ottimizzazione del linker__
 
-Rust di base non effettua ottimizzazioni al momento del linking ma gli piú essere detto di farlo.
-Questo incrementa la quantitá di ottimizzazioni effettuabili e puó avere un effetto sulle dimensioni dei binari generati, questo effetto puó essere amplificato se in combinazione con l'opzione di ottimizzazione per dimensioni sopracitata.
+Rust di base non effettua ottimizzazioni al momento del linking ma gli più essere detto di farlo.
+Questo incrementa la quantità di ottimizzazioni effettuabili e può avere un effetto sulle dimensioni dei binari generati, questo effetto puó essere amplificato se in combinazione con l'opzione di ottimizzazione per dimensioni sopracitata.
 
 __Libreria standard__
 
 La libreria standard di Rust include libbacktrace e libunwind, che potrebbero essere non volute in alcuni programmi. 
-Utilizzare `#![no_std]` puó quindi fornire dei binari piú piccoli ma cambia in modo sostanziale il modo in cui il codice deve essere scritto. 
-Nota che utilizzare Rust senza la libreria standard é spesso funzionalmente vicino al codice C equivalente.
+Utilizzare `#![no_std]` può quindi fornire dei binari più piccoli ma cambia in modo sostanziale il modo in cui il codice deve essere scritto. 
+Nota che utilizzare Rust senza la libreria standard è spesso funzionalmente vicino al codice C equivalente.
 
 Per esempio, il programma seguente in C legge un nome e dice "ciao" alla persona con quel nome:
 
@@ -1567,8 +1567,8 @@ fn main() {
 }
 ```
 
-Questo programma, quando compilato e confrontato con il programma C avrá una dimensione maggiore e utilizzerá piú memoria ma non é esattamente equivalente al codice C che lo precede.
-Il reale equivalente in realtá assomiglia di piú a questo:
+Questo programma, quando compilato e confrontato con il programma C avrà una dimensione maggiore e utilizzerá più memoria ma non è esattamente equivalente al codice C che lo precede.
+Il reale equivalente in realtà assomiglia di più a questo:
 
 ```rust
 #![feature(lang_items)]
@@ -1600,46 +1600,46 @@ fn start(_argc: isize, _argv: *const *const u8) -> isize {
 #[lang="stack_exhausted"] extern fn stack_exhausted() {}
 ```
 
-Che dovrebbe certamente eguagliare il C nell'utilizzo della memoria, incrementando peró la complessitá e rimuovendo le garanzie fornite dal codice Rust (evitate utilizzando `unsafe`).
+Che dovrebbe certamente eguagliare il C nell'utilizzo della memoria, incrementando però la complessità e rimuovendo le garanzie fornite dal codice Rust (evitate utilizzando `unsafe`).
 
 <h3><a href="#why-no-stable-abi" name="why-no-stable-abi">
-Perché Rust non ha una ABI stabile come il C e perché devo annotare le cose con extern?
+Perchè Rust non ha una ABI stabile come il C e perché devo annotare le cose con extern?
 </a></h3>
 
-Dedicarsi a una ABI é una decisione importante che puó limitare i cambiamenti vantaggiosi futuri. Dato che Rust ha raggiunto la versione 1.0 a Maggio 2015 é troppo presto per impegnarsi a costruire una ABI stabile. Ció peró non implica che non possa succedere nel futuro.
-(Nonostante questo il C++ é riuscito a vivere per molti anni senza specificare una ABI stabile.)
+Dedicarsi a una ABI è una decisione importante che può limitare i cambiamenti vantaggiosi futuri. Dato che Rust ha raggiunto la versione 1.0 a Maggio 2015 é troppo presto per impegnarsi a costruire una ABI stabile. Ció peró non implica che non possa succedere nel futuro.
+(Nonostante questo il C++ è riuscito a vivere per molti anni senza specificare una ABI stabile.)
 
 Il lemma `extern` permette di usare con Rust specifiche ABI, come quella ben definita del C, per interoperare con altri linguaggi.
 
 <h3><a href="#can-rust-code-call-c-code" name="can-rust-code-call-c-code">
-Puó il codice Rust chiamare il codice C?
+Può il codice Rust chiamare il codice C?
 </a></h3>
 
-Sí. Chiamare il C da Rust é progettato per avere la stessa efficienza delle chiamate di codice C dal C++.
+Sì. Chiamare il C da Rust è progettato per avere la stessa efficienza delle chiamate di codice C dal C++.
 
 <h3><a href="#can-c-code-call-rust-code" name="can-c-code-call-rust-code">
-Puó il codice C chiamare il codice Rust?
+Può il codice C chiamare il codice Rust?
 </a></h3>
 
-Sí. Il codice Rust deve essere sposto mediante una dichiarazione `extern`, che lo rende compatibile con la ABI del C. 
-Tale funzione puó essere passata al codice C come puntatore a una funzione o, se con l'attributo `#[no_mangle]` chiamata direttamente dal C.
+Sì. Il codice Rust deve essere sposto mediante una dichiarazione `extern`, che lo rende compatibile con la ABI del C. 
+Tale funzione può essere passata al codice C come puntatore a una funzione o, se con l'attributo `#[no_mangle]` chiamata direttamente dal C.
 
 <h3><a href="#why-rust-vs-cxx" name="why-rust-vs-cxx">
-Scrivo giá del C++ perfetto. Cosa mi fornisce di piú Rust?
+Scrivo già del C++ perfetto. Cosa mi fornisce di più Rust?
 </a></h3>
 
-Il C++ moderno include molte funzioni che rendono la scrittura di codice sicuro e corretto meno prono ad errori ma non é perfetto e rimane comunque facile introdurre vulnerabilitá.
-Gli sviluppatori del C++ stanno cercando di porre rimedio a queste problematiche ma il C++ é limitato da una lunga storia che impedisce di attuare molte idee che si vorrebbero sperimentare.
+Il C++ moderno include molte funzioni che rendono la scrittura di codice sicuro e corretto meno prono ad errori ma non è perfetto e rimane comunque facile introdurre vulnerabilità.
+Gli sviluppatori del C++ stanno cercando di porre rimedio a queste problematiche ma il C++ è limitato da una lunga storia che impedisce di attuare molte idee che si vorrebbero sperimentare.
 
-Rust é stato disegnato sin dal primo giorno per essere un linguaggio di programmazione per sistemi sicuro, questo significa che non é limitato da scelte pregresse che potrebbero impedire di raggiungere il corretto livello di sicurezza come il C++.
-In C++, la sicurezza si ottiene mediante una rigorosa disciplina personale ed é semplice commettere errori mentre in Rust, la sicurezza é predefinita. 
+Rust è stato disegnato sin dal primo giorno per essere un linguaggio di programmazione per sistemi sicuro, questo significa che non é limitato da scelte pregresse che potrebbero impedire di raggiungere il corretto livello di sicurezza come il C++.
+In C++, la sicurezza si ottiene mediante una rigorosa disciplina personale ed è semplice commettere errori mentre in Rust, la sicurezza é predefinita. 
 Rust permette quindi di lavorare in un gruppo di persone meno perfette di te, senza dover spendere il tuo tempo per controllare il codice altrui per controllare potenziali falle di sicurezza nel codice altrui.
 
 <h3><a href="#how-to-get-cxx-style-template-specialization" name="how-to-get-cxx-style-template-specialization">
 Come creo l'equivalente della specializzazione dei template del C++ in Rust?
 </a></h3>
 
-Rust attualmente non ha un equivalente esatto alla specializzazione dei template ma [ci si sta lavorando su](https://github.com/rust-lang/rfcs/pull/1210) e verrá probabilmente aggiunta a presto. 
+Rust attualmente non ha un equivalente esatto alla specializzazione dei template ma [ci si sta lavorando su](https://github.com/rust-lang/rfcs/pull/1210) e verrà probabilmente aggiunta a presto. 
 Ad ogni modo, effetti simili si possono ottenere con i [tipi associati](https://doc.rust-lang.org/stable/book/associated-types.html).
 
 <h3><a href="#how-does-ownership-relate-to-cxx-move-semantics" name="how-does-ownership-relate-to-cxx-move-semantics">
@@ -1647,33 +1647,33 @@ Come si compara il sistema dei possessi in Rust con le semantiche del movimento 
 </a></h3>
 
 I concetti base sono simili ma i due sistemi differiscono nella pratica.
-In entrambi i sistemi "muovere" un valore é un modo per trasferire il possesso
+In entrambi i sistemi "muovere" un valore è un modo per trasferire il possesso
 delle risorse sottostanti. Ad esempio, muovere una stringa trasferisce il suo buffer
 al posto di copiarla.
 
-In Rust il trasferimento di possesso é il comportamento standard.
+In Rust il trasferimento di possesso è il comportamento standard.
 Ad esempio, se scrivo una funzione che accetta una `String` come parametro,
-questa funzione prenderá possesso del valore della `String` fornita dal chiamante:
+questa funzione prenderà possesso del valore della `String` fornita dal chiamante:
 
 ```rust
 fn elabora(s: String) { }
 
 fn chiamante() {
     let s = String::from("Ciao mondo!");
-    elabora(s); // Trasferisce la proprietá di `s` a `elabora`
-    elabora(s); // Errore! il possesso é giá stato trasferito.
+    elabora(s); // Trasferisce la proprietà di `s` a `elabora`
+    elabora(s); // Errore! il possesso è già stato trasferito.
 }
 ```
 
 Come puoi vedere nel frammento di codice sopra, nella funzione `chiamante`,
 la prima chiamata a `elabora` trasferisce il possesso della variabile `s`.
 Il compilatore tiene traccia del possesso, quindi una seconda chiamata a
-`elabora` genere un errore perché non é consentito trasferire il possesso
+`elabora` genere un errore perchè non é consentito trasferire il possesso
 dello stesso valore due volte.
-Rust previene anche il movimento di un valore se vi é ancora un 
+Rust previene anche il movimento di un valore se vi è ancora un 
 riferimente ad esso.
 
-Il C++ ha un approccio distinto, il comportamento predefinito é infatti
+Il C++ ha un approccio distinto, il comportamento predefinito è infatti
 di copiare un valore (nello specifico invocandone il costruttore della copia).
 Ad ogni modo i chiamati possono dichiarare i loro parametri utilizzando
 un "riferimento rvalore" come `string&&`, per indicare che prenderanno
@@ -1698,23 +1698,23 @@ Ad esempio, il codice sopra viene compilato senza alcun avviso o errore
 utilizzando l'ultima versione di Clang.
 Inoltre in C++ il possesso della stringa `s` stessa
 (se non del suo buffer interno) rimane in `chiamante`, e quindi il 
-destruttore di `s` verrá eseguito quando `chiamante` ritorna, anche se
-é stato spostato (in Rust, al contrario, i valori spostati sono rimossi
+destruttore di `s` verrà eseguito quando `chiamante` ritorna, anche se
+è stato spostato (in Rust, al contrario, i valori spostati sono rimossi
 dai nuovi proprietari).
 
 <h3><a href="#how-to-interoperate-with-cxx" name="how-to-interoperate-with-cxx">
 Come posso interoperare il C++ da Rust, o il Rust da C++?
 </a></h3>
 
-Il Rust é il C++ possono interoperare tramite il C. Sia il Rust che il C++ forniscono una [foreign function interface](https://doc.rust-lang.org/book/ffi.html) per il C, che puó essere utilizzata per comunicare tra di loro. 
-Se scrivere dei collegamenti in C é troppo complicato, puoi sempre utilizzare [rust-bindgen](https://github.com/crabtw/rust-bindgen) per generare automaticamente dei collegamenti C++ funzionanti.
+Il Rust è il C++ possono interoperare tramite il C. Sia il Rust che il C++ forniscono una [foreign function interface](https://doc.rust-lang.org/book/ffi.html) per il C, che può essere utilizzata per comunicare tra di loro. 
+Se scrivere dei collegamenti in C è troppo complicato, puoi sempre utilizzare [rust-bindgen](https://github.com/crabtw/rust-bindgen) per generare automaticamente dei collegamenti C++ funzionanti.
 
 <h3><a href="#does-rust-have-cxx-style-constructors" name="does-rust-have-cxx-style-constructors">
 Rust possiede dei costruttori in stile C++?
 </a></h3>
 
-No. Al loro posto si utilizzano delle funzioni, il cui nome usuale é `new()`, ad ogni modo questa é semplicemente una convenzione e non una regola del linguaggio.
-La funzione `new()` é semplicemente un'altra funzione. Un esempio di ció é questo:
+No. Al loro posto si utilizzano delle funzioni, il cui nome usuale è `new()`, ad ogni modo questa é semplicemente una convenzione e non una regola del linguaggio.
+La funzione `new()` è semplicemente un'altra funzione. Un esempio di ciò é questo:
 
 ```rust
 struct Foo {
@@ -1739,59 +1739,59 @@ Rust possiede dei costruttori copia?
 </a></h3>
 
 Non esattamente. I tipi che implementano `Copy` faranno una copia simil-C senza alcun lavoro aggiuntivo.
-Non é possibile peró implementare tipi `Copy` che richiedono un comportamento personalizzato alla copia.
+Non è possibile però implementare tipi `Copy` che richiedono un comportamento personalizzato alla copia.
 Al loro posto in Rust i costruttori copia sono creati implementando il tratto e successivamente chiamando il metodo `clone`.
-Permettere di definire manualmente l'operatore copia permette di ridurre la complessitá, facilitando per lo sviluppatore l'identificazione di operazioni potenzialmente costose.
+Permettere di definire manualmente l'operatore copia permette di ridurre la complessità, facilitando per lo sviluppatore l'identificazione di operazioni potenzialmente costose.
 
 <h3><a href="#does-rust-have-move-constructors" name="does-rust-have-move-constructors">
 Rust possiede dei costruttori di movimento?
 </a></h3>
 
 No. I valori di tutti i tipi sono mossi tramite `memcpy`. 
-Questo permette di scrivere del codice `unsafe` generico molto piú semplice, dato che l'assegnazione, il passaggio e il ritorno di valori sono privi di effetti collaterali.
+Questo permette di scrivere del codice `unsafe` generico molto più semplice, dato che l'assegnazione, il passaggio e il ritorno di valori sono privi di effetti collaterali.
 
 <h3><a href="#compare-go-and-rust" name="compare-go-and-rust">
 In cosa si assomigliano Go e Rust, in cosa sono invece diversi?
 </a></h3>
 
-Rust e Go hanno degli obiettivi molto differenti. Le differenze seguenti non sono le uniche (sarebbero troppe per elencarle) ma eccone alcune tra le piú importanti:
+Rust e Go hanno degli obiettivi molto differenti. Le differenze seguenti non sono le uniche (sarebbero troppe per elencarle) ma eccone alcune tra le più importanti:
 
-- Rust é di piú basso livello di Go. Ad esempio, Rust non richiede un garbage collector, mentre Go sí. In generale Rust permette un livello di controllo comparabile con il C o il C++.
-- Rust si focalizza sul garantire sicurezza ed efficienza mantenendo astrazioni di alto livello mentre Go vuole essere un linguaggio compatto e semplice che compila velocemente e puó funzionare con molti strumenti.
+- Rust è di più basso livello di Go. Ad esempio, Rust non richiede un garbage collector, mentre Go sì. In generale Rust permette un livello di controllo comparabile con il C o il C++.
+- Rust si focalizza sul garantire sicurezza ed efficienza mantenendo astrazioni di alto livello mentre Go vuole essere un linguaggio compatto e semplice che compila velocemente e può funzionare con molti strumenti.
 - Rust supporta la programmazione generica, Go no.
-- Rust ha forti influenze dal mondo della programmazione funzionale, includendo il sistema dei tipi derivato dalle typeclasses di Haskell. Go ha un sistema dei tipi piú semplici, utilizzanti interfacce compatibili con la programmazione generica.
+- Rust ha forti influenze dal mondo della programmazione funzionale, includendo il sistema dei tipi derivato dalle typeclasses di Haskell. Go ha un sistema dei tipi più semplici, utilizzanti interfacce compatibili con la programmazione generica.
 
 <h3><a href="#how-do-rust-traits-compare-to-haskell-typeclasses" name="how-do-rust-traits-compare-to-haskell-typeclasses">
 Come si comparano i tratti di Rust con le typeclasses di Haskell?
 </a></h3>
 
-I tratti in Rust somigliano alle typeclasses di Haskell ma attualmente non sono cosí potenti, dato che Rust non puó esprimere i tipi di piú altro livello. I tipi associati di Rust sono gli equivalenti delle famiglie di tipi di Haskell.
+I tratti in Rust somigliano alle typeclasses di Haskell ma attualmente non sono così potenti, dato che Rust non può esprimere i tipi di più altro livello. I tipi associati di Rust sono gli equivalenti delle famiglie di tipi di Haskell.
 
 Alcune differenze specifiche tra le typeclasses di Haskell e i tratti di Rust includono:
 
 - I tratti in Rusta hanno un primo parametro implicito chiamato `Self`. `trait Bar` in Rust corrisponde a `class Bar self` in Haskell e `trait Bar<Foo>` in Rust corrisponde a `class Bar foo self` in Haskell.
 - I "Supertratti" o "limitatori di superclass" in Rust sono scritti `trait Sub: Super`, mentre in Haskell `class Super self => Sub self`.
 - Rust vieta istanze orfanes, indicando regole di coerenza differenti tra Rust e Haskell.
-- La risoluzione dell `impl` di Rust considera le clausole `where` e i relativi tratti per decidere se due `impl` si sovrappongono, o per scegliere tra diverse `impl` possibili. Haskell considera ció solo nelle dichiarazioni `instance`, ignorando ogni limitazione posta altrove.
-- Un sottoinsieme dei tratti di Rust (Quelli ["object safe"](https://github.com/rust-lang/rfcs/blob/master/text/0255-object-safety.md)) puó essere usato per il dispacciamento dinamico mediante tratti. La stessa funzionalitá é disponibile in Haskell attraverso il metodo di GHC `ExistentialQuantification`.
+- La risoluzione dell `impl` di Rust considera le clausole `where` e i relativi tratti per decidere se due `impl` si sovrappongono, o per scegliere tra diverse `impl` possibili. Haskell considera ciò solo nelle dichiarazioni `instance`, ignorando ogni limitazione posta altrove.
+- Un sottoinsieme dei tratti di Rust (Quelli ["object safe"](https://github.com/rust-lang/rfcs/blob/master/text/0255-object-safety.md)) può essere usato per il dispacciamento dinamico mediante tratti. La stessa funzionalità è disponibile in Haskell attraverso il metodo di GHC `ExistentialQuantification`.
 
 <h2 id="documentation">Documentazione</h2>
 
 <h3><a href="#why-are-so-many-rust-answers-on-stackoverflow-wrong" name="why-are-so-many-rust-answers-on-stackoverflow-wrong">
-Perché su Stack Overflow molte delle risposte su Rust sono sbagliate?
+Perchè su Stack Overflow molte delle risposte su Rust sono sbagliate?
 </a></h3>
 
-Il linguaggio Rust é pubblico da diversi anni e ha raggiunto la versione 1.0 a Maggio del 2015.
+Il linguaggio Rust è pubblico da diversi anni e ha raggiunto la versione 1.0 a Maggio del 2015.
 Nei periodi precedenti il linguaggio ha ricevuto delle modifiche sostanziali e molte risposte fanno riferimento a versioni vecchie del linguaggio.
 
-Nel tempo sempre piú risposte saranno disponibili per la versione corrente, migliorando la problematica alterando il rapporto tra le risposte corrette e quelle sbagliate. 
+Nel tempo sempre più risposte saranno disponibili per la versione corrente, migliorando la problematica alterando il rapporto tra le risposte corrette e quelle sbagliate. 
 
 <h3><a href="#where-do-i-report-issues-in-the-rust-documentation" name="where-do-i-report-issues-in-the-rust-documentation">
 Dove segnalo problemi alla documentazione di Rust?
 </a></h3>
 
 Puoi segnalare problemi con la documentazione sul [pannello delle problematiche](https://github.com/rust-lang/rust/issues) di Rust. 
-Assicurati peró di leggere [linee guida alla contribuzione](https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md#writing-documentation) prima.
+Assicurati però di leggere [linee guida alla contribuzione](https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md#writing-documentation) prima.
 
 <h3><a href="#how-do-i-view-rustdoc-documentation-for-a-library-my-project-depends-on" name="how-do-i-view-rustdoc-documentation-for-a-library-my-project-depends-on">
 Come posso vedere la documentazione di rustdoc di una dipendenza del mio progetto?

--- a/it-IT/index.html
+++ b/it-IT/index.html
@@ -34,7 +34,7 @@ title: Il linguaggio di programmazione Rust
         <li>pattern matching</li>
         <li>deduzione automatica dei tipi</li>
         <li>tempo di esecuzione ridotto</li>
-        <li>interoperabilitá efficiente con il C</li>
+        <li>interoperabilità efficiente con il C</li>
       </ul>
       </div>
       <div class="col-md-8">

--- a/it-IT/install.html
+++ b/it-IT/install.html
@@ -36,7 +36,7 @@ title: Installazione &middot; Linguaggio di programmazione Rust
           <!-- unrecognized platform: ask for help -->
           <p>Non ho riconosciuto la tua piattaforma.</p>
           <p>
-            Rust é disponibile per Windows, Linux, Mac OS X, FreeBSD and NetBSD. Se
+            Rust è disponibile per Windows, Linux, Mac OS X, FreeBSD and NetBSD. Se
             sei su una di queste piattaforme e vedi questo messaggio per favore
             <a href="https://github.com/rust-lang/rust-www/issues/new">segnala un problema</a>,
             insieme a questi valori
@@ -112,9 +112,9 @@ title: Installazione &middot; Linguaggio di programmazione Rust
         <h3>Gestione del compilatore con <code>rustup</code></h3>
 
         <p>
-          Rust é installato e gestito da
+          Rust è installato e gestito da
           <a href="https://github.com/rust-lang-nursery/rustup.rs"><code>rustup</code></a>
-          . Rust é soggetto a un ciclo di 
+          . Rust è soggetto a un ciclo di 
           <a href="https://github.com/rust-lang/rfcs/blob/master/text/0507-release-channels.md">
             rilascio rapido ogni 6 settimane
           </a> e supporta un
@@ -144,18 +144,18 @@ title: Installazione &middot; Linguaggio di programmazione Rust
           <span class="platform-specific win" style="display: none;">
             <code>%USERPROFILE%\.cargo\bin</code>
           </span>,
-          qui é dove puoi trovare glis strumenti di rust, inclusi
+          qui è dove puoi trovare glis strumenti di rust, inclusi
           <code>rustc</code>, <code>cargo</code>, and <code>rustup</code>.
         </p>
 
         <p>
-          Di conseguenza, é corretto per gli sviluppatori Rust di 
+          Di conseguenza, è corretto per gli sviluppatori Rust di 
           includere questa cartella nella loro 
           <a href="https://en.wikipedia.org/wiki/PATH_(variable)">
           Variabile di ambiente
           <code>PATH</code></a>.  
           Durante l'installazione, <code>rustup</code>,
-          cercherá di configurare
+          cercherà di configurare
           <code>PATH</code> ma a causa delle disuguaglianze tra le
           righe di comando delle piattaforme e bug in <code>rustup</code>, 
           le modifiche a
@@ -166,7 +166,7 @@ title: Installazione &middot; Linguaggio di programmazione Rust
 
         <p>
           Se, dopo l'installazione, l'esecuzione di <code>rustc --version</code> nella
-          riga di comando fallisce, questa é la ragione piú probabile.
+          riga di comando fallisce, questa è la ragione più probabile.
         </p>
 
         <div class="platform-specific win">
@@ -178,7 +178,7 @@ title: Installazione &middot; Linguaggio di programmazione Rust
 	  <p>
             Su Windows, Rust richiede inoltre gli strumenti di compilazione
             C++ per Visual Studio 2013 o superiori.
-            Il modo piú semplice per ottenerli é installare 
+            Il modo più semplice per ottenerli è installare 
 	    <a href="http://landinghub.visualstudio.com/visual-cpp-build-tools">
 	      Microsoft Visual C++ Build Tools 2015
             </a>
@@ -206,8 +206,8 @@ title: Installazione &middot; Linguaggio di programmazione Rust
       <div class="col-md-12">
         <p>
           L'installazione descritta sopra, tramite
-          <code>rustup</code>, é il modo piú consigliato per installare Rust per la maggior parte degli sviluppatori,
-          ma Rust puó anche 
+          <code>rustup</code>, è il modo più consigliato per installare Rust per la maggior parte degli sviluppatori,
+          ma Rust può anche 
           <a href="other-installers.html">essere installato tramite altri metodi</a>
         </p>
       </div>

--- a/it-IT/legal.md
+++ b/it-IT/legal.md
@@ -7,7 +7,7 @@ title: Informazioni legali su Rust &middot; Linguaggio di programmazione Rust
 
 ## Codice sorgente
 
-Il [codice sorgente](https://github.com/rust-lang/rust) di Rust é distribuito
+Il [codice sorgente](https://github.com/rust-lang/rust) di Rust è distribuito
 principalmente seguendo i termini della licenza MIT e della licenza Apache (versione 2.0),
 con parti coperte da varie licenze simil-BSD.
 Vedi [LICENSE-APACHE](https://github.com/rust-lang/rust/blob/master/LICENSE-APACHE),
@@ -16,10 +16,10 @@ e [COPYRIGHT](https://github.com/rust-lang/rust/blob/master/COPYRIGHT) per ulter
 
 ## Loghi e marchi
 
-I loghi di Rust e Cargo (bitmap e vettoriali) sono di proprietá di Mozilla e
+I loghi di Rust e Cargo (bitmap e vettoriali) sono di proprietà di Mozilla e
 distribuiti sotto i termini della 
 [Creative Commons Attribution license (CC-BY)](https://creativecommons.org/licenses/by/4.0/). 
-Questa é la licenza Creative Commons piú aperta che permette il riuso e la modifica 
+Questa è la licenza Creative Commons più aperta che permette il riuso e la modifica 
 per qualsiasi scopo. Le restizioni sono che i distributori devono "creditare appropriatamente
 fornendo un link alla licenza e indicare se sono state apportate modificazioni".
 **Nota che l'utilizzo di questi loghi e dei nomi Rust, Cargo sono soggetti anche essi
@@ -44,8 +44,8 @@ Varianti del logo di Rust si possono trovare qui:
 
 # Politica di attribuzione
 
-I nomi e loghi di Rust e Cargo permettono di individuare ció che é ufficialmente
-parte della comunitá di Rust e cosa non ne fa parte.
+I nomi e loghi di Rust e Cargo permettono di individuare ciò che è ufficialmente
+parte della comunità di Rust e cosa non ne fa parte.
 Siamo quindi attenti su dove permettiamo che essi appaiano.
 Allo stesso tempo, vogliamo permettere il massimo utilizzo creativo
 possibile per questi marchi.
@@ -56,13 +56,13 @@ leggi questa pagina o [contattaci](mailto:trademark@rust-lang.org) per parlarcen
 **Troppo Lungo; Non lo leggo**: 
 La maggior parte degli utilizzi non commerciali dei nomi e loghi Rust/Cargo
 sono ammessi e non richiedono autorizzazione; la maggior parte degli utilizzi commerciali
-richiede autorizzazione. In entrambi i casi, la regola piú importante é che l'utilizzo di loghi e marchi
+richiede autorizzazione. In entrambi i casi, la regola più importante è che l'utilizzo di loghi e marchi
 non deve apparire come ufficiale o come un supporto da parte del progetto Rust.
 
 ## Attribuzione di Rust
 
-Il Linguaggio di programmazione Rust é un progetto open source della comunitá governato da un team di sviluppo.
-Il progetto é anche sponsorizzato dalla Mozilla Foundation("Mozilla"), che possiede
+Il Linguaggio di programmazione Rust è un progetto open source della comunità governato da un team di sviluppo.
+Il progetto è anche sponsorizzato dalla Mozilla Foundation("Mozilla"), che possiede
 e protegge l'attribuzione dei nomi e marchi di Rust e Cargo("I marchi di Rust").
 Questo documento fornisce informazioni inerenti l'utilizzo dei marchi di Rust specifici
 al linguaggio di programmazione, includendo anche esempi di utilizzi comuni che le persone
@@ -79,30 +79,30 @@ La registrazione del marchio di Rust include due lemmi e due loghi:
 * <img src="https://www.rust-lang.org/logos/cargo.png">
 
 I marchi registrati sono nomi o design che dicono al mondo l'origine di un bene o servizio.
-Proteggere il marchio di un progetto open source é particolarmente importante.
+Proteggere il marchio di un progetto open source è particolarmente importante.
 Tutti possono modificare il codice sorgente e generare un prodotto da quel codice,
 risulta quindi importante che solo il progetto originale o le sue variazioni autorizzate
 possano usufruire dei marchi registrati.
 Limitando attivamente l'utilizzo dei marchi di Rust, Mozilla e il progetto Rust 
 possono aiutare utenti e sviluppatori a sapere se stanno avendo accesso a un
 prodotto facente parte del progetto Rust e non la versione modificata da qualcuno.
-Il marchio registrato assicura gli utenti e gli sviluppatori della qualitá
+Il marchio registrato assicura gli utenti e gli sviluppatori della qualità
 e sicurezza del prodotto che stanno usando.
 
 ## Utilizzo di marchi e loghi
 
 ### Apparire ufficiali, affiliati o sostenuti
 
-La regola base é che i marchi di Rust non possono essere utilizzati in modo
+La regola base è che i marchi di Rust non possono essere utilizzati in modo
 che appaiano(a un osservatore medio) ufficiali, affiliati o sponsorizzati dal 
-progetto Rust o da Mozilla, almenoché non vi sia autorizzazione ufficiale da
+progetto Rust o da Mozilla, almenochè non vi sia autorizzazione ufficiale da
 parte del team di sviluppo.
-Questo é il modo fondamentale in cui proteggiamo utenti e sviluppatori dalla confusione.
+Questo è il modo fondamentale in cui proteggiamo utenti e sviluppatori dalla confusione.
 
-Essendo questa regola inerente la gestione di percezioni é soggettiva e abbastanza
+Essendo questa regola inerente la gestione di percezioni è soggettiva e abbastanza
 complessa da individuare concretamente. Ci sono alcuni modi ovvi per evitare 
 problemi come ad esempio includere la dicitura "non ufficiale" in modo evidente ma 
-se sei ancora dubbioso, saremo piú che felici di aiutarti; scrivici a
+se sei ancora dubbioso, saremo più che felici di aiutarti; scrivici a
 [trademark@rust-lang.org](mailto:trademark@rust-lang.org).
 
 ### Le basi: parlare di Rust o Cargo
@@ -116,58 +116,58 @@ Non possono essere utilizzati:
 - per riferirsi ad altri linguaggi di programmazione;
 - in modo fuorviante o che possa implicare associazione con moduli esterni,
   strumenti, documentazione o altre risorse del linguaggio di programmazione Rust;
-- in modi che confondono la comunitá sul fatto che il linguaggio di programmazione Rust
+- in modi che confondono la comunità sul fatto che il linguaggio di programmazione Rust
   sia o meno open source e libero da utilizzare.
 
 ### Utilizzi che non richiedono esplicita approvazione
 
-Esistono una varietá di utilizzi che non richiedono esplicita autorizzazione. **Ad ogni modo, in tutti i casi sotto elencati, devi assicurarti che l'utilizzo dei marchi di Rust non appaia ufficiale, come illustrato sopra.**
+Esistono una varietà di utilizzi che non richiedono esplicita autorizzazione. **Ad ogni modo, in tutti i casi sotto elencati, devi assicurarti che l'utilizzo dei marchi di Rust non appaia ufficiale, come illustrato sopra.**
 
-* É concesso indicare accuratamente che un programma é stato scritto nel linguaggio di programmazione Rust,
-la sua compatibilitá con il linguaggio Rust o che contiene Rust stesso.
+* É concesso indicare accuratamente che un programma è stato scritto nel linguaggio di programmazione Rust,
+la sua compatibilità con il linguaggio Rust o che contiene Rust stesso.
 In questi casi, puoi utilizzare i marchi di Rust per indicare questo, senza
 autorizzazione pregressa. Questo si applica sia agli utilizzi non commerciali che
 a quelli con fini di lucro.
 
 * Utilizzare i marchi di Rust in nomi di prodotti non commerciali come RustPostgres, Rustymine
-o nei nomi di repository di codice sorgente su ad esempio GitHub é concesso in riferimento
-all'utilizzo o all'idoneitá del linguaggio di programmazione Rust.
+o nei nomi di repository di codice sorgente su ad esempio GitHub è concesso in riferimento
+all'utilizzo o all'idoneità del linguaggio di programmazione Rust.
 Alcuni utilizzi potrebbero anche includere il logo di Rust, anche in forma modificata.
 Nel caso di progetti commerciali(includendo il crowdfunding o progetti sponsorizzati),
 per favore controlla con [trademark@rust-lang.org](mailto:trademark@rust-lang.org) per assicurarti
 che il tuo utilizzo non appaia come ufficiale.
 
 * Utilizzare il marchio di Rust su magliette, cappelli e/o altri manufatti o merchandising,
-anche se in forma modificata, é concesso per il tuo utilizzo personale o per l'utilizzo
-da parte di un piccolo gruppo di membri della comunitá, a condizione che gli oggetti non siano in vendita. 
+anche se in forma modificata, è concesso per il tuo utilizzo personale o per l'utilizzo
+da parte di un piccolo gruppo di membri della comunità, a condizione che gli oggetti non siano in vendita. 
 Se vuoi distribuire del merchandise con i loghi di Rust a eventi affiliati al linguaggio 
 per favore contattaci per l'autorizzazione a [trademark@rust-lang.org](mailto:trademark@rust-lang.org).
 
 * Utilizzare i marchi di Rust(anche in forma modificata) per eventi sociali come
-incontri, tutorial e simili é concesso per eventi per cui é gratuita la partecipazione.
+incontri, tutorial e simili è concesso per eventi per cui é gratuita la partecipazione.
 Per eventi commerciali (inclusi quelli sponsorizzati), per favore controlla con [trademark@rust-lang.org](mailto:trademark@rust-lang.org). Ad ogni modo, le parole "RustCamp", "RustCon" o
 "RustConf" non possono essere utilizzate senza esplicita autorizzazione. 
 In combinazione con le restrizioni precedenti **l'evento non deve risultare come ufficialmente supportato o organizzato dal progetto Rust** in assenza di autorizzazione scritta.
 
 * L'utilizzo del marchio di Rust in libri e pubblicazioni come "Il giornale di Rust" 
-"Manuale di Rust" é concesso.
+"Manuale di Rust" è concesso.
 
 * L'utilizzo della parola "Rust" su siti web, brochure, documentazione, tesi di ricerca,
-libri e confezioni di prodotti, se in riferimento al linguaggio di programmazione é concesso.
+libri e confezioni di prodotti, se in riferimento al linguaggio di programmazione è concesso.
 
 ### Utilizzi che richiedono esplicita approvazione
 
 * Distribuire una versione modificata del linguaggio di programmazione Rust, del 
 gestore di pacchetti Cargo e chiamarli Rust o Cargo richiede autorizzazione esplicita scritta da 
 parte del team di Rust.
-Generalmente consentiamo questi utilizzi finché le modifiche apportate sono
+Generalmente consentiamo questi utilizzi finchè le modifiche apportate sono
 (1) relativamente piccole e (2) molto ben comunicate agli utenti finali.
 
 * Vendere magliette, cappelli e/o altri manufatti o merchandising,
 richiede un esplicito permesso scritto da parte del team di Rust.
-Generalmente permettiamo questi utilizzi se (1) é indicato chiaramente
+Generalmente permettiamo questi utilizzi se (1) è indicato chiaramente
 che il merchandising non fa parte in alcun modo del progetto Rust e se (2)
-é chiaramente comunicato se i profitti possono essere a beneficio del 
+è chiaramente comunicato se i profitti possono essere a beneficio del 
 progetto Rust.
 
 * Utilizzare i marchi di Rust all'interno di un altro marchio registrato richiede 
@@ -179,15 +179,15 @@ Se hai dubbi su come il tuo utilizzo inteso dei marchi di Rust
 richieda autorizzazione, contattaci per favore a
 [trademark@rust-lang.org](mailto:trademark@rust-lang.org).
 
-Questo documento é in parte derivato dalla
+Questo documento è in parte derivato dalla
 [Politica di utilizzo dei marchi della Python Software Foundation](https://www.python.org/psf/trademarks/).
 
-Questo documento non é una stesura ufficiale della politica dei marchi di Mozilla 
-ma é utile a chiarire la politica di attribuzione di Mozilla per quanto concerne Rust.
+Questo documento non è una stesura ufficiale della politica dei marchi di Mozilla 
+ma è utile a chiarire la politica di attribuzione di Mozilla per quanto concerne Rust.
 
 ## Aiutarci
 
-Come membreo della comunitá di Rust, per favore sii vigile nei confronti di utilizzi
+Come membreo della comunità di Rust, per favore sii vigile nei confronti di utilizzi
 discutibili del logo di Rust e del lemma "Rust".
 Puoi segnalare abusi a 
 [trademark@rust-lang.org](mailto:trademark@rust-lang.org). Analizzeremo ciascun
@@ -200,5 +200,5 @@ Grazie!
 
 ## Licenza
 
-Chi fosse interessato puó adattare questo documento in conformitá con la 
+Chi fosse interessato può adattare questo documento in conformità con la 
 [licenza Creative Commons CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/it-IT/other-installers.md
+++ b/it-IT/other-installers.md
@@ -14,16 +14,16 @@ title: Altri metodi di installazione &middot; Linguaggio di programmazione Rust
 <span id="which"></span>
 
 Rust funziona su molte piattaforme e ci sono molti modi per installare Rust.
-Se vuoi installare Rust nel modo piú semplice e consigliato, segui le istruzioni
+Se vuoi installare Rust nel modo più semplice e consigliato, segui le istruzioni
 della [pagina di installazione principale][installation page].
 
 Quella pagina descrive l'installazione tramite [`rustup`], uno strumento che
 gestisce compilatori di rust multipli in modo stabile per tutte le piattaforme
 supportate da Rust.
-Perché quindi uno dovrebbe desiderare di _non_ utilizzarlo?
+Perchè quindi uno dovrebbe desiderare di _non_ utilizzarlo?
 - Installazione offline. `rustup` scarica componenti dalla rete su richiesta.
   se hai bisogno di installare Rust senza una connessione a internet, `rustup`
-  non é adatto.
+  non è adatto.
 - Preferenza per il gestore di pacchetti di sistema. Su Linux in particolare may
   anche su macOS con [Homebrew] e in Windows con [Chocolatey], gli sviluppatori
   a volte preferiscono installare Rust con il gestore di pacchetti del loro
@@ -32,15 +32,15 @@ Perché quindi uno dovrebbe desiderare di _non_ utilizzarlo?
   uno script scaricato da `curl`. Alcuni non si fidano di questa operazione
   e preferiscono scaricare e installare Rust in autonomia.
 - Verifica firme. Anche se `rustup` effettua download tramite HTTPS,
-  l'unico modo ad oggi possibile per verificare le firme digitali é 
+  l'unico modo ad oggi possibile per verificare le firme digitali è 
   l'installazione manuale.
 - Installazione da interfaccia grafica e integrazione con "Aggiungi/Rimuovi Programmi"
   su Windows. `rustup` funziona da riga di comando e non registra le sue installazioni
-  nel menu di Windows come gli altri programmi. Se preferisci un'installazione piú
+  nel menu di Windows come gli altri programmi. Se preferisci un'installazione più
   tipica su Windows sono disponibili gli installatori indipendenti `.msi`.
-  In futuro `rustup` includerá un'interfaccia grafica su Windows.
+  In futuro `rustup` includerà un'interfaccia grafica su Windows.
 
-Il supporto di Rust alle piattaforme é definito in [tre fasce][three tiers], che
+Il supporto di Rust alle piattaforme è definito in [tre fasce][three tiers], che
 corrispondono strettamente con il metodo di installazione disponibile: in generale,
 Rust fornisce eseguibili per tutte le piattaforme di prima e seconda fascia,
 rendendoli disponibili anche allo strumento `rustup`.
@@ -56,14 +56,14 @@ Il modo per installare `rustup` differisce tra le piattaforme:
 
 * Sugli Unix, esegui `curl https://sh.rustup.rs -sSf | sh` nella tua riga di comando.
   Questo scarica e esegue [`rustup-init.sh`], che a sua volta
-  scarica e esegue la versione di `rustup-init` piú 
+  scarica e esegue la versione di `rustup-init` più 
   adatta alla piattaforma corrente.
 * Su Windows, scarica e installa [`rustup-init.exe`].
 
-`rustup-init` puó essere configurato interattivamente, tutte le operazioni
+`rustup-init` può essere configurato interattivamente, tutte le operazioni
 possono inoltre essere comandate da degli argomenti da riga di comando da
 fornire allo script di installazione. Passando `--help` a `rustup-init`
-fará mostrare gli argomenti disponibili:
+farà mostrare gli argomenti disponibili:
 
 ```
 curl https://sh.rustup.rs -sSf | sh -s -- --help
@@ -98,13 +98,13 @@ permettono l'installazione in assenza di connessione a internet.
 Sono disponibili in tre forme: pacchetti compressi tar(estensione `.tar.gz`),
 funzionanti in ambienti Unix, installatori Windows(`.msi`) e pacchetti applicativi
 Mac (`.pkg`), questi installatori contengono `rustc`, `cargo`, `rustdoc`, la libreria
-standard e la documentazione standard ma non forniscono le possibilitá di compilazione
+standard e la documentazione standard ma non forniscono le possibilità di compilazione
 incrociata offerte da `rustup`.
 
-Le ragioni piú comuni per utilizzarli sono:
+Le ragioni più comuni per utilizzarli sono:
 
 - Installazione in assenza di rete
-- Preferenza per un installatore grafico, piú integrato con Windows
+- Preferenza per un installatore grafico, più integrato con Windows
 
 Ciascuno di questi eseguibili sono firmati digitalmente con la [firma digitale di Rust][Rust signing key]
 disponibile su [keybase.io], rilasciata dall'infrastruttura di rilascio di Rust,

--- a/it-IT/security.html
+++ b/it-IT/security.html
@@ -7,15 +7,15 @@ title: Politica di sicurezza di Rust &middot; Linguaggio di programmazione Rust
 
 <h2>Segnalare un problema</h2>
 
-<p>La sicurezza é uno dei principi fondamentali di Rust e con tale proposito
+<p>La sicurezza è uno dei principi fondamentali di Rust e con tale proposito
     vorremmo assicurarci che Rust abbia un'implementazione sicura.
     Ti ringraziamo per aver preso del tempo per comunicare responsabilmente
     ogni problematica da te trovata.</p>
 
 <p>Tutti i problemi di sicurezza in Rust devono essere riportati per email a 
 <a href="mailto:security@rust-lang.org">security@rust-lang.org</a>. Questo indirizzo
-consegna il messaggio a un piccolo team di sicurezza. La tua email sará visionata entro 24
-ore e riceverai una mail di risposta piú dettagliata entro 48 ore
+consegna il messaggio a un piccolo team di sicurezza. La tua email sarà visionata entro 24
+ore e riceverai una mail di risposta più dettagliata entro 48 ore
 indicante i passi successivi per la gestione della tua segnalazione. Se preferisci, puoi
 criptare la segnalazione usando <a href="../rust-security-team-key.gpg.ascii">la nostra chiave pubblica</a>.
 Disponibile anche <a
@@ -24,14 +24,14 @@ href="https://pgp.mit.edu/pks/lookup?op=vindex&amp;search=0xEFB9860AE7520DAC">su
 
 <p>Questo indirizzo email riceve molto spam, quindi assicurati di inserire
 nell'oggetto informazioni descrittive per evitare che la segnalazione finisca ignorata. 
-Dopo la risposta iniziale, il team di sicurezza ti terrá aggiornato sui progressi
+Dopo la risposta iniziale, il team di sicurezza ti terrà aggiornato sui progressi
 fatti verso la risoluzione del problema e il suo annuncio al pubblico.
 Come raccomandato da <a href="https://en.wikipedia.org/wiki/RFPolicy">RFPolicy</a>,
 questi aggiornamenti verranno mandati almeno ogni cinque giorni.
-In realtá é piú probabile che sia ogni 24-48 ore.</p>
+In realtà è più probabile che sia ogni 24-48 ore.</p>
 
 <p>Se non hai ancora ricevuto risposta alla tua email dopo 48 ore o il team
-    di sicurezza non si é fatto sentire per almeno cinque giorni, ecco alcune
+    di sicurezza non si è fatto sentire per almeno cinque giorni, ecco alcune
     cose che puoi fare:</p>
 
 <ul>
@@ -53,8 +53,8 @@ In realtá é piú probabile che sia ogni 24-48 ore.</p>
 <p>La politica di diffusione del progetto Rust si compone di 5 fasi:</p>
 
 <ol>
-<li>Il rapporto di sicurezza é ricevuto e assegnato a un amministratore.
-    Questa persona coordinerá il processo di risoluzione e rilascio.</li>
+<li>Il rapporto di sicurezza è ricevuto e assegnato a un amministratore.
+    Questa persona coordinerà il processo di risoluzione e rilascio.</li>
 
 <li>Il problema viene confermato e viene stilata una lista di tutte le versioni vulnerabili.</li>
 
@@ -65,21 +65,21 @@ In realtá é piú probabile che sia ogni 24-48 ore.</p>
     dell'annuncio.</li>
 
 <li>Alla data di fine della non divulgazione, nella <a href="https://groups.google.com/forum/#!forum/rustlang-security-announcements">
-mailing list di sicurezza del progetto Rust</a> é spedita una copia dell'annuncio. I cambiamenti
+mailing list di sicurezza del progetto Rust</a> è spedita una copia dell'annuncio. I cambiamenti
 sono inoltrati al repository pubblico e le nuove versioni sono pubblicate su rust-lang.org.
-Entro 6 ore della notifica alla mailing list, una copia dell'annuncio verrá pubblicata
+Entro 6 ore della notifica alla mailing list, una copia dell'annuncio verrà pubblicata
 sul blog ufficiale di Rust.</li> </ol>
 
-<p>Questo processo puó richiedere un po' di tempo, specialmente quando é richiesta coordinazione
-    con gli sviluppatori di altri progetti. Verrá fatto ogni sforzo possibile per gestire la problematica
-    in maniera celere, ad ogni modo é importante seguire il processo evidenziato sopra
+<p>Questo processo può richiedere un po' di tempo, specialmente quando è richiesta coordinazione
+    con gli sviluppatori di altri progetti. Verrà fatto ogni sforzo possibile per gestire la problematica
+    in maniera celere, ad ogni modo è importante seguire il processo evidenziato sopra
     per assicurare una gestione coerente.</p>
 
 <h2>Ricevere aggiornamenti di sicurezza</h2>
 
-<p>Il miglior modo per ricevere gli aggiornamenti di sicurezza é iscriversi alla <a
+<p>Il miglior modo per ricevere gli aggiornamenti di sicurezza è iscriversi alla <a
 href="https://groups.google.com/forum/#!forum/rustlang-security-announcements">mailing list di sicurezza del progetto Rust</a>. 
-La mailing list non é molto attiva e riceve le notifiche pubbliche nel momento
+La mailing list non è molto attiva e riceve le notifiche pubbliche nel momento
 in cui la non divulgazione termina.</p>
 
 <h3>Notifiche in anticipo</h3>

--- a/it-IT/team.md
+++ b/it-IT/team.md
@@ -16,10 +16,10 @@ localized-teams:
     name: Team del compilatore
     responsibility: "si occupano del compilatore e della sua ottimizzazione"
   Tooling and infrastructure:
-    name: Utilitá e infrastrutture
+    name: Utilità e infrastrutture
     responsibility: "lavorano agli strumenti (rustup, Cargo), alla piattaforma di controllo automatico, etc..."
   Community team:
-    name: Team della comunitá
+    name: Team della comunità
     responsibility: "coordinano gli eventi, la riuscita, i rapporti con gli utenti commerciali e il materiale didattico"
   Documentation team:
     name: Team della documentazione
@@ -74,20 +74,20 @@ localized-teams:
 
 # Il team di rust
 
-Il progetto Rust é
+Il progetto Rust è
 [amministrato](https://github.com/rust-lang/rfcs/blob/master/text/1068-rust-governance.md)
 da un numero di team, ciascuno focalizzato in una specifica area di competenza.
-Sotto vi é una lista, in ordine alfabetico.
+Sotto vi è una lista, in ordine alfabetico.
 
 Per contattare un team, invia la tua domanda o commenta nel [Forum Sviluppo](https://internals.rust-lang.org/)
 e tagga il tuo post con la categoria corrispondente al nome del team.
-Nota che le vulnerabilitá sono soggette al [processo di annuncio vulnerabilitá](security.html). 
+Nota che le vulnerabilità sono soggette al [processo di annuncio vulnerabilitá](security.html). 
 
 {% for team in site.data.team.teams %}
 <section id="{{ team.name | replace:' ','-' }}">
 <h2> {{ page.localized-teams[team.name].name | default: team.name }} </h2>
 
-<strong>Responsabilitá</strong>: <em>{{ page.localized-teams[team.name].responsibility | default: team.responsibility }}</em>
+<strong>Responsabilità</strong>: <em>{{ page.localized-teams[team.name].responsibility | default: team.responsibility }}</em>
 
 <br />
 

--- a/it-IT/user-groups.md
+++ b/it-IT/user-groups.md
@@ -8,11 +8,11 @@ Ci sono oltre 50 [Gruppi Utenti Rust][user_group] nel mondo fra oltre 20
 countries che contano oltre 7,000 membri. 
 I Rustacchiani si incontrano periodicamente
 nei Gruppi Utenti Rust.
-Un ottimo modo per entrare nella comunitá, per imparare e per socializzare
+Un ottimo modo per entrare nella comunità, per imparare e per socializzare
 con persone che hanno interessi simili. Gli incontri sono tenuti su base mensile
 e sono molto informali. Gli incontri sono aperti a tutti.
 
-Se hai fondato un nuovo gruppo utanti e vorresti aggiungerlo a questa lista per favore contatta il [Team comunitá Rust](./team.html#Community) o 
+Se hai fondato un nuovo gruppo utanti e vorresti aggiungerlo a questa lista per favore contatta il [Team comunità Rust](./team.html#Community) o 
 ancora meglio, apri una pull request a [questo sito](https://github.com/rust-lang/rust-www/blob/master/en-US/user-groups.md).
 
 ## Australia


### PR DESCRIPTION
I fixed all stressed Italian letters. There would not be errors in links to other languages. This PR is a continuation of initial work in PR https://github.com/rust-lang/rust-www/issues/720.