### PR TITLE
Fix stable_blog link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 name: The Rust Programming Language
 stable: "1.16.0"
 stable_date: "2017-03-16"
-stable_blog: "https://blog.rust-lang.org/2017/03/16/Rust-1.16.0.html"
+stable_blog: "https://blog.rust-lang.org/2017/03/16/Rust-1.16.html"
 stable_full_version: "rustc 1.16.0 (30cf806ef 2017-03-10)"
 beta: "1.17"
 beta_date: "2017-04-27"


### PR DESCRIPTION
The stable_blog link in _config.yml returns 404.