### PR TITLE
Refinement wording for Chinese example at index page

### DIFF
--- a/_includes/example.rs
+++ b/_includes/example.rs
@@ -9,7 +9,7 @@ fn main() {
             1 =>  println!("Este código es editable y ejecutable!"),
             2 =>  println!("Ce code est modifiable et exécutable!"),
             3 =>  println!("このコードは編集して実行出来ます！"),
-            4 =>  println!("这个代码是可以编辑并且能够运行的！"),
+            4 =>  println!("这段代码是可以编辑并且能够运行的！"),
             _ =>  {},
         }
     }

--- a/_includes/example.rs.html
+++ b/_includes/example.rs.html
@@ -10,7 +10,7 @@
             1 =>  <span class='prelude-val'>println!</span>(<span class='string'>"Este código es editable y ejecutable!"</span>),
             2 =>  <span class='prelude-val'>println!</span>(<span class='string'>"Ce code est modifiable et exécutable!"</span>),
             3 =>  <span class='prelude-val'>println!</span>(<span class='string'>"このコードは編集して実行出来ます！"</span>),
-            4 =>  <span class='prelude-val'>println!</span>(<span class='string'>"这个代码是可以编辑并且能够运行的！"</span>),
+            4 =>  <span class='prelude-val'>println!</span>(<span class='string'>"这段代码是可以编辑并且能够运行的！"</span>),
             _ =>  {},
         }
     }


### PR DESCRIPTION
This pull request applies a small refinement for the Chinese example at the index page.

Detailed explanation:

- `这个` in Chinese means `this` (or more often means `this object`).
- `这段` in Chinese means `this piece of ...`, and is commonly used when referencing source code.