### PR TITLE
Fix ja-JP links

### DIFF
--- a/_layouts/ja-JP/basic.html
+++ b/_layouts/ja-JP/basic.html
@@ -26,10 +26,10 @@
           </a>
 	</li>
 	<li class="col-xs-12 col-md-10 menu">
-	  <h2><a href="/documentation.html">ドキュメント</a></h2>
-	  <h2><a href="/install.html">インストール</a></h2>
-	  <h2><a href="/community.html">コミュニティ</a></h2>
-	  <h2><a href="/contribute.html">開発に参加する</a></h2>
+	  <h2><a href="/ja-JP/documentation.html">ドキュメント</a></h2>
+	  <h2><a href="/ja-JP/install.html">インストール</a></h2>
+	  <h2><a href="/ja-JP/community.html">コミュニティ</a></h2>
+	  <h2><a href="/ja-JP/contribute.html">開発に参加する</a></h2>
 	</li>
       </ul>
     </header>


### PR DESCRIPTION
Fixed an issue that jumps from Japanese page navigation to English page.
https://github.com/potato4d/rust-www/blob/master/_layouts/ja-JP/basic.html#L29-L32