### PR TITLE
Fix website formatting issue

### DIFF
--- a/fr-FR/user-groups.md
+++ b/fr-FR/user-groups.md
@@ -4,6 +4,7 @@ title: Groupe d'utilisateurs Rust &middot; Rust, le langage de programmation
 ---
 
 # Rust User Groups
+
 Dans le monde entier, il existe plus 50 groupes d'utilisateurs Rust représentant
 quelques 7000 membres répartis dans plus de 20 pays. Les Rustacéens se retrouvant
 périodiquement dans ces groupes d'utilisateur. C'est une bonne introduction pour se
@@ -64,6 +65,7 @@ mieux, de créer une Pull Request sur cette [forge GitHub](https://github.com/ru
 ## Danemark
 
 [Copenhangen Rust Group](http://cph.rs), Copenhagen.
+
 ## France
 
 [Lille Rust Meetup](https://www.meetup.com/rust-lille/), Lille.
@@ -77,6 +79,7 @@ mieux, de créer une Pull Request sur cette [forge GitHub](https://github.com/ru
 [Finland Rust-lang Group](https://www.meetup.com/Finland-Rust-Meetup/), Helsinki.
 
 ## Allemagne
+
 [Rust Cologne/Bonn User Group](https://www.meetup.com/Rust-Cologne-Bonn/), Köln.
 
 [Rust Berlin](https://www.meetup.com/Rust-Berlin/), Berlin.


### PR DESCRIPTION
The Markdown engine used for rendering the rust-lang website does not like headings which are not preceded by a linefeed, i.e. this code...

```
Something
## A heading
```

...will be badly rendered as `Something ## A heading`.

Note that this behaviour violates the CommonMark spec ( http://spec.commonmark.org/0.27/#atx-headings : "ATX headings need not be separated from surrounding content by blank lines, and they can interrupt paragraphs"). So if you know more than me about the rendering engine in use, you might want to ask them to fix their parser.

But since putting blank lines before and after headings makes the markdown coding more consistent/readable anyway, I've went for the alternate option of working around the parser bug and putting line feeds everywhere :)