### PR TITLE
Remove outdated benchmarks faq

### DIFF
--- a/en-US/faq.md
+++ b/en-US/faq.md
@@ -1491,7 +1491,7 @@ their new owners).
 How can I interoperate with C++ from Rust, or with Rust from C++?
 </a></h3>
 
-Rust and C++ can interoperate through C. Both Rust and C++ provide a [foreign function interface](https://doc.rust-lang.org/book/ffi.html) for C, and can use that to communicate between each other. If writing C bindings is too tedious, you can always use [rust-bindgen](https://github.com/servo/rust-bindgen) to help automatically generate workable C bindings.
+Rust and C++ can interoperate through C. Both Rust and C++ provide a [foreign function interface](https://doc.rust-lang.org/book/ffi.html) for C, and can use that to communicate between each other. If writing C bindings is too tedious, you can often use [rust-bindgen](https://github.com/servo/rust-bindgen) to automatically generate workable C bindings.
 
 <h3><a href="#does-rust-have-cxx-style-constructors" name="does-rust-have-cxx-style-constructors">
 Does Rust have C++-style constructors?

--- a/en-US/faq.md
+++ b/en-US/faq.md
@@ -230,12 +230,6 @@ By default, Rust's [`HashMap`][HashMap] uses the [SipHash](https://131002.net/si
 
 While SipHash [demonstrates competitive performance](http://cglab.ca/%7Eabeinges/blah/hash-rs/) in many cases, one case where it is notably slower than other hashing algorithms is with short keys, such as integers. This is why Rust programmers often observe slow performance with [`HashMap`][HashMap]. The [FNV hasher](https://crates.io/crates/fnv) is frequently recommended for these cases, but be aware that it does not have the same collision-resistance properties as SipHash.
 
-<h3><a href="#why-is-there-no-integrated-benchmarking" name="why-is-there-no-integrated-benchmarking">
-Why is there no integrated benchmarking infrastructure?
-</a></h3>
-
-There is, but it's only available on the nightly release channel. We ultimately plan to build a pluggable system for integrated benchmarks, but in the meantime, the current system is [considered unstable](https://github.com/rust-lang/rust/issues/29553).
-
 <h3><a href="#does-rust-do-tail-call-optimization" name="does-rust-do-tail-call-optimization">
 Does Rust do tail-call optimization?
 </a></h3>


### PR DESCRIPTION
I noticed that there's an FAQ entry saying that integrated benchmarks are considered unstable.  The entry comes from a year ago.  Is this still true?

Also, it seems like a weird question for a FAQ.  So even if it is still unstable, doesn't seem worth mentioning here.   It does not seem typical for a language to have an integrated benchmarking system.