### PR TITLE
Add Adgear to Friends of Rust

### DIFF
--- a/_data/users.yml
+++ b/_data/users.yml
@@ -43,6 +43,11 @@
   logo: academia.edu.svg
   how: "Turning strings into structured paper and author data, <a href='https://github.com/djudd/human-name-rb'>faster than Ruby</a>."
 -
+  name: Adgear
+  url: https://adgear.com/
+  logo: adgear.svg
+  how: "Real-time bidding platform"
+-
   name: AgilData
   url: http://www.agildata.com/
   logo: agildata.svg


### PR DESCRIPTION
Still missing: an adgear.svg file. Not sure where to find that. @francois-couture ?

The `how` can of course be updated as needed. I am opening this to get approval from withing the company to then open this PR on the main repo.

https://www.rust-lang.org/en-US/friends.html