### PR TITLE
Add links to some projects in Rust to the home page

### DIFF
--- a/en-US/index.html
+++ b/en-US/index.html
@@ -52,6 +52,18 @@ title: The Rust Programming Language
       </div>
     </div>
 
+    <div class="row">
+      <div class="col-md-12">
+        <h2>What can you build with Rust?</h2>
+        <ul class="laundry-list">
+          <li>A <a href="https://servo.org/">parallel web browser engine</a></li>
+          <li>A fast, cross-platform <a href="https://github.com/BurntSushi/ripgrep">command line tool</a></li>
+          <li>An <a href="https://www.habitat.sh/">application automation framework</a></li>
+          <li>An <a href="https://www.redox-os.org/">operating system</a></li>
+        </ul>
+      </div>
+    </div>
+
   <script type="text/javascript">
     {% include include.js %}
 


### PR DESCRIPTION
I got a suggestion recently that I think is awesome: we should show people the kinds of things people are making in Rust.

I've added links to 4 open source projects here-- I'd like to propose we keep this list to open source projects so that people could go see the Rust code if they wanted.

This is "playing favorites" somewhat, but I think we should be showing off our community's success stories!

r? @rust-lang/core 