### PR TITLE
Fix distribution page link in FAQ

### DIFF
--- a/en-US/faq.md
+++ b/en-US/faq.md
@@ -1050,7 +1050,7 @@ How do I cross-compile in Rust?
 
 Cross compilation is possible in Rust, but it requires [a bit of work](https://github.com/japaric/rust-cross/blob/master/README.md) to set up. Every Rust compiler is a cross-compiler, but libraries need to be cross-compiled for the target platform.
 
-Rust does distribute [copies of the standard library](https://static.rust-lang.org/dist/) for each of the supported platforms, which are contained in the `rust-std-*` files for each of the build directories found on the distribution page, but there are not yet automated ways to install them.
+Rust does distribute [copies of the standard library](https://static.rust-lang.org/dist/index.html) for each of the supported platforms, which are contained in the `rust-std-*` files for each of the build directories found on the distribution page, but there are not yet automated ways to install them.
 
 <h2 id="modules-and-crates">Modules and Crates</h2>
 

--- a/es-ES/faq.md
+++ b/es-ES/faq.md
@@ -1050,7 +1050,7 @@ How do I cross-compile in Rust?
 
 Cross compilation is possible in Rust, but it requires [a bit of work](https://github.com/japaric/rust-cross/blob/master/README.md) to set up. Every Rust compiler is a cross-compiler, but libraries need to be cross-compiled for the target platform.
 
-Rust does distribute [copies of the standard library](https://static.rust-lang.org/dist/) for each of the supported platforms, which are contained in the `rust-std-*` files for each of the build directories found on the distribution page, but there are not yet automated ways to install them.
+Rust does distribute [copies of the standard library](https://static.rust-lang.org/dist/index.html) for each of the supported platforms, which are contained in the `rust-std-*` files for each of the build directories found on the distribution page, but there are not yet automated ways to install them.
 
 <h2 id="modules-and-crates">Modules and Crates</h2>
 

--- a/fr-FR/faq.md
+++ b/fr-FR/faq.md
@@ -1050,7 +1050,7 @@ How do I cross-compile in Rust?
 
 Cross compilation is possible in Rust, but it requires [a bit of work](https://github.com/japaric/rust-cross/blob/master/README.md) to set up. Every Rust compiler is a cross-compiler, but libraries need to be cross-compiled for the target platform.
 
-Rust does distribute [copies of the standard library](https://static.rust-lang.org/dist/) for each of the supported platforms, which are contained in the `rust-std-*` files for each of the build directories found on the distribution page, but there are not yet automated ways to install them.
+Rust does distribute [copies of the standard library](https://static.rust-lang.org/dist/index.html) for each of the supported platforms, which are contained in the `rust-std-*` files for each of the build directories found on the distribution page, but there are not yet automated ways to install them.
 
 <h2 id="modules-and-crates">Modules and Crates</h2>
 

--- a/it-IT/faq.md
+++ b/it-IT/faq.md
@@ -1236,7 +1236,7 @@ Come faccio a usare la compilazione incrociata in Rust?
 La compilazione incrociata è possibile in Rust ma richiede [alcune accortezze](https://github.com/japaric/rust-cross/blob/master/README.md) per essere impostata.
 Ogni compilatore Rust permette anche la compilazione incrociata ma le librerie necessitano di essere ricompilate per ogni piattaforma obiettivo.
 
-Rust distribuisce [copie della libreria standard](https://static.rust-lang.org/dist/) per ciascuna delle piattaforme supportate, ritrovabili nei file `rust-std-*` presenti nella pagina citata ma ad oggi non esistono metodi automatizzati per installarle.
+Rust distribuisce [copie della libreria standard](https://static.rust-lang.org/dist/index.html) per ciascuna delle piattaforme supportate, ritrovabili nei file `rust-std-*` presenti nella pagina citata ma ad oggi non esistono metodi automatizzati per installarle.
 
 <h2 id="modules-and-crates">Moduli e pacchetti</h2>
 

--- a/ja-JP/faq.md
+++ b/ja-JP/faq.md
@@ -1076,7 +1076,7 @@ How do I cross-compile in Rust?
 
 Cross compilation is possible in Rust, but it requires [a bit of work](https://github.com/japaric/rust-cross/blob/master/README.md) to set up. Every Rust compiler is a cross-compiler, but libraries need to be cross-compiled for the target platform.
 
-Rust does distribute [copies of the standard library](https://static.rust-lang.org/dist/) for each of the supported platforms, which are contained in the `rust-std-*` files for each of the build directories found on the distribution page, but there are not yet automated ways to install them.
+Rust does distribute [copies of the standard library](https://static.rust-lang.org/dist/index.html) for each of the supported platforms, which are contained in the `rust-std-*` files for each of the build directories found on the distribution page, but there are not yet automated ways to install them.
 
 <h2 id="modules-and-crates">Modules and Crates</h2>
 

--- a/ko-KR/faq.md
+++ b/ko-KR/faq.md
@@ -1247,7 +1247,7 @@ Rust에서 크로스 컴파일은 어떻게 하나요?
 Rust에서는 크로스 컴파일을 할 수 있지만 설치 과정이 [좀 필요합니다](https://github.com/japaric/rust-cross/blob/master/README.md).
 모든 Rust 컴파일러는 크로스 컴파일러지만 라이브러리는 해당 플랫폼 용으로 크로스 컴파일될 필요가 있습니다.
 
-Rust는 지원되는 플랫폼에 대해서 [표준 라이브러리의 사본](https://static.rust-lang.org/dist/)을 배포하고 있으며, 배포판 페이지의 각 빌드 디렉토리에 있는 `rust-std-*` 파일들로 들어 있습니다만, 아직 이걸 자동으로 설치하는 방법은 없습니다.
+Rust는 지원되는 플랫폼에 대해서 [표준 라이브러리의 사본](https://static.rust-lang.org/dist/index.html)을 배포하고 있으며, 배포판 페이지의 각 빌드 디렉토리에 있는 `rust-std-*` 파일들로 들어 있습니다만, 아직 이걸 자동으로 설치하는 방법은 없습니다.
 
 <h2 id="modules-and-crates">모듈 및 크레이트</h2>
 

--- a/pt-BR/faq.md
+++ b/pt-BR/faq.md
@@ -1050,7 +1050,7 @@ How do I cross-compile in Rust?
 
 Cross compilation is possible in Rust, but it requires [a bit of work](https://github.com/japaric/rust-cross/blob/master/README.md) to set up. Every Rust compiler is a cross-compiler, but libraries need to be cross-compiled for the target platform.
 
-Rust does distribute [copies of the standard library](https://static.rust-lang.org/dist/) for each of the supported platforms, which are contained in the `rust-std-*` files for each of the build directories found on the distribution page, but there are not yet automated ways to install them.
+Rust does distribute [copies of the standard library](https://static.rust-lang.org/dist/index.html) for each of the supported platforms, which are contained in the `rust-std-*` files for each of the build directories found on the distribution page, but there are not yet automated ways to install them.
 
 <h2 id="modules-and-crates">Modules and Crates</h2>
 

--- a/vi-VN/faq.md
+++ b/vi-VN/faq.md
@@ -1050,7 +1050,7 @@ How do I cross-compile in Rust?
 
 Cross compilation is possible in Rust, but it requires [a bit of work](https://github.com/japaric/rust-cross/blob/master/README.md) to set up. Every Rust compiler is a cross-compiler, but libraries need to be cross-compiled for the target platform.
 
-Rust does distribute [copies of the standard library](https://static.rust-lang.org/dist/) for each of the supported platforms, which are contained in the `rust-std-*` files for each of the build directories found on the distribution page, but there are not yet automated ways to install them.
+Rust does distribute [copies of the standard library](https://static.rust-lang.org/dist/index.html) for each of the supported platforms, which are contained in the `rust-std-*` files for each of the build directories found on the distribution page, but there are not yet automated ways to install them.
 
 <h2 id="modules-and-crates">Modules and Crates</h2>
 

--- a/zh-CN/faq.md
+++ b/zh-CN/faq.md
@@ -1050,7 +1050,7 @@ How do I cross-compile in Rust?
 
 Cross compilation is possible in Rust, but it requires [a bit of work](https://github.com/japaric/rust-cross/blob/master/README.md) to set up. Every Rust compiler is a cross-compiler, but libraries need to be cross-compiled for the target platform.
 
-Rust does distribute [copies of the standard library](https://static.rust-lang.org/dist/) for each of the supported platforms, which are contained in the `rust-std-*` files for each of the build directories found on the distribution page, but there are not yet automated ways to install them.
+Rust does distribute [copies of the standard library](https://static.rust-lang.org/dist/index.html) for each of the supported platforms, which are contained in the `rust-std-*` files for each of the build directories found on the distribution page, but there are not yet automated ways to install them.
 
 <h2 id="modules-and-crates">Modules and Crates</h2>
 


### PR DESCRIPTION
This link currently points to an empty binary file, but according to [this Reddit thread](https://www.reddit.com/r/rust/comments/4s050r/httpsstaticrustlangorgdist_disappeared/), it should actually point to `/dist/index.html`.