### PR TITLE
Add Rust Bangalore as requested

### DIFF
--- a/en-US/user-groups.md
+++ b/en-US/user-groups.md
@@ -110,6 +110,8 @@ Budapest.
 
 [Rust Group Coimbatore](https://github.com/dvigneshwer/Rust_Group_Coimbatore), Coimbatore.
 
+[Rust Bangalore](https://twitter.com/rustox), Bangalore.
+
 ## Indonesia
 
 [Rust Indonesia](https://github.com/rustid/meetup), Yogyakarta.


### PR DESCRIPTION
Organizers requested to be added.

I only added to the english page for now as I saw there are multiple differences across languages. It might be useful to keep the full list of user groups in a single location instead of having it duplicated (and concurrently mutated) in multiple locations.

I can submit a PR to merge it back into one document and include redirects again if wanted.