### PR TITLE
Doc team changes

### DIFF
--- a/_data/team.yml
+++ b/_data/team.yml
@@ -111,6 +111,9 @@ people:
     irc: peschkaj
   pnkfelix:
     name: Felix Klock
+  QuietMisdreavus:
+    name: QuietMisdreavus
+    irc: misdreavus
   sfackler:
     name: Steven Fackler
   shepmaster:
@@ -171,7 +174,7 @@ teams:
     email: community-team@rust-lang.org
   - name: Documentation team
     responsibility: "ensuring Rust has fantastic documentation"
-    members: [steveklabnik, GuillaumeGomez, jonathandturner, peschkaj, frewsxcv]
+    members: [steveklabnik, GuillaumeGomez, frewsxcv, QuietMisdreavus]
   - name: Moderation team
     responsibility: "helping uphold the <a href='https://www.rust-lang.org/conduct.html'>code of conduct</a>"
     members: [mbrubeck, BurntSushi, manishearth, pnkfelix, niconii]
@@ -183,7 +186,7 @@ teams:
     email: style-team@rust-lang.org
   - name: Rust team alumni
     responsibility: "enjoying a leisurely retirement"
-    members: [Gankro, huonw, pcwalton]
+    members: [Gankro, huonw, pcwalton, peschkaj]
 
 # Information on sites to get profile information from
 sites:


### PR DESCRIPTION
* Moving @peschkaj to Alumni; they took some time off and have not come
back. Thanks for everything! :heart:
* Removing @jonathandturner; he's full-in on Servo. Thank you! :heart:
* Adding @QuietMisdreavus; welcome! :sparkle: