### PR TITLE
Add German translation

### DIFF
--- a/_includes/example.rs
+++ b/_includes/example.rs
@@ -1,24 +1,24 @@
 fn main() {
-    let greetings = ["Hallo", "Hello", "Hola", "Bonjour",
+    let greetings = ["Hello", "Hola", "Bonjour",
                      "Ciao", "こんにちは", "안녕하세요",
                      "Cześć", "Olá", "Здравствуйте",
-                     "Chào bạn", "您好"];
+                     "Chào bạn", "您好", "Hallo"];
 
     for (num, greeting) in greetings.iter().enumerate() {
         print!("{} : ", greeting);
         match num {
-            0 =>  println!("Dieser Code kann bearbeitet und ausgeführt werden!"),
-            1 =>  println!("This code is editable and runnable!"),
-            2 =>  println!("¡Este código es editable y ejecutable!"),
-            3 =>  println!("Ce code est modifiable et exécutable !"),
-            4 =>  println!("Questo codice è modificabile ed eseguibile!"),
-            5 =>  println!("このコードは編集して実行出来ます！"),
-            6 =>  println!("여기에서 코드를 수정하고 실행할 수 있습니다!"),
-            7 =>  println!("Ten kod można edytować oraz uruchomić!"),
-            8 =>  println!("Esse código é editável e executável!"),
-            9 =>  println!("Этот код можно отредактировать и запустить!"),
-            10 => println!("Bạn có thể edit và run code trực tiếp!"),
-            11 => println!("这段代码是可以编辑并且能够运行的！"),
+            0 =>  println!("This code is editable and runnable!"),
+            1 =>  println!("¡Este código es editable y ejecutable!"),
+            2 =>  println!("Ce code est modifiable et exécutable !"),
+            3 =>  println!("Questo codice è modificabile ed eseguibile!"),
+            4 =>  println!("このコードは編集して実行出来ます！"),
+            5 =>  println!("여기에서 코드를 수정하고 실행할 수 있습니다!"),
+            6 =>  println!("Ten kod można edytować oraz uruchomić!"),
+            7 =>  println!("Esse código é editável e executável!"),
+            8 =>  println!("Этот код можно отредактировать и запустить!"),
+            9 =>  println!("Bạn có thể edit và run code trực tiếp!"),
+            10 => println!("这段代码是可以编辑并且能够运行的！"),
+            11 => println!("Dieser Code kann bearbeitet und ausgeführt werden!"),
             _ =>  {},
         }
     }

--- a/_includes/example.rs
+++ b/_includes/example.rs
@@ -1,5 +1,5 @@
 fn main() {
-    let greetings = ["Hello", "Hola", "Bonjour",
+    let greetings = ["Hallo", "Hello", "Hola", "Bonjour",
                      "Ciao", "こんにちは", "안녕하세요",
                      "Cześć", "Olá", "Здравствуйте",
                      "Chào bạn", "您好"];
@@ -7,17 +7,18 @@ fn main() {
     for (num, greeting) in greetings.iter().enumerate() {
         print!("{} : ", greeting);
         match num {
-            0 =>  println!("This code is editable and runnable!"),
-            1 =>  println!("¡Este código es editable y ejecutable!"),
-            2 =>  println!("Ce code est modifiable et exécutable !"),
-            3 =>  println!("Questo codice è modificabile ed eseguibile!"),
-            4 =>  println!("このコードは編集して実行出来ます！"),
-            5 =>  println!("여기에서 코드를 수정하고 실행할 수 있습니다!"),
-            6 =>  println!("Ten kod można edytować oraz uruchomić!"),
-            7 =>  println!("Esse código é editável e executável!"),
-            8 =>  println!("Этот код можно отредактировать и запустить!"),
-            9 =>  println!("Bạn có thể edit và run code trực tiếp!"),
-            10 => println!("这段代码是可以编辑并且能够运行的！"),
+            0 =>  println!("Dieser Code kann bearbeitet und ausgeführt werden!"),
+            1 =>  println!("This code is editable and runnable!"),
+            2 =>  println!("¡Este código es editable y ejecutable!"),
+            3 =>  println!("Ce code est modifiable et exécutable !"),
+            4 =>  println!("Questo codice è modificabile ed eseguibile!"),
+            5 =>  println!("このコードは編集して実行出来ます！"),
+            6 =>  println!("여기에서 코드를 수정하고 실행할 수 있습니다!"),
+            7 =>  println!("Ten kod można edytować oraz uruchomić!"),
+            8 =>  println!("Esse código é editável e executável!"),
+            9 =>  println!("Этот код можно отредактировать и запустить!"),
+            10 => println!("Bạn có thể edit và run code trực tiếp!"),
+            11 => println!("这段代码是可以编辑并且能够运行的！"),
             _ =>  {},
         }
     }

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,3 +1,4 @@
+<a href="/de-DE/">Deutsch</a>,
 <a href="/en-US/">English</a>,
 <a href="/es-ES/">Español</a>,
 <a href="/fr-FR/">Français</a>,

--- a/_layouts/de-DE/basic.html
+++ b/_layouts/de-DE/basic.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<!-- Page last generated {{ site.time }} -->
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ page.title }}</title>
+    <meta name="keywords" content="Rust, Programmiersprache Rust, rustlang, rust-lang, Mozilla Rust">
+    <meta name="description" content="Eine Systemprogrammiersprache die blitzschnell läuft, Speicherfehler vermeidet und Threadsicherheit garantiert.">
+
+    <link rel="stylesheet" href="/css/bootstrap.css">
+    <link rel="stylesheet" href="/css/style.css">
+    {% for css_name in page.extra_css %}
+    <link rel="stylesheet" href="/css/{{ css_name }}">
+    {% endfor %}
+  </head>
+
+  <body class="container">
+    <a href="https://github.com/rust-lang/rust">
+      <img class="ribbon" style="display: none" src="/logos/forkme.png" alt="Auf GitHub besuchen" width="298" height="298">
+    </a>
+
+    <header>
+      <ul class="row menu">
+	<li class="col-xs-12 col-md-2">
+          <a href="/de-DE/index.html">
+            <img class="img-responsive" src="/logos/rust-logo-blk.svg" onerror="this.src='/logos/rust-logo-256x256-blk.png'" height="128" width="128" alt="Rust logo" />
+          </a>
+	</li>
+	<li class="col-xs-12 col-md-10 menu">
+	  <h2><a href="/de-DE/documentation.html">Dokumentation</a></h2>
+	  <h2><a href="/de-DE/install.html">Installation</a></h2>
+	  <h2><a href="/de-DE/community.html">Community</a></h2>
+	  <h2><a href="/de-DE/contribute.html">Mitwirken</a></h2>
+	</li>
+      </ul>
+    </header>
+
+    {{ content }}
+
+    <footer>
+      <p>Diese Seite in anderen Sprachen:
+        {% include footer.html %}
+      </p>
+    </footer>
+
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-58390457-1', 'auto');
+      ga('send', 'pageview');
+
+    </script>
+  </body>
+</html>

--- a/_layouts/de-DE/default.html
+++ b/_layouts/de-DE/default.html
@@ -1,0 +1,7 @@
+---
+layout: de-DE/basic
+---
+
+<div class="content">
+  {{ content }}
+</div>

--- a/_layouts/de-DE/faq.html
+++ b/_layouts/de-DE/faq.html
@@ -1,0 +1,10 @@
+---
+layout: de-DE/default
+---
+
+<link href='https://fonts.googleapis.com/css?family=Source+Serif+Pro:400,600' rel='stylesheet' type='text/css'>
+<link href='/css/syntax-highlight.css' rel='stylesheet' type='text/css'>
+
+<div class="faq">
+  {{ content }}
+</div>

--- a/de-DE/community.md
+++ b/de-DE/community.md
@@ -1,0 +1,223 @@
+---
+layout: de-DE/default
+title: Die Rust-Community &middot; Die Programmiersprache Rust
+---
+
+# Die Rust-Community
+
+Die Programmiersprache Rust bietet viele Vorteile, doch ihre größte Stärke ist die Gemeinschaft der Menschen, die zusammentreffen, um das Arbeiten in Rust zu einer belohnenden Erfahrung zu machen.
+
+Wir sind stets bemüht, eine freundliche, sichere und einladende Umgebung für alle zu bieten - unabhängig von Erfahrung, Geschlecht, Geschlechteridentität, sexueller Orientierung, körperlicher Einschränkung, Aussehen, ethnischer Herkunft, Alter, Religion, Nationalität oder ähnlichem. Unser [Verhaltenskodex][coc] definiert dabei die Richtlinien für alle offiziellen Rust-Foren.
+
+Falls du das Gefühl hast von einem anderen Teilnehmer schikaniert oder bedrängt zu werden, [kontaktiere][mod_team_email] bitte ein Mitglied des [Rust-Moderationsteams][mod_team] (englisch). Egal ob du regelmäßig am Projekt mitwirkst oder frisch dazugekommen bist - es ist uns sehr wichtig diese Gemeinschaft zu einer sicheren Umgebung für dich zu machen.
+
+[coc]: conduct.html
+[mod_team_email]: mailto:rust-mods@rust-lang.org
+
+## Einstieg
+
+Die wichtigsten Anlaufpunkte für Einsteiger in Rust:
+
+- [#rust-beginners][beginners_irc], ein IRC-Kanal, der gerne Fragen jeder Komplexität beantwortet.
+- Das [Benutzerforum][users_forum] für alle Diskussionen rund um Rust.
+
+Zu vielen Problemen findest du auch auf der Fragen- und Antwortenseite [Stack Overflow][stack_overflow] Hilfestellung.
+
+[stack_overflow]: https://stackoverflow.com/questions/tagged/rust
+
+## Neuigkeiten
+
+[This Week in Rust][twir] sammelt die neuesten Veränderungen, anstehende Termine sowie eine wöchentliche Auflistung aller Änderungen in der Sprache und ihren Bibliotheken. Im [Rust-Blog][rust_blog] findest du Ankündigungen wichtiger Entwicklungsschritte; und fast alles, was in der Rust-Welt vor sich geht, wird auch im inoffiziellen Subreddit [/r/rust][reddit] diskutiert.
+
+Wir pflegen auch einen [Twitter][twitter]-Account und ein [Weibo][weibo] für unsere chinesischsprachigen Benutzer.
+
+[twir]: https://this-week-in-rust.org/
+[rust_blog]: http://blog.rust-lang.org/
+[reddit]: https://www.reddit.com/r/rust
+[reddit_coc]: https://www.reddit.com/r/rust/comments/2rvrzx/our_code_of_conduct_please_read/
+[twitter]: https://twitter.com/rustlang
+[weibo]: http://weibo.com/u/5616913483
+
+## IRC-Kanäle
+
+Die Rust-Community verwaltet einige freundliche und gut besuchte IRC-Kanäle auf Mozillas IRC-Netzwerk, irc.mozilla.org.
+
+[#rust][rust_irc] ist ein Kanal für allgemeine Diskussionen rund um Rust und ein guter Ort, um nach Hilfe zu fragen. Dort werden gerne alle Fragen zu Rust entgegengenommen und meist schnell beantwortet.
+
+Das Entwicklerteam von Rust koordiniert sich in [#rust-internals][internals_irc]. Dort finden Diskussionen über die Weiterentwicklung der Sprache und der Infrastruktur statt. Hier hast du die Möglichkeit, fragen zum Mitwirken am Rust-Projekt zu stellen.
+
+### Hauptkanäle (Englisch)
+
+- [#rust][rust_irc] für alles rund um Rust
+- [#rust-beginners][beginners_irc] für Anfänger in der Sprache, weniger gut besucht als #rust
+- [#rust-internals][internals_irc] für Diskussionen um die Entwicklung der Sprache
+
+### Deutsche und internationale Kanäle
+
+- [#rust-de][de_irc] ist für die allgemeine Diskussion über Rust auf Deutsch
+- [#rust-br][br_irc] é dedicado à discussão sobre Rust no Brasil
+- [#rust-es][es_irc] es para una discusión general sobre Rust en español
+- [#rust-fr][fr_irc] est dédié à la programmation en Rust en français
+- [#rust-ru][ru_irc] для общих дискуссий о Rust на русском языке
+- [Rust中文][cn_org] Rust 语言中文 Chat 社区(非IRC频道)
+
+### Teamkanäle (Englisch)
+
+
+- [#cargo][cargo_irc] für Diskussionen rund um Cargo, den Paketmanager von Rust. Die Heimat des [Cargo-Teams][cargo_team]
+- [#rust-community][community_irc] ist die Heimat des [Community Teams][community_team]
+- [#rustc][rustc_irc] ist die Heimat des [Compilerteams][compiler_team]
+- [#rust-dev-tools][dev_tools_irc] ist die Heimat des [Developer Tools Teams][dev_tools_team]
+- [#rust-docs][docs_irc] ist die Heimat des [Dokumentationsteams][doc_team]
+- [#rust-infra][infra_irc] ist die Heimat des [Infrastruktur-Teams][infra_team]
+- [#rust-lang][lang_irc] ist die Heimat des [Sprachteams][language_team]
+- [#rust-libs][libs_irc] ist die Heimat des [Bibliotheksteams][library_team]
+- [#rust-mods][mod_irc] ist der IRC-Kanal des [Moderationsteams][mod_team]
+- [#rust-style][style_irc] ist die Heimat des [Style-Teams][style_team]
+
+### Themenkanäle (Englisch)
+
+Diese Kanäle sind für die weiter Rust-Community und nicht vom [Moderationsteam][mod_team] verwaltet.
+
+- [#rust-bots][bots_irc] versendet Benachrichtigungen zu Rust von einer Auswahl an Bots
+- [#rust-crypto][crypto_irc] zur Diskussion über Kryptographie in Rust
+- [#rust-embedded][embedded_irc] für Embedded-Entwicklung in Rust
+- [#rust-gamedev][gamedev_irc] für Spieleentwicklung in Rust
+- [#rust-geo][rustgeo_irc] zur Diskussion von GeoRust
+- [#rust-machine-learning][machine_learning_irc] für Machine-Learning-Themen in Rust
+- [#rust-networking][networking_irc] für Netzwerkentwickler und Programmierer in Rust
+- [#rust-osdev][osdev_irc] für Diskussionen zur Betriebssystementwicklung in Rust
+- [#rust-sci][sci_irc] für wissenschaftliches Rechnen in Rust
+- [#rust-wasm][wasm_irc] für Diskussionen um die Benutzung von Rust mit WebAssembly
+- [#rust-webdev][webdev_irc] für Themen zur Webentwicklung in Rust
+- [#iron][iron_irc] für die Diskussion zu Iron, dem erweiterbaren Rust-Webframework
+- [#nom][nom_irc] is for discussion on Nom, a Rust parser combinator library
+- [#nom][nom_irc] für Diskussionen zu Nom, einer Rust-Parserkombinatorbibliothek
+- [#redox][redox_irc] für Gespräche über Redox, dem Betriebssystem in Rust
+- [#rocket][rocket_irc] zur Diskussion über Rocket, einem beliebten HTTP-Framework in Rust
+- [#serde][serde_irc] if for discussion on Serde, a popular Rust serialization library
+- [#serde][serde_irc] zur Diskussion zu Serde, einer Serialisierungsbibliothek in Rust
+- [#servo][servo_irc] zur Diskussion über Servo, Mozillas Browserengine in Rust
+- [#xi][xi_irc] für Diskussionen um Xi, den Texteditior in Rust
+
+[IRC]: https://en.wikipedia.org/wiki/Internet_Relay_Chat
+[beginners_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-beginners
+[bots_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-bots
+[br_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-br
+[cargo_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23cargo
+[cn_org]: https://chat.rust-china.org/
+[community_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-community
+[crypto_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-crypto
+[de_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-de
+[es_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-es
+[embedded_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-embedded
+[fr_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-fr
+[gamedev_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-gamedev
+[internals_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
+[lang_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-lang
+[libs_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-libs
+[networking_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-networking
+[osdev_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-osdev
+[ru_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-ru
+[rust_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust
+[rustc_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
+[servo_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23servo
+[webdev_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-webdev
+[docs_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-docs
+[xi_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23xi
+[dev_tools_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-dev-tools
+[style_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23style
+[style_team]: team.html#Style-team
+[mod_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23mods
+[machine_learning_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-machine-learning
+[hyper_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23hyper
+[iron_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23iron
+[redox_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23redox
+[nom_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23nom
+[infra_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-infra
+[rustgeo_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-geo
+[rocket_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rocket
+[serde_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23serde
+[sci_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-sci
+[wasm_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-wasm
+
+
+## Diskussionsforen
+
+Es gibt zwei Foren für zeitversetze Diskussionen:
+
+- Das [Users Forum][users_forum], um Fragen zu stellen, Codeschnipsel zu posten, über Rust-Projekte zu sprechen, und so weiter.
+- Das [Internals Forum][internals_forum], reserviert für das Design und die Implementierung der Sprache Rust und ihrer Infrastruktur (beispielsweise Cargo, die Standardbibliothek und weitere Interna).
+
+[users_forum]: https://users.rust-lang.org/
+[internals_forum]: https://internals.rust-lang.org/
+
+## YouTube-Kanal
+
+Rust hat einen [YouTube-Kanal][youtube_channel], wo Präsentationen vor Benutzern und auf Konferenzen von Mitgliedern der Community hochgeladen werden.
+
+[youtube_channel]: https://www.youtube.com/channel/UCaYhcUwRBNscFNUKTjgPFiA
+
+## Benutzergruppen und Meet-Ups
+
+Weltweit gibt es mehr als 90 [Rust-Benutzergruppen][user_group] in über 35 Ländern. Rust-Benutzer treffen sich regelmäßig in den Benutzergruppen. Sie bieten die Möglichkeit einfach Teil der Community zu werden und andere Mitglieder kennenzulernen und Erfahrungen auszutauschen. Die Treffen finden üblicherweise monatlich statt, sind zwanglos gehalten und stets für neue Teilnehmer offen.
+
+Es gibt einen weltweiten [Kalender][calendar], um über Rust-Veranstaltungen auf dem Laufenden zu bleiben. Kontaktiere das [Community Team][community_team] (Englisch), um deine eigenen Veranstaltungen zu veröffentlichen.
+
+[user_group]: ./user-groups.html
+[calendar]: https://www.google.com/calendar/embed?src=apd9vmbc22egenmtu5l6c5jbfc@group.calendar.google.com
+
+## Das Rust-Entwicklerteam
+
+Rust entsteht durch einen Community-getriebenen Entwicklungsprozess, in dem die meisten Entscheidungen über offene Diskussionen und Übereinkommen zustande kommen. Die Verantwortung ist dabei auf verschiedene [Teams][teams] aufgeteilt:
+
+* Das [Core Team][core_team] leitet den Design- und Entwicklungsprozess, überwacht die Einführung neuer Features und trifft endgültige Entscheidungen für die kein Konsens gefunden werden kann (was selten vorkommt).
+
+* Das [Language Team][language_team] entwirft neue Sprach-Features.
+
+* Das [Library Team][library_team] ist für die Rust-Standardbibliothek, die Crates aus rust-lang und Bibliothekskonventionen verantwortlich.
+
+* Das [Compiler Team][compiler_team] entwickelt und optimiert Compiler-Interna.
+
+* Das [Dev Tools Team][dev_tools_team] treibt die Tools zur Arbeit mit Rust-Code voran.
+
+* Das [Cargo Team][cargo_team] kümmert sich um Entwurf und Design von Cargo.
+
+* Das [Infrastructure Team][infra_team] ist für die Infrastruktur des Rust-Projekts selbst verantwortlich: CI, Erzeugung von Releases, Bots und Codemetriken.
+
+* Das [Community Team][community_team] koordiniert Veranstaltungen, Öffentlichkeitsarbeit, die Verbindung zu kommerziellen Nutzern und Lernmaterial. Das Team sorgt auch für die Weiterleitung von Anfragen an die zuständigen Stellen, falls es nicht klar ist, wer zu einer konkreten Fragestellung zu kontaktieren ist.
+
+* Das [Moderationsteam][mod_team] sorgt dafür, dass der [Verhaltenskodex][coc] aufrechterhalten wird.
+
+* Das [Dokumentationsteam][doc_team] hält die fantastische Dokumentation zu Rust auf dem neuesten Stand.
+
+Zusätzlich zum den offiziellen Aufstellungen können die meisten Teams auch auf eine große Zahl an Reviewern zurückgreifen, die Fachwissen einbringen und Code gegenlesen. Falls du interessiert bist, dich an einem der Teams zu beteiligen,
+kontaktiere unverbindlich den Leiter des Teams oder ein anderes Teammitglied, die dir bei den ersten Schritten helfen.
+
+[teams]: team.html
+[core_team]: team.html#Core-team
+[language_team]: team.html#Language-design-team
+[library_team]: team.html#Library-team
+[compiler_team]: team.html#Compiler-team
+[dev_tools_team]: team.html#Dev-tools-team
+[cargo_team]: team.html#Cargo-team
+[community_team]: team.html#Community-team
+[mod_team]: team.html#Moderation-team
+[doc_team]: team.html#Documentation-team
+[infra_team]: team.html#Infrastructure-team
+
+## Die Entwicklung von Rust
+
+An Rust haben bisher über [2000 Entwickler mitgewirkt][authors], eine Zahl, die jede Woche stetig wächst. [Wir würden uns freuen, wenn du auch bald auf dieser Liste stehst][contribute]!
+
+Wie oben erwähnt, steht das [Rust Internals Forum][internals_forum] für Themen rund um die Entwicklung und Implementierung von Rust zur Verfügung. Ein großer Teil der Diskussionen finden auch auf GitHub statt:
+
+- Das [Haupt-Repository][github] und der [Issue Tracker][issue_tracking] bilden die vorderste Front der Implementierungsarbeit. Unsere Reviewer unterstützen auch Neulinge gerne und freundlich, also zögere nicht ein Pull Request zu stellen, sobald du mit einer Verbesserung beitragen möchtest!
+
+- Das [RFC-Repository][rfcs] führt in unserem RFC- (Request for Comments-) Prozess Buch, dem Hauptweg, über den die Community und die Entwicklerteams Konsens finden und Entscheidungen zu neuen Features der Sprache, der Standardbibliothek und dem Tooling treffen.
+
+[authors]: https://thanks.rust-lang.org/rust/all-time
+[contribute]: contribute.html
+[github]: https://github.com/rust-lang/rust
+[rfcs]: https://github.com/rust-lang/rfcs
+[issue_tracking]: https://github.com/rust-lang/rust/issues

--- a/de-DE/conduct.md
+++ b/de-DE/conduct.md
@@ -1,0 +1,41 @@
+---
+layout: de-DE/default
+title: Der Rust-Verhaltenskodex &middot; Die Programmiersprache Rust
+---
+
+# Der Rust-Verhaltenskodex
+
+## Verhalten
+
+**Kontakt**: [rust-mods@rust-lang.org](mailto:rust-mods@rust-lang.org) (Englisch)
+
+* Wir sind stets bemüht, eine freundliche, sichere und einladende Umgebung für alle zu bieten - unabhängig von Erfahrung, Geschlecht, Geschlechteridentität, sexueller Orientierung, körperlicher Einschränkung, Aussehen, ethnischer Herkunft, Alter, Religion, Nationalität oder ähnlichem.
+* Bitte vermeide im IRC offen sexuelle oder andere Nicknames, die eine freundliche, sichere und einladende Umgebung gefährden könnten.
+* Bitte verhalte dich zuvorkommend und höflich. Es gibt keinen Grund, unverschämt zu anderen Teilnehmern zu sein.
+* Bitte respektiere, dass es immer abweichende Meinungen gibt und dass jede Design- oder Implementierungsentscheidung auf Abwägungen basiert und Aufwand verursacht. Es gibt selten eine perfekte Lösung.
+* Bitte reduziere unstrukturierte Beiträge auf ein Minimum. Wenn du konkrete Ideen hast, forke eins unserer Repositories, experimentiere damit und arbeite einen gut durchdachten Vorschlag oder ein Pull Request aus.
+* Falls wir feststellen müssen, dass du andere Teilnehmer beleidigst, belästigst oder schikanierst, werden wir dich von der Kommunikation ausschließen. Solches Verhalten ist nicht willkommen. Falls du dir nicht sicher bist, was aus unserer Sicht alles in diese Kategorie fällt, lies im <a href="http://citizencodeofconduct.org/">Citizen Code of Conduct</a> unter dem Stichwort "harassment" nach. Wir übernehmen die dortige Definition für unsere Zwecke. Insbesondere tolerieren wir kein Verhalten, das dazu geeignet ist, sozial benachteiligte Gruppen auszuschließen.
+* Persönliche Belästigung ist ebenso unakzeptabel. Falls du das Gefühl hast von einem anderen Teilnehmer schikaniert oder unangenehm bedrängt zu werden, kontaktiere bitte sofort einen der IRC-Ops oder ein Mitglied des [Rust-Moderationsteams](/team.html#Moderatoren) (englisch). Egal ob du regelmäßig am Projekt mitwirkst oder frisch dazugekommen bist - es ist uns sehr wichtig diese Gemeinschaft zu einer sicheren Umgebung zu machen, und wir werden dich unterstützen.
+* Genauso ist Spamming, Trolling, Flaming und anderes Verhalten, das nur der Erregung von Aufmerksamkeit dient, nicht willkommen.
+
+## Moderation
+
+Dies sind die Richtlinien, um den Verhaltenskodex unserer Community aufrecht zu erhalten. Falls du der Meinung bist, dass ein Thread der Moderation bedarf, kontaktiere bitte das [Rust-Moderationsteam](/team.html#Moderatoren) (englisch).
+
+1. Bemerkungen, die gegen den Rust-Verhaltenskodex verstoßen, wie etwa verhasste, verletzende, unterdrückende oder ausschließende Bemerkungen sind verboten (Fluchen und die Benutzung von Schimpfwörtern ist grundsätzlich erlaubt, aber nicht wenn sie andere Personen zum Ziel haben).
+2. Bemerkungen, die Moderatoren als unangemessen einstufen, ob sie Teil des Verhaltenskodex sind oder nicht, sind ebenfalls verboten.
+3. Die Moderatoren werden auf derartige Bemerkungen zunächst mit einer Warnung reagieren.
+4. Wird die Warnung nicht berücksichtigt, so wird der Teilnehmer oder die Teilnehmerin aus dem Kommunikationskanal entfernt ("gekickt"), um ihm oder ihr Bedenkzeit zu geben.
+5. Kehrt der Nutzer oder die Nutzerin trotzdem zurück und unterlässt das störende Verhalten nicht, so wird er oder sie permanent von der Kommunikation ausgeschlossen ("gebannt").
+6. Moderatoren haben die Befugnis, nach eigenem Ermessen den Ban eines Nutzers oder einer Nutzerin aufzuheben, falls es sich um den ersten derartigen Verstoß handelt und eine aufrichtige Entschuldigung gegenüber der beleidigten Person erfolgt ist.
+7. Falls du der Meinung bist, dass ein Ban eines Teilnehmers ungerechtfertigt war, suche bitte Kontakt zum betreffenden Moderator oder einem anderen Mitglied des Moderationsteams.
+8. Moderatorinnen und Moderatoren nehmen gegenüber anderen Mitgliedern eine Vorbildfunktion ein. Falls ein Moderator eine unangemessene Situation verursacht, so wird dies strenger geahndet als bei anderen Teilnehmern.
+
+Wir als Rust-Community haben uns das Ziel gesetzt, füreinander da zu sein. Versuche nicht nur faktisch unanfechtbar aufzutreten sondern dein bestes Ich zu präsentieren. Bemühe dich, nicht mit persönlich unangenehmen oder heiklen Themen zu jonglieren, die nicht zur eigentlichen Diskussion beitragen. Dies führt oft zu unnötigen Streits, verletzten Gefühlen, schadet dem Vertrauen zwischen uns und kann im schlimmsten Fall dazu führen, Menschen aus unser Community zu vertreiben.
+
+Falls jemand an einer deiner Bemerkungen oder Taten Anstoß nimmt, versuche nicht instinktiv defensiv zu reagieren, sondern mache einen Schritt zurück und entschuldige dich. Auch wenn du der Meinung bist, dass die Anschuldigung nicht gerechtfertigt war und du missverstanden wurdest, stehen die Chancen gut dass die Meinungsverschiedenheit auf unzureichender Kommunikation beruht. Denke daran, dass es auch deine Pflicht ist, anderen Mitgliedern ein angenehmes Umfeld zu bieten. Wir wollen uns alle gut verstehen und sind vor allem deshalb hier, weil wir über coole Technologie diskutieren wollen. Du wirst merken, dass Menschen gute Absichten hinter einer unglücklichen Bemerkung annehmen und dir bereitwillig vergeben, solange du ihr Vertrauen bewahrst.
+
+Die Durchsetzung der aufgezählten Richtlinien gelten für alle Dienste des Rust-Projekts, einschließlich der offiziellen IRC-Kanäle (#rust, #rust-internals, #rust-tools, #rust-libs, #rustc, #rust-beginners, #rust-docs, #rust-community, #rust-lang, und #cargo), den GitHub-Repositories unter rust-lang, rust-lang-nursery und rust-lang-deprecated, sowie allen Foren unter rust-lang.org (users.rust-lang.org, internals.rust-lang.org). Für andere Projekte, die den Rust-Verhaltenskodex übernehmen, kontaktiere bitte deren Administratoren zu Anfragen oder Problemen. Falls du den Verhaltenskodex für dein eigenes Projekt implementieren möchtest, empfiehlt es sich, deine eigenen Moderationsregeln zu erwähnen um Verwirrung zu vermeiden.
+
+*Basierend auf der [Node.js Policy on Trolling](http://blog.izs.me/post/30036893703/policy-on-trolling) und dem [Contributor Covenant v1.3.0](http://contributor-covenant.org/version/1/3/0/).*
+

--- a/de-DE/contribute-bugs.md
+++ b/de-DE/contribute-bugs.md
@@ -1,0 +1,40 @@
+---
+layout: de-DE/default
+title: Bei Rust mitwirken &mdash; Fehler finden, sichten und beheben &middot; Die Programmiersprache Rust
+---
+
+# Bei Rust mitwirken &mdash; Fehler finden, sichten und beheben
+
+Die tägliche Pflege des Projekts dreht sich um den [Issue Tracker][issue tracker] und [Pull Requests][pull] - Mithilfe wird immer benötigt! Der einfachste Weg um einzusteigen sind Tickets mit den [E-easy] und [E-mentor]-Labels, die für neue Rust-Programmierer geeignet sind.
+
+Bei Issues, die mit `E-mentor` gekennzeichnet sind, hat sich ein erfahrener Entwickler bereit erklärt, dich durch den Lösungsprozess und das [Einsenden eines Pull Request][pull] zu begleiten. Kontaktiere den Mentor auf dem Issue Tracker indem du ihn mit [@mentioning] in einem Kommentar erwähnst, oder ihn per Mail oder IRC direkt anschreibst. Denke daran, dass Rust-Entwickler täglich viele Benachrichtigungen erhalten und einzelne Nachrichten übersehen werden können, also scheue dich nicht noch einmal nachzuhaken, falls du einmal keine Antwort erhältst.
+
+Andere Rust-Projekte bieten ähnliche Einsteigeraufgaben, so etwa der Webbrowser [Servo], die HTTP-Bibliothek [hyper], das Code-Formatierungswerkzeug [rustfmt], die Unix-Bindings [nix] oder der Linter [clippy].
+
+Obwohl Rust bereits eine [ansehnliche Test-Suite][test] besitzt, gibt es immer Testfälle, die noch nicht abgedeckt sind. Das [E-needstest]-Label kennzeichnet Issues, die wahrscheinlich schon gelöst sind, zu deren Problemstellung aber noch ein Unit-Test fehlt. Testfälle zu schreiben ist eine gute Gelegenheit, um mit einer neuen Projektstruktur vertraut zu werden und zum erstem Mal mitzuwirken.
+
+Rust braucht immer Freiwillige, die Issues [sichten][triage], also Bugs reproduzieren, Testfälle minimieren, Labels zuweisen und gelöste Tickets schließen. Um Labels zuzuweisen, brauchst du zusätzliche Berechtigungen auf GitHub, die aber leicht zu bekommen sind, sobald du etwas Erfahrung im Projekt gesammelt hast. Frag einfach ein [Teammitglied][team].
+
+Sobald du dich im Projekt zurechtfindest und ein paar Pull Requests zu einem Teilgebiet eingereicht hast, kannst du versuchen Pull Requests anderer Benutzer durchzusehen. Gute Reviewer sind rar und immer gern gesehen. Dazu brauchst du keine besonderen Berechtigungen &mdash; kommentiere einfach Pull Requests die dich interessieren konstruktiv und höflich. Wenn du mehr zu guten Code Reviews lernen möchtest, wirf einen Blick in [diesen Leitfaden][reviews].
+
+<!--
+TODO: weekly triage email?
+TODO: @nrc says suggesting everybody review w/o training is bad
+-->
+
+[@mentioning]: https://github.com/blog/821
+[E-easy]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-easy
+[E-mentor]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-easy+label%3AE-mentor
+[E-needstest]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-needstest
+[PR]: https://github.com/rust-lang/rust/pulls
+[Servo]: https://github.com/servo/servo
+[clippy]: https://github.com/Manishearth/rust-clippy
+[hyper]: https://github.com/hyperium/hyper
+[issue tracker]: https://github.com/rust-lang/rust/issues
+[nix]: https://github.com/nix-rust/nix/
+[pull]: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md#pull-requests
+[reviews]: http://blog.originate.com/blog/2014/09/29/effective-code-reviews/
+[rustfmt]: https://github.com/rust-lang-nursery/rustfmt
+[team]: team.html
+[test]: https://github.com/rust-lang/rust-wiki-backup/blob/master/Note-testsuite.md
+[triage]: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md#issue-triage

--- a/de-DE/contribute-community.md
+++ b/de-DE/contribute-community.md
@@ -1,0 +1,49 @@
+---
+layout: de-DE/default
+title: Bei Rust mitwirken &mdash; Community-Building &middot; Die Programmiersprache Rust
+---
+
+# Mithelfen, die Rust-Gemeinschaft aufzubauen
+
+Hilf Einsteigern, erzähle Anderen von Rust, triff interessante Leute, und mache Rust zu einem glänzenden Beispiel für Open-Source-Entwicklung.
+
+Behalte [#rust-beginners] im Auge. Auf diesen Channel verweisen wir neue Rust-Programmierer, die Hilfe benötigen. Es ist entscheidend, dass sie dort schnelle, genaue und freundliche Antworten erhalten. Auch auf [Stack Overflow], [users.rust-lang.org] und [/r/rust] suchen Rust-Programmierer häufig nach Unterstützung. [Dieser Leitfaden][helpful] gibt dir Tipps im Umgang mit Fragen anderer Entwickler.
+
+Wenn du bereits in einem Gebiet des Projekts erfahren bist, mach dich auf der Suche nach Bugs, die mit [E-easy] gekennzeichnet werden können. Wenn du so einen einfachen Issue findest, dessen Lösung dir offensichtlich erscheint, kommentiere mit einem Lösungsvorschlag und füge den E-easy-Tag an. Denke daran, dass für dich offensichtliche Zusammenhänge für einen Einsteiger nicht genauso klar sein müssen, deshalb ist eine genaue Beschreibung des Problems und seiner Lösung wichtig. Du kannst also auch beitragen, indem du nach schwachen Beschreibungen einfacher Bugs suchst und sie verbesserst.
+
+Erfahrene Entwickler, die Geduld und Talent zum Erklären mitbringen, sollten sich überlegen [Mentoren für neue Helfer][mentor] zu werden. Füge zu einfachen Bugs das [E-mentor]-Tag hinzu und poste einen Kommentar, dass du das Mentoring für dieses Issue übernimmst. Erwarte dass dich neue Entwickler wegen des Problems kontaktieren, und bemühe dich ihnen zeitnah zur Seite zu stehen.
+
+Aufgaben auf Einsteigerniveau bereitzuhalten ist nicht nur für Rust, sondern für alle Projekte von Vorteil. Falls dein eigenes Projekt eine konstante Menge an Einsteigerproblemen bietet, hast du die Möglichkeit selbst ein solches Mentoring-Programm ins Leben zu rufen. **Aufgaben für Anfänger bereitzustellen ist eine der effektivsten Möglichkeiten, um neue Programmierer in dein Projekt zu bringen**. Falls du Tipps zum Mentoring neuer Mitglieder brauchst, wirf einen Blick in [diesen Leitfaden][mentor-guide].
+
+Rede im "What's everyone working on this week"-Thread in [/r/rust] und in [users.rust-lang.org] über deine aktuellen Projekte und sprich an wo du Unterstützung benötigst. Diese Foren bieten einen guten Startpunkt für Zusammenarbeit.
+
+Stelle Rust auch deinen Freunden und Kollegen vor. Rust-[Benutzergruppen][user groups] und [-Events][events] sind ein einzigartiger und spannender Teil der Rust-Community, es gibt viele davon, und sie sind überall! Falls du noch nicht dabei warst, geh' hin und erleb' es! Falls in deiner Nähe noch keine Veranstaltungen zu Rust gibt, überlege dir selbst etwas zu organisieren. Frage nach Interessenten und kündige Events auf [/r/rust] und [users.rust-lang.org] an. Kontaktiere das [Community-Team][community team], damit dein Event im offiziellen Kalender landet und bei [This Week in Rust] angekündigt wird.
+
+Behalte dabei aber im Hinterkopf, stets auf die Ansichten anderer Rücksicht zu nehmen &mdash; nicht jeder wird Gefallen an Rust finden, und das ist in Ordnung.
+
+Andere Interessenten am Community-Building kannst du in [#rust-community] treffen.
+
+<!--
+Other ideas:
+TWIR, podcasts.
+
+experience reports
+conf talks
+
+Conduct training on Rust. (link to training material).
+-->
+
+[#rust-beginners]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-beginners
+[#rust-community]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-community
+[/r/rust]: https://reddit.com/r/rust
+[E-easy]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-easy
+[E-mentor]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-easy+label%3AE-mentor
+[Stack Overflow]: https://stackoverflow.com/questions/tagged/rust
+[This Week in Rust]: https://this-week-in-rust.org
+[community team]: https://www.rust-lang.org/team.html#Community
+[events]: https://www.google.com/calendar/embed?src=apd9vmbc22egenmtu5l6c5jbfc@group.calendar.google.com
+[helpful]: https://codeblog.jonskeet.uk/2009/02/17/answering-technical-questions-helpfully/
+[mentor]: https://users.rust-lang.org/t/mentoring-newcomers-to-the-rust-ecosystem/3088
+[mentor-guide]: https://manishearth.github.io/blog/2016/01/03/making-your-open-source-project-newcomer-friendly/
+[user groups]: user-groups.html
+[users.rust-lang.org]: https://users.rust-lang.org

--- a/de-DE/contribute-compiler.md
+++ b/de-DE/contribute-compiler.md
@@ -1,0 +1,56 @@
+---
+layout: de-DE/default
+title: Bei Rust mitwirken &mdash; Sprache, Compiler und Standardbibliothek &middot; Die Programmiersprache Rust
+---
+
+# Bei Rust mitwirken &mdash; Sprache, Compiler und Standardbibliothek
+
+Der Quelltext von Compiler und Standardbibliothek liegen im Hauptrepository, und nachdem seine Verwaltung die Hauptaufgabe dieses Repositories ist, beziehen sich auch viele Labels im Issue-Tracker darauf. Ein paar der ergiebigeren Labels sind [A-codegen] für die Übersetzung von Rust in die LLVM-IR; [A-debuginfo] für die Erzeugung von Metadaten für Debugger, [A-diagnostics] für Fehlermeldungen und anderes Feedback des Compilers; [A-libs] für Tickets zur Standardbibliothek, [A-macros] und [A-syntaxext] für Syntaxerweiterungen und [A-typesystem] für das Typsystem der Sprache.
+
+Es existiert keine regelmäßig gepflegte Dokumentation zur Architektur des Compilers, aber [eine kurze Übersicht findet sich im Repository][rustc-guide]. Die [API-Dokumentation für die Crates des Compilers][internals-docs] kann ebenso wie der Codebrowser [Rust DXR] bei der Navigation im Quelltext helfen. Die [Richtlinien zur Rust-Testsuite][testsuite] und [`make tips`][tips] geben eine Anleitung zum Gebrauch des Buildsystems.
+
+Eine der größten Entwicklungsziele in absehbarer Zukunft ist, die Interna des Compilers nicht mehr auf dem Syntaxbaum des Quelltexts, sondern auf der [Zwischenrepräsentation MIR][mir] arbeiten zu lassen. Es wird erwartet, dass diese Änderung durch Vereinfachung des Compilers viele neue Möglichkeiten mit sich bringt. Hilfe wird unter Anderem bei der Implementierung eines neuen MIR-basierten Übersetzungsschritts, neuer MIR-basierter Optimierungsstrategien und inkrementeller Kompilation benötigt. Es existiert noch keine zentrale Sammelstelle für Aufgaben zu diesem Thema, du kannst aber jederzeit auf [internals.rust-lang.org] oder [#rust-internals] nachfragen.
+
+Es ist peinlich [wenn der Compiler einmal abstürzt][ice] &mdash; der gefürchtete Internal Compiler Error (ICE). Das [I-ICE]-Label markiert derartige Fehler auf dem Issue Tracker, und dort gibt es einige davon. Diese Bugs zu beheben sind eine gute Einsteigeraufgabe, da sie oft isoliert auftreten und es einfach ist festzustellen, wenn der Fehler behoben ist.
+
+Die Performance von Rust-Code ist einer der größten Vorteile der Sprache; die des Compilers dagegen eine ihrer größten Schwächen. Jegliche Verbesserungen an Laufzeit- oder &mdash; noch besser &mdash; Compilezeitperformance werden gefeiert. Die [I-slow] und [A-optimization]-Labels beschäftigen sich mit Laufzeit- und [I-compiletime] mit Compilezeitperformance. Es gibt [eine Seite, die die Übersetzungsgeschwindigkeit][rustc-perf] für einige Szenarien verfolgt. Die Compiler-Performance kann mit Hilfe des `-Z time-passes`-Flags rückverfolgt werden, und Rust-Code kann mit gängigen Profilern wie `perf` unter Linux analysiert werden.
+
+Große Neuerungen an Sprache und Standardbibliothek werden durch den [Request for Comments (RFC)][rfc]-Prozess verabschiedet, in dem das Design ausgearbeitet wird. Obwohl er öffentlich zugänglich ist handelt es sich um einen sozialen Prozess zwischen Entwicklern, die schon Erfahrung in der Zusammenarbeit haben. Wir empfehlen dir, dich dem Prozess langsam vertraut zu machen &mdash; ein vorschnell eingereichter RFC ohne ausreichendes Verständnis des historischen, technischen oder sozialen Kontextes hinter dem Problem führt leicht zu einem schlechten ersten Eindruck und Enttäuschung deinerseits. Lies am besten das oben erwähnte Readme, um mit dem Vorgehen vertraut zu werden. In der Geschichte von Rust sind schon viele Ideen diskutiert worden, viele verworfen, manche bis zu einem späteren Termin aufgeschoben, und der [RFC-Issue Tracker][rfc-issues] verwaltet einige Wunschideen die erst noch ihren Weg in die Sprache finden müssen. Kurz bevor ein RFC zur Implementierung freigegeben wird findet die _Final Comment Period_ statt, die durch das [final-comment-period][rfc-fcp]-Label im RFC-Repository gekennzeichnet wird. Ebenso findet nochmals eine [_Final Comment Period_][issue-fcp] statt, bevor ein Feature im stable-Branch des Compilers aktiviert wird (ein Vorgehen, dass als „Ungating“ bekannt ist). Beide FCPs sind kritische Zeitpunkte, um Meinungen einzubringen und die Entwicklungsrichtung der Sprache zu Beeinflussen. Sie werden im wöchentlichen Teambericht auf [internals.rust-lang.org] angekündigt.
+
+Andere Rust-Compilerentwickler kannst du in [#rustc], Sprachdesigner in [#rust-lang] und Bibliotheksentwickler in [#rust-libs] kennenlernen.
+
+<!--
+TODO: guide to compile-time benchmarking
+TODO: using the triage bot?
+TODO: some of this RFC description could probably go in the RFC readme
+-->
+
+
+[#rust-internals]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
+[#rust-lang]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-lang
+[#rust-libs]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-libs
+[#rustc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
+[A-codegen]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-codegen
+[A-debuginfo]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-debuginfo
+[A-diagnostics]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-diagnostics
+[A-libs]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-libs
+[A-macros]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-macros
+[A-optimization]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-optimization
+[A-syntaxext]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-syntaxext
+[A-typesystem]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-typesystem
+[I-ICE]: https://github.com/rust-lang/rust/labels/I-ICE
+[I-compiletime]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AI-compiletime
+[I-slow]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AI-slow
+[Rust DXR]: https://dxr.mozilla.org/rust/source/src
+[ice]: https://users.rust-lang.org/t/glacier-a-big-ol-pile-of-ice/3380
+[internals-docs]: https://manishearth.github.io/rust-internals-docs
+[internals.rust-lang.org]: https://internals.rust-lang.org/
+[issue-fcp]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AB-unstable+label%3Afinal-comment-period
+[mir]: https://github.com/rust-lang/rust/issues/27840
+[rfc-fcp]: https://github.com/rust-lang/rfcs/pulls?q=is%3Aopen+is%3Apr+label%3Afinal-comment-period
+[rfc-issues]: https://github.com/rust-lang/rfcs/issues
+[rfc]: https://github.com/rust-lang/rfcs#table-of-contents
+[rustc-guide]: https://github.com/rust-lang/rust/blob/master/src/librustc/README.md
+[rustc-perf]: http://ncameron.org/perf-rustc/
+[testsuite]: https://github.com/rust-lang/rust-wiki-backup/blob/master/Note-testsuite.md
+[tips]: https://github.com/rust-lang/rust/blob/3d1f3c9d389d46607ae28c51cc94c1f43d65f3f9/Makefile.in#L48

--- a/de-DE/contribute-docs.md
+++ b/de-DE/contribute-docs.md
@@ -1,0 +1,39 @@
+---
+layout: de-DE/default
+title: Bei Rust mitwirken &mdash; Dokumentation &middot; Die Programmiersprache Rust
+---
+
+# Bei Rust mitwirken &mdash; Dokumentation
+
+Dokumentation ist nie perfekt, und es gibt nie genug davon. Viele Aspekte der Sprache erfordern kein tiefes Verständnis um ihre Dokumentation zu verfassen, zu verbessern oder gegenzulesen. Im Gegenteil bietet das Dokumentieren eine großartige Gelegenheit, Rust zu lernen, und es ist leicht, Verbesserungsmöglichkeiten an den Dokumenten zu finden. Eine Passage ist zu umständlich formuliert? Wichtige Informationen werden nicht erwähnt? Dein Pull Request wird gerne angenommen!
+
+**Die wirkungsvollste Dokumentation, die du schreiben kannst, ist die [für Crates des Rust-Ökosystems][crate_docs]**. Während das Kernprojekt relativ gut dokumentiert ist, gilt das selbe nicht für [viele der gängigen Crates und Werkzeuge][awesome-rust], mit denen wir täglich zu tun haben. Das Verfassen von API-Dokumentation wird dir viel Dankbarkeit entgegenbringen.
+
+Das Buch [The Rust Programming Language][The book] ist das wichtigste Dokument zu Rust und wird im Hauptrepository verwaltet. Es hat sein eigenes Issue-Label, [A-book], und wird kontinuierlich verbessert. Andere wichtige Dokumentation findet sich in der [Rust-Referenz][The Rust Reference], der [Dokumentation zur Standardbibliothek][std], dem [Rustonomicon][The Rustonomicon] (einem Leitfaden zu korrektem `unsafe`-Code). Die [Rust-Stilrichtlinien][Rust Style Guidelines] sind noch so unvollständig, dass sie bisher nicht prominent angekündigt werden; hier kann ein engagierter Helfer viel erreichen. Der [Fehlerindex][err] gibt ausführlichere Erklärungen zu Compilerfehlern. Nachdem immer neue Fehlercodes hinzukommen, muss dieser Index [auf dem neuesten Stand gehalten werden][err-issue]. Die meiste Dokumentation im Rust-Repository liegt im Verzeichnis [src/doc] und wird mit dem Issue-Label [A-docs] gekennzeichnet. Zu guter Letzt wird dieses Dokument zusammen mit anderen Bestandteilen der Website im [Rust-Website-Repository][Rust website Git repository] verwaltet. Um mitzuwirken bearbeite einfach den Inhalt und stelle ein Pull Request!
+
+Ein großer Teil der Rust-Dokumentation liegt nicht im Haupt-Repository oder wird nicht vom Rust-Projekt selbst verwaltet, ist aber trotzdem unersetzlich für den Erfolg von Rust. Beispiele für solch exzellente Werke sind [Rust By Example], [Rust Design Patterns] und [rust-rosetta]. Andere derartige Projekte, bei denen du mitwirken kannst, findest du bei [rust-learning].
+
+Andere Dokumentationsbegeisterte findest du immer in [#rust-docs].
+
+<!--
+TODO: blogging, translation
+-->
+
+[#rust-docs]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-docs
+[A-book]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-book
+[A-docs]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-docs
+[Rust By Example]: https://github.com/rust-lang/rust-by-example
+[Rust Design Patterns]: https://github.com/nrc/patterns
+[Rust Style Guidelines]: https://doc.rust-lang.org/style/index.html
+[The Book]: https://doc.rust-lang.org/book/index.html
+[The Rust Reference]: https://doc.rust-lang.org/reference
+[The Rustonomicon]: https://doc.rust-lang.org/nomicon/index.html
+[awesome-rust]: https://github.com/kud1ing/awesome-rust
+[crate_docs]: https://users.rust-lang.org/t/lets-talk-about-ecosystem-documentation/2791
+[err-issue]: https://github.com/rust-lang/rust/issues/24407
+[err]: https://doc.rust-lang.org/error-index.html
+[rust-learning]: https://github.com/ctjhoa/rust-learning
+[rust-rosetta]: https://github.com/Hoverbear/rust-rosetta
+[src/doc]: https://github.com/rust-lang/rust/tree/master/src/doc
+[std]: https://doc.rust-lang.org/std/index.html
+[Rust website Git repository]: https://github.com/rust-lang/rust-www

--- a/de-DE/contribute-libs.md
+++ b/de-DE/contribute-libs.md
@@ -1,0 +1,47 @@
+---
+layout: de-DE/default
+title: Bei Rust mitwirken &mdash; Bibliotheken &middot; Die Programmiersprache Rust
+---
+
+# Bei Rust mitwirken &mdash; Bibliotheken
+
+Wenn du mit eigenem Code helfen möchtest, sind Programmbibliotheken die richtige Anlaufstelle: Nachdem Rust noch eine junge Sprache ist, existieren für eine Vielzahl an Problemstellungen noch keine oder nur unvollständige Bibliotheken.
+
+Es ist oft schwierig, ein Konzept für eine neue Bibliothek zu finden, das Reichweite hat und Freude am Entwickeln bereitet. Hier ein paar Vorschläge für die ersten Schritte:
+
+* Lies den wöchentlichen "What's everyone working on this week"-Thread auf [/r/rust] und [users.rust-lang.org] und streue deine eigenen Ideen ein. Diese Diskussionen sind voller Projektankündigungen anderer Rust-Programmierer, die noch Helfer suchen.
+* Mach' dich mit den besten Rust-Bibliotheken auf [awesome-rust] und [libs.rs] vertraut.
+* Manche größere Projekte wie der Web-Browser [Servo], die HTTP-Bibliothek [hyper], das Code-Formatierungswerkzeug [rustfmt], die Unix-Bindings [nix] und die Lintersammlung [clippy] bieten großartige Möglichkeiten, an existierendem Code mitzuarbeiten.
+* Wirke bei einer der großen Rust-Organisationen auf GitHub wie [PistonDevelopers], [servo], [redox-os], [iron], [contain-rs] oder [hyperium] mit. Es ist leicht in diesen großen Communities Platz zu finden. Diese Projekte haben oft größeren Bedarf an neuen Programmierern als rust-lang und haben erfahrene Entwickler, die dich gerne bei deinen ersten Schritten begleiten.
+* Hilf mit, Bibliotheken von [rust-lang-nursery] nach rust-lang zu bringen. Dazu gibt es leider nicht viel Dokumentation, frag einfach bei [#rust-libs] nach.
+* Sieh im RFC Issue Tracker nach [Anfragen zu neuen Community-Bibliotheken][requested].
+* Suche auf [GitHub Trending][trending] nach aktiven Rust-Projekten, die deine Hilfe brauchen.
+
+Es ist gut, wenn du als Bibliotheksentwickler mit dem [empfohlenen Vorgehen für Rust-Bibliotheken][lib-prac] vertraut bist.
+
+Andere Bibliotheksentwickler triffst du in [#rust-libs].
+
+<!--
+TODO: Not sure #rust-libs is the place to direct people
+-->
+
+[#rust-libs]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-libs
+[/r/rust]: https://reddit.com/r/rust
+[PistonDevelopers]: https://github.com/PistonDevelopers
+[Servo]: https://github.com/servo/servo
+[Servo]: https://github.com/servo/servo
+[awesome-rust]: https://github.com/kud1ing/awesome-rust
+[clippy]: https://github.com/Manishearth/rust-clippy
+[contain-rs]: https://github.com/contain-rs
+[hyper]: https://github.com/hyperium/hyper
+[hyperium]: https://github.com/hyperium
+[iron]: https://github.com/iron
+[lib-prac]: https://pascalhertleif.de/artikel/good-practices-for-writing-rust-libraries/
+[libs.rs]: http://libs.rs
+[nix]: https://github.com/nix-rust/nix/
+[redox-os]: https://github.com/redox-os
+[requested]: https://github.com/rust-lang/rfcs/labels/A-community-library
+[rust-lang-nursery]: https://github.com/rust-lang-nursery
+[rustfmt]: https://github.com/rust-lang-nursery/rustfmt
+[trending]: https://github.com/trending?l=rust
+[users.rust-lang.org]: https://users.rust-lang.org

--- a/de-DE/contribute-tools.md
+++ b/de-DE/contribute-tools.md
@@ -1,0 +1,42 @@
+---
+layout: de-DE/default
+title: Bei Rust mitwirken &mdash; Tooling, IDEs und Infrastruktur &middot; Die Programmiersprache Rust
+---
+
+# Bei Rust mitwirken &mdash; Tooling, IDEs und Infrastruktur
+
+Codewerkzeuge spielen im Erfolg einer Sprache eine große Rolle,
+und es gibt in diesem Bereich noch eine Menge Arbeit.
+**Ein großer Schwerpunkt der aktuellen Entwicklung von Rust
+ist es, [die IDE-Experience zu verbessern][ides]**.
+Dies beinhaltet Arbeit am gesamten Rust-Stack, vom Compiler selbst
+bis zu deiner Lieblings-IDE. Folge dem Link für mehr Information.
+
+Sowohl Cargo, der Paketmanager, als auch der Dokumentationsgenerator rustdoc
+sind zwar voll funktionsfähig, leiden aber an einem Entwicklermangel.
+Rustdoc hat viele offene Probleme, die im Main-Repository unter dem Label
+[A-rustdoc] gelistet sind. Es sind hauptsächlich Bugs, die lediglich einen
+Bugfix und einen Pull Request erfordern.
+Cargo hat [sein eigenes Repository mit Issue-Tracker][Cargo], und
+wer beitragen möchte, kann sich gerne in [#cargo] melden.
+
+Obwohl Rust-Programme sowohl mit den bekannten GDB- und LLDB-Debuggern eingeschränkt
+untersucht werden können, gibt es noch immer viele Fälle, in denen Debugging
+unerwartete Ergebnisse liefert oder unerwartetes Verhalten zeigt.
+Diese Fälle werden im [A-debuginfo]-Label verwaltet.
+
+Ideen für weitere Tooling-Projekte zum Mithelfen finden sich in
+[awesome-rust].
+
+Es gibt häufig andere interessante Tooling-Projekte, welche nur auf
+die richtigen Leute warten, um implementiert zu werden.
+Diese können mit anderen Tooling-Enthusiasten in
+[#rust-tools] diskutiert werden.
+
+[#cargo]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
+[#rust-tools]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-tools
+[A-debuginfo]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-debuginfo
+[A-rustdoc]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-rustdoc
+[Cargo]: https://github.com/rust-lang/cargo/issues
+[awesome-rust]: https://github.com/kud1ing/awesome-rust
+[ides]: https://forge.rust-lang.org/ides.html

--- a/de-DE/contribute-translations.md
+++ b/de-DE/contribute-translations.md
@@ -1,0 +1,8 @@
+---
+layout: de-DE/default
+title: Bei Rust mitwirken &mdash; Internationalisierung &middot; Die Programmiersprache Rust
+---
+
+# Bei Rust mitwirken &mdash; Internationalisierung
+
+_Dokumentation zu Übersetzungen_

--- a/de-DE/contribute.md
+++ b/de-DE/contribute.md
@@ -1,0 +1,65 @@
+---
+layout: de-DE/default
+title: Bei Rust mitwirken &middot; Die Programmiersprache Rust
+---
+
+# Bei Rust mitwirken
+
+Du hast begonnen, Rust zu lernen und Freude daran gefunden? Du möchtest Teil davon sein?
+Wenn du nicht sicher bist wo du beginnen sollst, kann dir diese Seite helfen.
+
+**Hast du einen Bug gefunden und willst ihn melden?** [Folge dem
+Bug-Reporting Handbuch][bugs].  Danke im Vorraus!
+
+Rust ist ein ausgedehntes System von Projekten, von denen die
+wichtigsten und bekanntesten von den [Rust Project Developers][devs] in
+[der rust-lang Organisation auf GitHub][rust-lang] gepflegt werden.
+Neulinge könnten an der Datei [CONTRIBUTING.md] des Projektes
+interessiert sein, wo die Vorgehensweise zum Beitragen zu
+[rust-lang/rust] erklärt wird.
+
+Es gibt viele Wege, zum Erfolg von Rust beizutragen.  Dieses Handbuch
+listet einige gute Anhaltspunkte auf:
+
+* [Fehler finden, sichten und beheben](contribute-bugs.html).
+  Die grundlegende Arbeit beim verwalten von großen Projekten wie Rust.
+* [Dokumentation](contribute-docs.html). Nicht nur offizielle
+  Dokumentation, sondern auch crates, blog posts, und andere
+  inoffizielle Quellen.
+* [Community-Building](contribute-community.html). Helfe dem Rustacean
+  an deiner Seite, und erweitere Rust's Einflussbereich.
+* [Tooling, IDEs und Infrastruktur](contribute-tools.html).  Die
+  wichtigen Bestandteile, welche die Nutzung einer Sprache praktisch und
+  mühelos machen.
+* [Bibliotheken](contribute-libs.html). Rust's Nutzen in einem
+  bestimmten Bereich hängt stark von der Verfügbarkeit qualitativ
+  hochwertiger Bibliotheken ab.
+* [Sprache, Compiler, und Standardbibliothek](contribute-compiler.html). Sprachdesign,
+  Feature-Implementierung, Leistungsverbesserung.
+* [Internationalisierung](contribute-translations.html). Hilf dabei, Rust
+  in der Welt bekannt zu machen, indem du es in deine Sprache übersetzt.
+
+Für weitere Fragen kannst du dich an [#rust-internals] oder
+[internals.rust-lang.org] wenden.
+
+Wir sind stolz darauf, zivilisierten Umgang miteinander zu erhalten &mdash;
+aus diesem Grund erfordern wir, dass Mithelfer unseren [Verhaltenskodex][coc] befolgen.
+Wenn du hierzu Fragen hast, wende dich an das [Community Team].
+
+<!--
+TODO: Write a guide to rust processes and governance to link from here
+TODO: List of active initiatives
+TODO: Write guide to advertising Rust projects to link from
+libs / community building
+-->
+
+[#rust-internals]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
+[CONTRIBUTING.md]: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md
+[bugs]: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md#bug-reports
+[coc]: conduct.html
+[community team]: https://www.rust-lang.org/team.html#Community
+[dev_proc]: community.html#rust-development
+[devs]: https://github.com/rust-lang/rust/graphs/contributors
+[internals.rust-lang.org]: https://internals.rust-lang.org/
+[rust-lang/rust]: https://github.com/rust-lang/rust
+[rust-lang]: https://github.com/rust-lang

--- a/de-DE/documentation.md
+++ b/de-DE/documentation.md
@@ -1,0 +1,79 @@
+---
+layout: de-DE/default
+title:  Dokumentation &middot; Die Programmiersprache Rust
+---
+
+# Dokumentation
+
+Wenn du Rust noch nie gesehen hast, solltest du zuerst einen Blick in das Buch [The Rust Programming Language][book] werfen. Es verschafft dir einen guten Überblick darüber, wie Rust funktioniert, wie du es installierst und erklärt die Syntax und die Konzepte hinter der Sprache. Wenn du dich erfolgreich durch das Buch gearbeitet hast, wirst du deine ersten Programme entwickeln können und ein gutes Grundverständnis der Ideen hinter Rust haben.
+
+# Rust lernen
+
+[The Rust Programming Language][book] (englisch). Auch bekannt als _das Buch_. The Rust Programming Language gibt eine Einführung zu den Themen, die für das Erlernen der Sprache am wichtigsten sind und ermöglicht es dir, produktiv mit Rust zu arbeiten. Es ist das wichtigste offizielle Dokument zur Sprache.
+
+[Rust By Example][rbe] (englisch). Eine Sammlung eigenständiger Beispiele in Rust zu einer Vielzahl an Themen. Die Beispielprogramme können im Browser ausgeführt werden.
+
+[Häufig gestellte Fragen][faq].
+
+[The Rustonomicon][nomicon] (englisch). Ein komplettes Buch zu `unsafe`-Code in Rust. Für fortgeschrittene Rust-Programmierer.
+
+[rust-learning]. Eine gemeinschaftlich verwaltete Sammlung an Ressourcen, um Rust zu lernen.
+
+[book]: https://doc.rust-lang.org/book/
+[rbe]: http://rustbyexample.com
+[faq]: faq.html
+[nomicon]: https://doc.rust-lang.org/nomicon/
+[rust-learning]: https://github.com/ctjhoa/rust-learning
+
+## Referenz
+
+[Standard Library API Reference][api]. Die Dokumentation der Standardbibliothek.
+
+[docs.rs]. Dokumentation für alle Crates, die auf [crates.io] veröffentlicht wurden.
+
+[The Rust Reference][ref]. Obwohl Rust keine offizielle Spezifikation besitzt, versucht die Referenz, die Funktionsweise der Sprache im Detail zu beschreiben. Einige der Punkte sind von Zeit zu Zeit veraltet.
+
+[Syntax Index][syn]. Dieser Anhang von The Rust Programming Language beinhaltet alle Syntaxbeispiele mit Querverweisen auf die entsprechenden Abschnitte im Buch.
+
+[The Cargo Guide][cargo]. Dokumentation für Cargo, den Paketmanager von Rust.
+
+[Compiler Error Index][err]. Detaillierte Erklärungen zu Fehlermeldungen, die der Rust-Compiler liefert.
+
+[Release Notes][release_notes]. Die Änderungen zwischen jeder veröffentlichten Rust-Version.
+
+[Platform Support][platform_support]. Eine Auflistung aller unterstützter Plattformen.
+
+[api]: https://doc.rust-lang.org/std/
+[syn]: https://doc.rust-lang.org/book/syntax-index.html
+[ref]: https://doc.rust-lang.org/reference
+[cargo]: http://doc.crates.io/guide.html
+[err]: https://doc.rust-lang.org/error-index.html
+[release_notes]: https://github.com/rust-lang/rust/blob/stable/RELEASES.md
+[docs.rs]: https://docs.rs
+[crates.io]: https://crates.io
+[platform_support]: https://forge.rust-lang.org/platform-support.html
+
+## Projektrichtlinien
+
+[Sicherheitsrichtlinien][security]. Die Richtlinien des Projekts zum Berichten, Beheben und Veröffentlichen sicherheitsrelevanter Bugs.
+
+[Richtlinien zu Urheber- und Markenrecht][legal]. Das Urheberrecht an Rust liegt bei den Entwicklern, und die Markenrechte bei Mozilla. Sachgemäße Benutzung der Markenrechte wird hier beschrieben.
+
+[Verhaltenskodex][coc]. Bezieht sich auf die `rust-lang`-Organisation auf GitHub, die offiziellen Foren, IRC-Kanäle und andere Plattformen der Rust-Community.
+
+[security]: security.html
+[legal]: legal.html
+[coc]: https://www.rust-lang.org/conduct.html
+
+## Dokumentation zu Nightly- und Betaversionen
+
+Ein Großteil der offiziellen Dokumentation ist neben den Dokumenten zur stabilen Version oben auch für die [Nightly][nightly]- und [Betaversionen][beta] erhältlich.
+
+[nightly]: https://doc.rust-lang.org/nightly/
+[beta]: https://doc.rust-lang.org/beta/
+
+## Ressourcen in anderen Sprachen
+
+Ressourcen in anderen Sprachen als Englisch findest du im entsprechenden Abschnitt bei [rust-learning][locale].
+
+[locale]: https://github.com/ctjhoa/rust-learning#locale-links

--- a/de-DE/downloads.html
+++ b/de-DE/downloads.html
@@ -1,0 +1,5 @@
+<!DOCTYPE HTML>
+
+<head>
+  <meta http-equiv="refresh" content="0; url=install.html">
+<head>

--- a/de-DE/faq.md
+++ b/de-DE/faq.md
@@ -1,0 +1,1648 @@
+---
+layout: de-DE/faq
+title: Häufig gestellte Fragen &middot; Die Programmiersprache Rust
+---
+
+# Häufig gestellte Fragen
+
+<p class="faq-intro">
+Auf dieser Seite werden häufig gestellte Fragen über die Programmiersprache Rust beantwortet. Die Seite ist keine vollständige Anleitung und zum Lernen der Sprache ungeeignet. Sie versucht, Antworten auf Fragen zu geben, welche in der Rust-Community immer wieder aufgetreten sind, und verdeutlicht einige Überlegungen hinter den Design-Entscheidungen zu Rust.
+</p>
+
+<p class="faq-intro">
+Wenn dir auffällt, dass hier eine wichtige oder verbreitete Frage fehlt, dann <a href="https://github.com/rust-lang/rust-www/blob/master/CONTRIBUTING.md">hilf uns, das zu ändern</a>.
+</p>
+
+<div id="toc">
+    <h2>Inhaltsverzeichnis</h2><a href="#toggle-toc"></a>
+    <div class="contents">
+        <ol id="toc-contents">
+            <li><a href="#project">Das Rust-Projekt</a></li>
+            <li><a href="#performance">Performance</a></li>
+            <li><a href="#syntax">Syntax</a></li>
+            <li><a href="#numerics">Arithmetik</a></li>
+            <li><a href="#strings">Strings</a></li>
+            <li><a href="#collections">Collections</a></li>
+            <li><a href="#ownership">Ownership</a></li>
+            <li><a href="#lifetimes">Lifetimes</a></li>
+            <li><a href="#generics">Generics</a></li>
+            <li><a href="#input-output">Eingabe / Ausgabe</a></li>
+            <li><a href="#error-handling">Fehlerbehandlung</a></li>
+            <li><a href="#concurrency">Nebenläufigkeit</a></li>
+            <li><a href="#macros">Makros</a></li>
+            <li><a href="#debugging">Debugging und Tooling</a></li>
+            <li><a href="#low-level">Low-Level</a></li>
+            <li><a href="#cross-platform">Cross-Platform</a></li>
+            <li><a href="#modules-and-crates">Module und Crates</a></li>
+            <li><a href="#libraries">Bibliotheken</a></li>
+            <li><a href="#design-patterns">Entwurfsmuster</a></li>
+            <li><a href="#other-languages">Andere Sprachen</a></li>
+            <li><a href="#documentation">Dokumentation</a></li>
+        </ol>
+    </div>
+</div>
+
+
+<h2 id="project">Das Rust-Projekt</h2>
+
+<h3><a href="#what-is-this-projects-goal" name="what-is-this-projects-goal">
+Was ist das Ziel des Rust-Projekts?
+</a></h3>
+
+Das Ziel des Rust-Projekts ist es, eine sichere, nebenläufige und praktikable Systemsprache zu implementieren.
+
+Rust existiert, weil andere, ähnlich abstrakte und effiziente Sprachen folgende Erwartungen nicht erfüllen:
+
+1. Es wird zu wenig auf Sicherheit geachtet.
+2. Die Unterstützung für Nebenläufigkeit ist mangelhaft.
+3. Für manche Sprachmerkmale gibt es keine praktische, einleuchtende Benutzung.
+4. Es gibt nur eingeschränkte Kontrolle über Ressourcen.
+
+Rust existiert als eine Alternative, welche sowohl effizienten Code als auch ein komfortables Abstraktionsniveau bietet, und dabei für jeden dieser vier Punkte Verbesserungen vorschlägt.
+
+<h3><a href="#is-this-project-controlled-by-mozilla" name="is-this-project-controlled-by-mozilla">
+Wird dieses Projekt von Mozilla kontrolliert?
+</a></h3>
+
+Nein. Im Jahr 2006 startete Graydon Hoare Rust als Teilzeitprojekt, und so blieb es für 3 Jahre. Erst als Rust 2009 die nötige Reife erreichte, um Kernkonzepte anhand einfacher Tests zu demonstrieren, beteiligte sich Mozilla. Rust wird vorrangig von Mozilla unterstützt, aber eine vielfältige, enthusiastische Community in der ganzen Welt arbeitet daran. Das [Rust-Team](https://www.rust-lang.org/team.html) besteht sowohl aus Mitarbeitern von Mozilla als auch aus unabhängigen Mitgliedern, und `rust` auf GitHub hatte bisher schon über [1,500 verschiedene Mitwirkende](https://github.com/rust-lang/rust/).
+
+Die [Führung des Projektes](https://github.com/rust-lang/rfcs/blob/master/text/1068-rust-governance.md) besteht aus einem Kernteam, welches die Vision und die Prioritäten festlegt und das Projekt von einer globalen Perspektive aus leitet. Es gibt auch kleinere Teams, welche sich um die Entwicklung bestimmter Interessenbereiche kümmern. Das können zum Beispiel der Kern der Sprache, der Compiler, Rust-Bibliotheken, Tooling oder die Moderation der offiziellen Rust-Communities sein. Fortschritt in jedem dieser Bereiche wird über einen [RFC-Prozess](https://github.com/rust-lang/rfcs) erreicht. Änderungen, für welche kein RFC notwendig ist, werden normalerweise in einer Pull Request im [`rustc` Repository](https://github.com/rust-lang/rust) diskutiert.
+
+<h3><a href="#what-are-some-non-goals" name="what-are-some-non-goals">
+Welche Ziele werden nicht angestrebt?
+</a></h3>
+
+1. Wir verwenden keine besonders modernen Technologien. Alte, etablierte Technologien sind besser.
+2. Ausdrucksstärke, Minimalismus oder Eleganz sind wünschenswerte, aber untergeordnete Ziele.
+3. Wir beabsichtigen nicht, alle Eigenschaften und Möglichkeiten von C++ oder anderen Sprachen abzudecken. Rust sollte die häufigsten Fälle abdecken.
+4. Wir beabsichtigen nicht, 100% statisch, 100% sicher, 100% reflektiv oder zu dogmatisch in irgendeiner anderen Hinsicht zu sein. Es gibt Kompromisse.
+5. Wir zielen nicht darauf ab, dass Rust auf jeder möglichen Plattform läuft. Rust soll ohne unnötige Kompromisse auf üblichen, verbreiteten Hardware- und Softwareplattformen laufen.
+
+<h3><a href="#how-does-mozilla-use-rust" name="how-does-mozilla-use-rust">
+In welchen Projekten nutzt Mozilla Rust?
+</a></h3>
+
+Hauptsächlich wird Rust in [Servo](https://github.com/servo/servo), einer experimentellen Browser Engine, an welcher Mozilla arbeitet, verwendet. Mozilla arbeitet auch daran, weitere Rust-Komponenten [in Firefox zu integrieren](https://bugzilla.mozilla.org/show_bug.cgi?id=1135640).
+
+<h3><a href="#what-examples-are-there-of-large-rust-projects" name="what-examples-are-there-of-large-rust-projects">
+Welche großen Rust-Projekte gibt es?
+</a></h3>
+
+Die zwei im Moment größten quelloffenen Rust-Projekte sind [Servo](https://github.com/servo/servo) und der [Rust-Compiler](https://github.com/rust-lang/rust) selbst.
+
+<h3><a href="#who-else-is-using-rust" name="who-else-is-using-rust">
+Wer benutzt sonst noch Rust?
+</a></h3>
+
+[Eine wachsende Zahl von Organisationen!](friends.html)
+
+<!--
+### What projects are good examples of idiomatic Rust code?
+
+TODO: Write this answer.
+-->
+
+<h3><a href="#how-can-i-try-rust-easily" name="how-can-i-try-rust-easily">
+Wie kann ich Rust einfach ausprobieren?
+</a></h3>
+
+Der einfachste Weg, Rust auszuprobieren, ist der [Playpen](https://play.rust-lang.org/) - eine Online-Applikation, in welcher man einfach Rust-Code schreiben und Ausführen kann. Wenn du Rust auf deinem eigenen System ausprobieren willst, [installiere es](https://www.rust-lang.org/install.html) und gehe das [Guessing Game](https://doc.rust-lang.org/stable/book/guessing-game.html)-Tutorial im Buch durch.
+
+<h3><a href="#how-do-i-get-help-with-rust-issues" name="how-do-i-get-help-with-rust-issues">
+Wie bekomme ich bei Problemen mit Rust Hilfe?
+</a></h3>
+
+Es gibt viele Wege. Du kannst:
+
+- Einen Forenpost im offiziellen Rust User Forum [users.rust-lang.org](https://nsers.rust-lang.org/) absetzen.
+- Im offiziellen [Rust-IRC-Kanal](https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust) (#rust on irc.mozilla.org) eine Frage stellen.
+- Auf [Stack Overflow](https://stackoverflow.com/questions/tagged/rust) eine Frage stellen (denke daran, sie mit dem „rust“-Tag zu markieren!).
+- Im inoffiziellen Rust-Subreddit [/r/rust](https://www.reddit.com/r/rust) posten.
+
+<h3><a href="#why-has-rust-changed-so-much" name="why-has-rust-changed-so-much">
+Warum hat sich Rust über die Zeit so stark verändert?
+</a></h3>
+
+Das ursprüngliche Ziel von Rust war es, eine sichere, aber einfach zu benutzende Systemprogrammiersprache zu erstellen.
+Um dieses Ziel zu erreichen, verfolgte Rust eine Vielzahl von Ideen, von denen es manche behielt (Lifetimes, Traits) und andere wieder verwarf (das Typestate-System oder Green Threading). Außerdem wurde ein großer Teil der Rust-Standardbibliothek vor der Veröffentlichung der Version 1.0 neu geschrieben, um mithilfe der Features von Rust eine qualitativ hochwertige, konsistente, plattformübergreifende API anzubieten. Jetzt, wo Rust die Version 1.0 erreicht hat, wird die Stabilität der Sprache garantiert. Obwohl sich die Sprache weiter entwickelt wird Code, der auf aktuellen Versionen von Rust funktioniert, auch in zukünftigen Versionen des Compilers gültig sein.
+
+<h3><a href="#how-does-rust-language-versioning-work" name="how-does-rust-language-versioning-work">
+Wie funktioniert Versionierung in Rust?
+</a></h3>
+
+Die Sprachversionierung von Rust folgt [SemVer](http://semver.org/). Änderungen an stabilen APIs, welche die Abwärtskompatibilität nicht gewährleisten, sind in _minor_-Versionen nur erlaubt, wenn sie Fehler oder Sicherheitslücken im Compiler beheben, oder wenn die Änderungen weitere Annotationen für Dispatch oder Typinferenz erforderlich machen. Weitere, detailreichere Richtlinien für _minor_-Versionsänderungen sind als genehmigte RFCs sowohl für die [Sprache](https://github.com/rust-lang/rfcs/blob/master/text/1122-language-semver.md) als auch die [Standardbibliotheken](https://github.com/rust-lang/rfcs/blob/master/text/1105-api-evolution.md) zu finden.
+
+Es gibt drei Veröffentlichungskanäle für Rust: Stable, Beta, und Nightly. Die Kanäle Stable und Beta werden alle sechs Wochen aktualisiert, wobei der aktuelle Nightly zur neuen Beta und die aktuelle Beta das neue Stable wird. Teile der Standardbibliotheken sind als _unstable_ markiert oder durch _Feature Gates_ abgeschirmt. Diese können ausschließlich im Nightly-Kanal verwendet werden. Neue Features sind solange als _unstable_ markiert, bis das Kernteam und zuständige Unterteams ihre Zustimmung zur Freigabe gegeben haben. Diese Herangehensweise erlaubt es Entwicklern, zu experimentieren, ohne die Garantie auf Abwärtskompatibilität zu gefährden.
+
+Mehr Details finden sich im Blogpost ["Stability as a Deliverable"](http://blog.rust-lang.org/2014/10/30/Stability.html).
+
+<h3><a href="#can-i-use-unstable-features-on-the-beta-or-stable-channel" name="can-i-use-unstable-features-on-the-beta-or-stable-channel">
+Kann ich auf dem Beta- oder Stable Channel Features aus dem Unstable Channel verwenden?
+</a></h3>
+
+Nein, das ist unmöglich. An Rust wird hart gearbeitet, um die Stabilität der Beta- und Stable Kanäle zu gewährleisten. Wir wollen nicht, dass sich jemand auf unstabile Features verlässt, für welche wir keine Stabilität gewährleisten und welche sich jederzeit ändern könnten. Das gibt uns auch die Möglichkeit, Änderungen im Nightly-Kanal realistisch auszutesten, während der Beta- und Stable Kanal stabil und unverändert bleiben.
+
+Alle sechs Wochen werden die Beta- und Stable Kanäle mit den stabilisierten Features aktualisiert. Im Nightly-Kanal gibt es häufig stabilisierende Updates, während die anderen Kanäle seltener Fixes akzeptieren. Wenn du darauf wartest, dass ein Feature im Beta- oder Stable Kanal bereitgestellt wird, dann kannst du die zugehörige Issue mit dem Tag [`B-unstable`](https://github.com/rust-lang/rust/issues?q=is%3Aissue+is%3Aopen+tracking+label%3AB-unstable) auf dem Issue Tracker finden.
+
+<h3><a href="#what-are-feature-gates" name="what-are-feature-gates">
+Was sind Feature Gates?
+</a></h3>
+
+_Feature Gates_ sind der Sprachmechanismus, den Rust verwendet, um Features des Compilers, der Sprache und der Standardbibliotheken zu stabilisieren. Ein Feature hinter einem _Gate_ ist nur im Nightly-Kanal verfügbar, und auch nur dann, wenn es explizit durch ein `#[feature]`-Attribut oder das Kommandozeilenargument `-Z unstable-options` angefordert wurde. Wenn ein Feature stabilisiert und in den Stable-Kanal übernommen wird, muss es nicht mehr explizit angefordert werden. Dann wird dieses Feature als _ungated_ bezeichnet. Feature Gates erlauben es den Entwicklern, zu experimentieren, während sie in der Entwicklung sind. Erst wenn die Entwickler sich auf eine Implementierung festlegen, halten die Features in der stabilen Sprache Einzug.
+
+<h3><a href="#why-a-dual-mit-asl2-license" name="why-a-dual-mit-asl2-license">
+Warum eine MIT-ASL2 Doppellizenz?
+</a></h3>
+
+Die Apache-Lizenz enthält wichtigen Schutz gegen Patentaggressoren, aber ist mit der GPLv2 inkompatibel. Um Probleme bei der Verwendung von Rust mit der GPLv2-Lizenz zu vermeiden, ist es alternativ MIT-lizenziert.
+
+<h3><a href="#why-a-permissive-license" name="why-a-permissive-license">
+Warum eine BSD-artige Freizügige Lizenz anstelle von MPL oder einer dreifachen Lizenz?
+</a></h3>
+
+Das liegt zu einem Teil an einer persönlichen Vorliebe des originalen Entwicklers Graydon Hoare, zum anderen daran, dass Programmiersprachen im Gegensatz zu Produkten wie Webbrowsern normalerweise einen weiter gefächerten Einflussbereich und ein vielseitigeres Einsatzgebiet haben. Wir würden gerne möglichst viele dieser potenziellen Mitwirkenden anziehen.
+
+<h2 id="performance">Performance</h2>
+
+<h3><a href="#how-fast-is-rust" name="how-fast-is-rust">
+Wie schnell ist Rust?
+</a></h3>
+
+Sehr schnell! Rust kann sich bereits in einigen Benchmarks (zu Beispiel dem [Benchmarks Game](https://benchmarksgame.alioth.debian.org/u64q/compare.php?lang=rust&lang2=gpp) und [anderen](https://github.com/kostya/benchmarks)) mit idiomatischem C und C++ Code messen.
+
+Eins der wichtigsten Prinzipien in Rust (wie auch in C++) sind [Zero-Cost Abstractions](http://blog.rust-lang.org/2015/05/11/traits.html): Keine der Abstraktionen in Rust verursachen programmweite Verlangsamungen oder einen Mehraufwand zur Laufzeit.
+
+Da Rust auf LLVM aufbaut und deshalb auch versucht, Clang-kompatiblen Code zu generieren, sind Leistungsverbesserungen in LLVM auch für Rust vorteilhaft. Langfristig sollten die detaillierten Informationen des Typsystems Optimierungen ermöglichen, welche in C/C++ unmöglich wären.
+
+<h3><a href="#is-rust-garbage-collected" name="is-rust-garbage-collected">
+Gibt es in Rust einen Garbage Collector?
+</a></h3>
+
+Nein. Eine der Schlüsselinnovationen von Rust ist es, *ohne* Garbage Collection Speichersicherheit (keine Segfaults) zu garantieren.
+
+Rust erlangt dadurch einige Vorteile: Vorhersagbare Bereinigung von Ressourcen, niedrige Mehrkosten für Speichermanagement und ein minimales Laufzeitsystem. Diese Eigenschaften ermöglichen es, Rust in beliebige Umgebungen einzubinden, und vereinfachen die [Integration von Rust in Sprachen mit GC](http://calculist.org/blog/2015/12/23/neon-node-rust/).
+
+Das Ownership und Borrowing System ermöglicht nicht nur Speichersicherheit ohne einen GC, sondern ist auch in anderen Zusammenhängen nützlich, zum Beispiel für [allgemeines Ressourcenmanagement](http://blog.skylight.io/rust-means-never-having-to-close-a-socket/) und [Nebenläufigkeit](http://blog.rust-lang.org/2015/04/10/Fearless-Concurrency.html).
+
+In Fällen, in denen einfache Ownership-Semantik nicht genügt, nutzen Rust-Programme den üblichen Referenzzähler/_Smart Pointer_-Typ [`Rc`](https://doc.rust-lang.org/std/rc/struct.Rc.html) und sein Thread-sicheres Gegenstück [`Arc`](https://doc.rust-lang.org/std/sync/struct.Arc.html).
+
+Es wird jedoch daran gearbeitet, in Zukunft einen *optionalen* Garbage Collector als Erweiterung anzubieten, um eine gute Integration mit Laufzeitumgebungen wie [Spidermonkey](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey)
+und [V8](https://developers.google.com/v8/?hl=en) zu ermöglichen, welche Garbage Collection verwenden.
+
+Es gibt auch experimentelle, in [purem Rust implementierte Kollektoren](https://manishearth.github.io/blog/2015/09/01/designing-a-gc-in-rust/), welche ohne Unterstützung des Compilers funktionieren.
+
+<h3><a href="#why-is-my-program-slow" name="why-is-my-program-slow">
+Warum ist mein Programm so langsam?
+</a></h3>
+
+Der Rust-Compiler optimiert Programme nur dann, wenn man das explizit anfordert, da [Optimierungen die Kompiliergeschwindigkeit verringern und allgemein während der Entwicklung unerwünscht sind](https://users.rust-lang.org/t/why-does-cargo-build-not-optimise-by-default/4150/3).
+
+Wenn du mit `cargo` kompilierst, nutze die `--release` option. Wenn du dein Program direkt mit `rustc` erstellst, nutze die Option `-O`. Beide Optionen schalten Optimierungen ein.
+
+<h3><a href="#why-is-rustc-slow" name="why-is-rustc-slow">
+Warum ist die Erstellung meines Programmes so zeitaufwändig?
+</a></h3>
+
+Rustc übersetzt und optimiert Code. Die High-Level-Abstraktionen in Rust kompilieren zu effizientem Maschinencode, und um diese Übersetzungen durchzuführen, wird Zeit benötigt - insbesondere beim Optimieren.
+
+Die Übersetzungszeit ist jedoch besser als sie scheint und es gibt Anlass zur Hoffnung, dass sie sich noch verbessern wird. Kompilierzeiten von ähnlich umfangreichen Rust- und C++ Projekten sind im Allgemeinen miteinander vergleichbar.
+
+Die häufige Auffassung, dass Rust langsam kompiliert, kommt zum Großteil aus dem Unterschied zwischen dem *Kompiliermodell* von C++ und Rust: Eine Kompiliereinheit in C++ ist eine Datei, während in Rust immer ein gesamter Crate kompiliert wird, welche aus vielen Dateien bestehen kann. Eine einzelne Datei während der Entwicklung zu verändern führt in C++ normalerweise zu weniger Rekompilation als in Rust. Es wird derzeit viel Arbeit in [inkrementelle Programmerstellung](https://github.com/rust-lang/rfcs/blob/master/text/1298-incremental-compilation.md) investiert, welche die Vorteile des Modells von C++ in Rust übernimmt.
+
+Neben dem Kompilationsmodell gibt es andere Aspekte des Sprachdesigns und der Compilerimplementation, welche die Übersetzungsleistung beeinflussen.
+
+Rust hat zunächst ein relativ komplexes Typsystem, und der Compiler muss einige Zeit darauf verwenden, die Typbedingungen zu überprüfen, welche Rust zur Laufzeit absichern.
+
+Außerdem sind einige Teile des Rust-Compilers ziemlich veraltet. Diese generieren insbesondere LLVM-IR niedriger Qualität, welche LLVM erst „reparieren“ muss. Es gibt Hoffnung, dass zukünftige, [MIR-basierte](https://github.com/rust-lang/rfcs/blob/master/text/1211-mir.md) Übersetzungs- und Optimierungsdurchläufe die Arbeit für LLVM leichter machen.
+
+Drittens hat die Nutzung von LLVM auch ihre Kosten: Rust hat dadurch hohe Leistung zur Laufzeit, aber LLVM ist ein großes Framework das nicht auf hohe Leistung zur Übersetzungszeit fokussiert ist, insbesondere bei Eingaben mit mangelhafter Qualität.
+
+Letztlich führt auch die übliche Strategie der Monomorphisierung von Generics (wie in C++) zwar zu schnellem Code zur Laufzeit, aber sie erfordert die Erzeugung von Signifikant mehr Code als andere Strategien. Durch die Verwendung von Trait-Objekten können Rust-Programmierer diese Aufblähung vermeiden, müssen dann aber auf späte Bindung mit ihren bekannten Nachteilen zurückgreifen.
+
+<h3><a href="#why-are-rusts-hashmaps-slow" name="why-are-rusts-hashmaps-slow">
+Warum ist die <code>HashMap</code> in Rust so langsam?
+</a></h3>
+
+Standardmäßig nutzt [`HashMap`][HashMap] den [SipHash](https://131002.net/siphash/)-Algorithmus, der entworfen wurde, um [Kollisionsattacken auf Hashtabellen](http://programmingisterrible.com/post/40620375793/hash-table-denial-of-service-attacks-revisited) zu verhindern und dabei trotzdem [für die häufigsten Anwendungsfälle gute Leistung](https://www.reddit.com/r/rust/comments/3hw9zf/rust_hasher_comparisons/cub4oh6) zu erzielen.
+
+Obwohl SipHash [in vielen Fällen hohe Leistung vorweisen kann](http://cglab.ca/%7Eabeinges/blah/hash-rs/), ist der Algorithmus für Anwendungsfälle mit kurzen Schlüsseln wie Ganzzahlen merklich langsamer. Deshalb wird von Rust-Programmierern häufig niedrige Leistung bei der Verwendung einer [`HashMap`][HashMap] beobachtet. In solchen Fällen wird häufig der [FNV-Hasher](https://crates.io/crates/fnv) empfohlen, der aber nicht die Kollisionsresistenz von SipHash vorweisen kann.
+
+<h3><a href="#why-is-there-no-integrated-benchmarking" name="why-is-there-no-integrated-benchmarking">
+Warum gibt es keine integrierte Benchmarking-Infrastruktur?
+</a></h3>
+
+Es gibt eine, welche aber nur im Nightly-Kanal verfügbar ist. Wir planen ein modulares System, welches integrierte Leistungstests ermöglicht. In der Zwischenzeit wird das System als [instabil](https://github.com/rust-lang/rust/issues/29553) eingeschätzt.
+
+<h3><a href="#does-rust-do-tail-call-optimization" name="does-rust-do-tail-call-optimization">
+Unterstützt Rust Tail Call Elimination?
+</a></h3>
+
+Im Allgemeinen nicht. Optimierung von Endrekursion kann unter [bestimmten Vorraussetzungen](http://llvm.org/docs/CodeGenerator.html#sibling-call-optimization) erfolgen, das ist aber [nicht gewährleistet](https://mail.mozilla.org/pipermail/rust-dev/2013-April/003557.html). Da die Optimierung ein vielfach erwünschtes Sprachmerkmal ist, wurde das Schlüsselwort `become` dafür reserviert, wobei allerdings die technische Umsetzbarkeit noch nicht geklärt ist. Eine [vorgeschlagene Erweiterung](https://github.com/rust-lang/rfcs/pull/81), welche Tail Call Elimination ermöglichen würde, wurde vorgeschlagen, zunächst aber verschoben.
+
+<h3><a href="#does-rust-have-a-runtime" name="does-rust-have-a-runtime">
+Hat Rust ein Laufzeitsystem?
+</a></h3>
+
+Nicht im Sinne von gängigen Sprachen wie Java. Teile der Standardbibliotheken könnte man als "Laufzeitsystem" bezeichnen, die einen Heap, Backtraces, Unwinding, und Stack Guards anbietet. Eine relativ [kleine Menge Initialisierungscode](https://github.com/rust-lang/rust/blob/33916307780495fe311fe9c080b330d266f35bfb/src/libstd/rt.rs#L43) läuft vor der `main`-Funktion des Benutzers. Die Standardbibliotheken linken außerdem gegen die C-Standardbibliotheken, welche ebenfalls eine ähnliche [Laufzeitinitialisierung](http://www.embecosm.com/appnotes/ean9/html/ch05s02.html) vornehmen. Rust kann ohne die Standardbibliotheken kompiliert werden, dann ist die Laufzeitumgebung äquivalent zu der von C.
+
+<h2 id="syntax">Syntax</h2>
+
+<h3><a href="#why-curly-braces" name="why-curly-braces">
+Warum geschwungene Klammern? Warum kann die Syntax von Rust nicht Haskell oder Python ähnlicher sein?
+</a></h3>
+
+Die Benutzung geschweifter Klammern ist eine Entwurfsentscheidung, welche eine Vielzahl von Programmiersprachen getroffen haben. Da Rust hier konsistent bleibt, ist es für in anderen Sprachen erfahrene Programmierer einfacher zu lernen.
+
+Geschweifte Klammern ermöglichen dem Programmierer eine flexible Syntax und dem Kompilierer einen einfacheren Parser.
+
+<h3><a href="#why-brackets-around-blocks" name="why-brackets-around-blocks">
+Ich kann die Klammern um <code>if</code>-Bedingungen weglassen, warum muss ich sie dann um einzeilige Blöcke setzen? Warum ist der C-Stil nicht erlaubt?
+</a></h3>
+
+Während C Klammerung um ein `if`-Statement aber keine Klammern für einzeilige Blöcke erfordert, trifft Rust die genau entgegengesetzte Wahl. Das trennt die Bedingung klar vom Block und vermeidet die Gefahren der optionalen Klammern, welche zu leicht übersehbaren Fehlern wie Apples [goto-fail-Bug](https://gotofail.com/) führen können.
+
+<h3><a href="#why-no-literal-syntax-for-dictionaries" name="why-no-literal-syntax-for-dictionaries">
+Warum gibt es keine Syntax für Dictionary-Literale?
+</a></h3>
+
+Die bevorzugte Vorgehensweise beim Entwurf von Rust war es, die *Sprache* selbst relativ klein zu halten und dafür mächtige *Bibliotheken* anzubieten. Rust bietet zwar Literale zur Initialisierung von Arrays und Strings an, aber diese sind die einzigen in die Sprache eingebauten Collection-Typen. Andere, in Bibliotheken definierte Typen, wie zum Beispiel der häufig genutzte [`Vec`][Vec] Collection-Typ erlauben die Initialisierung durch Makros wie [`vec!`][VecMacro].
+
+In der Zukunft wird die Design-Entscheidung, Makros zum Initialisieren von Datenstrukturen zu verwenden, wahrscheinlich auf weitere Datentypen erweitert werden. Zusätzlich zu [`HashMap`][HashMap] und [`Vec`][Vec] sollen Typen wie [`BTreeMap`][BTreeMap] unterstützt werden. Wenn du jetzt schon komfortablere Syntax zur Initialisierung von Datenstrukturen benötigst, kannst du dafür [dein eigenes Makro definieren](https://stackoverflow.com/questions/27582739/how-do-i-create-a-hashmap-literal).
+
+<h3><a href="#when-should-i-use-an-implicit-return" name="when-should-i-use-an-implicit-return">
+Wann sollte ich ein implizites Return verwenden?
+</a></h3>
+[comment]: <> (Ich finde, hier wird zu wenig auf den Unterschied, den ein Semikolon macht (insbesondere im Ggs. zu anderen Sprachen) eingegangen. Allgemein könnte man hier den Unterschied zwischen Ausdruck und Statement erklären. Upstream?)
+Rust ist eine stark Ausdruck-orientierte Sprache, und _implizite Returns_ gehören zu diesem Design. Konstrukte wie `if`, `match`, oder normale Blöcke sind in Rust Ausdrücke. Der folgende Programmcode testet zum Beispiel, ob ein [`i64`][i64] ungerade ist und liefert das Ergebnis mit einem impliziten Return zurück.
+
+```rust
+fn is_odd(x: i64) -> bool {
+    if x % 2 != 0 { true } else { false }
+}
+```
+
+Das kann natürlich weiter vereinfacht werden:
+
+```rust
+fn is_odd(x: i64) -> bool {
+    x % 2 != 0
+}
+```
+
+In beiden Beispielen ist die letzte Zeile der Rückgabewert der Funktion. Ein wichtiges Detail ist, dass der Rückgabetyp einer Funktion, welche mit einem Semikolon endet, `()` ist. Dies deutet an, dass kein Wert zurückgegeben wird. Implizite Rückgaben funktionieren nur ohne abschließendes Semikolon, da sonst der Wert des Ausdrucks unterdrückt wird.
+
+Explizite Rückgaben müssen dann benutzt werden, wenn implizite unmöglich sind, zum Beispiel wenn man vor dem Ende des Funktionskörpers einen Wert zurückgeben will. Beide Funktionen im obigen Beispiel hätten mit einem `return` und einem Semikolon geschrieben werden können, aber das wäre unnötig ausführlich und gegen die Konventionen von gutem Rust-Code.
+
+<h3><a href="#why-arent-function-signatures-inferred" name="why-arent-function-signatures-inferred">
+Warum werden Funktionssignaturtypen nicht vom Compiler hergeleitet?
+</a></h3>
+
+Deklarationen in Rust werden normalerweise mit expliziten Typannotationen versehen, während der eigentliche Programmcode mit inferierten Typen arbeitet. Diese Entscheidung ist folgendermaßen begründet:
+
+- Erforderliche Signaturdeklarationen helfen, die Stabilität von Schnittstellen in Modulen und Crates zu gewährleisten.
+- Signaturtypen erleichtern dem Programmierer das Verständnis des Programms. Dadurch, dass die Signaturtypen immer explizit lokal im Programm definiert sind, muss eine IDE keinen Inferenzalgorithmus über den gesamten Crate laufen lassen, um den Typ eines Argumentes herauszufinden.
+- Da die Argumenttypen auf Funktionsebene festgelegt sind, kann der Inferenzalgorithmus stark vereinfacht werden.
+
+<h3><a href="#why-does-match-have-to-be-exhaustive" name="why-does-match-have-to-be-exhaustive">
+Warum muss ein <code>match</code> alle Fälle abdecken?
+</a></h3>
+
+Um Klarheit zu schaffen und Refactoring zu vereinfachen.
+
+Erstens: wenn ein `match` jeden Fall eines `enum`s abdeckt, führt das zukünftige Hinzufügen einer Variante zu einem Kompilierfehler und nicht einem Fehler zur Laufzeit. Diese Hilfe durch den Kompilierer ermöglicht es dem Rust-Programmierer, zu Refakturisieren, ohne neue Fehler befürchten zu müssen.
+
+Zweitens: abdeckende Prüfung aller Fälle expliziert die Semantik des default-Falles. Allgemein wäre ein nicht-abdeckendes `match` nur sicher, wenn der Thread im Fall einer unvorhergesehenen Variante ein `panic` auslösen würde. In frühen Versionen von Rust, in denen `match` nicht zwingend alle Fälle abdecken musste, wurde dies als Ursache für viele Fehler befunden.
+
+Mit `_` kannst du einfach alle weiteren, unspezifizierten Fälle ignorieren:
+
+```rust
+match val.do_something() {
+    Cat(a) => { /* ... */ }
+    _      => { /* ... */ }
+}
+```
+
+<h2 id="numerics">Arithmetik</h2>
+
+<h3><a href="#which-type-of-float-should-i-use" name="which-type-of-float-should-i-use">
+Soll ich für mathematische Operationen mit Gleitkommazahlen <code>f32</code> oder <code>f64</code> verwenden?
+</a></h3>
+
+Diese Wahl hängt vom Zweck des Programmes ab.
+
+Wenn du für deine Gleitkommazahlen die größtmögliche Genauigkeit benötigst, dann nutze [`f64`][f64]. Wenn du Speicher- oder Rechenzeiteffizienz benötigst und dafür Abstriche in der Genauigkeit machen kannst (da du pro Wert weniger Bits zur Darstellung zur Verfügung hast), dann ist [`f32`][f32] besser. Auch auf 64-Bit Hardware sind Operationen mit [`f32`][f32] normalerweise schneller. Ein häufiges Beispiel findet man in der Grafikprogrammierung: hier wird typischerweise [`f32`][f32] verwendet, da hohe Leistung nötig ist und 32-Bit Gleitkommazahlen zur Darstellung von Pixeln auf dem Bildschirm ausreichen.
+
+Wähle im Zweifel [`f64`][f64], um bessere Präzision zu erreichen.
+
+<h3><a href="#why-cant-i-compare-floats" name="why-cant-i-compare-floats">
+Warum kann ich keine Gleitkommazahlen vergleichen oder sie als Schlüsseltypen für <code>HashMap</code> oder <code>BTreeMap</code> verwenden?
+</a></h3>
+
+Gleitkommazahlen können mit den Operatoren `==`, `!=`, `<`, `<=`, `>`, `>=`, sowie mit der Funktion `partial_cmp()` verglichen werden. `==` and `!=` sind Teil des [`PartialEq`][PartialEq]-Traits, während `<`, `<=`, `>`, `>=`, und `partial_cmp()` Teil des [`PartialOrd`][PartialOrd]-Traits sind.
+
+Gleitkommazahlen können nicht mit der Funktion `cmp()` verglichen werden, welche Teil des [`Ord`][Ord] Traits ist, da es für Gleitkommazahlen keine totale Ordnung gibt. Genauso gibt es keine totale Gleichheitsrelation, weswegen Gleitkommazahlen auch nicht den [`Eq`][Eq]-Trait implementieren. Der Grund ist, dass der Gleitkommawert [`NaN`](https://en.wikipedia.org/wiki/NaN) nicht gleich, kleiner als oder größer als irgendeine anderen Gleitkommazahl (oder sogar `NaN` selbst) ist.
+
+Da Gleitkommazahlen weder [`Eq`][Eq] noch [`Ord`][Ord] implementieren, können sie nicht für Typen verwendet werden, deren Trait-Bounds diese Eigenschaften verlangen, wie zum Beispiel [`BTreeMap`][BTreeMap] oder [`HashMap`][HashMap]. Das ist wichtig, da diese Typen *annehmen*, dass ihre Schlüssel totale Ordnung oder totale Gleichheit anbieten - anderenfalls würden sie nicht richtig funktionieren.
+
+[Es gibt einen Crate](https://crates.io/crates/ordered-float), welche [`f32`][f32] und [`f64`][f64] um eine Implementierung von [`Ord`][Ord] und [`Eq`][Eq] erweitert, die in manchen Fällen nützlich sein kann.
+
+<h3><a href="#how-can-i-convert-between-numeric-types" name="how-can-i-convert-between-numeric-types">
+Wie kann ich zwischen numerischen Typen umwandeln?
+</a></h3>
+
+Es gibt zwei Möglichkeiten: Das `as` Schlüsselwort, welches einfache Typumwandlung für primitive Typen vollzieht, und die Traits [`Into`][Into] und [`From`][From], welche für einige Typkonversionen implementiert sind (und welche du für eigene Typen selbst implementieren kannst). Die [`Into`][Into] und [`From`][From]-Traits sind nur in Fällen implementiert, in denen eine verlustfreie Umwandlung möglich ist. Zum Beispiel wird `f64::from(0f32)` kompilieren, `f32::from(0f64)` aber nicht. Das Schlüsselwort `as` hingegen wandelt alle primitiven Typen untereinander um und schneidet wenn nötig deren Werte ab.
+
+<h3><a href="#why-doesnt-rust-have-increment-and-decrement-operators" name="why-doesnt-rust-have-increment-and-decrement-operators">
+Warum kennt Rust keine Inkrement- und Dekrementoperatoren?
+</a></h3>
+[comment]: <> (Unterschied Expression/Statement?)
+Präinkrement und Postinkrement sowie ihre Gegenstücke für Dekrement sind zwar komfortabel, aber auch relativ komplex. Sie erfordern Kenntnis der Ausführungsreihenfolge und können in C und C++ leicht zu subtilen Fehlern oder undefiniertem Verhalten führen. `x = x + 1` oder `x += 1` sind nur geringfügig länger und dafür eindeutig.
+
+<h2 id="strings">Strings</h2>
+
+<h3><a href="#how-to-convert-string-or-vec-to-slice" name="how-to-convert-string-or-vec-to-slice">
+Wie kann ich einen <code>String</code> oder <code>Vec&lt;T&gt;</code> in einen Slice konvertieren (<code>&amp;str</code> und <code>&amp;[T]</code>)?
+</a></h3>
+
+Normalerweise kannst du eine Referenz zu einem `String` oder `Vec<T>` immer dort übergeben, wo ein Slice passend wäre.
+Mithilfe von [Deref Coercions](https://doc.rust-lang.org/stable/book/deref-coercions.html) können [`String`s][String] und [`Vec`s][Vec] automatisch in ihren jeweiligen Slice-Typen „zerfallen“, wenn man eine Referenz darauf mit `&` oder `&mut` übergibt.
+
+Methoden, die auf `&str` oder `&[T]` implementiert wurden, können auf `String` und `Vec<T>` direkt aufgerufen werden. Der Aufruf `some_string.char_at(0)` zum Beispiel funktioniert, obwohl `char_at` eine Methode von `&str` und `some_string` ein `String` ist.
+
+Manchmal, zum Beispiel in generischem Code, wird manuelle Konversion notwendig. Diese kann man mit dem _Slicing-Operator_ `&my_vec[..]` erreicht werden.
+
+<h3><a href="#how-to-convert-between-str-and-string" name="how-to-convert-between-str-and-string">
+Wie kann man <code>&amp;str</code> in <code>String</code> und umgekehrt umwandeln?
+</a></h3>
+
+Die Methode [`to_string()`][to_string] wandelt einen [`&str`][str] zu einem [`String`][String] um, und [`String`s][String] werden automatisch zu [`&str`][str] umgewandelt, wenn man per _Borrowing_ eine Referenz auf sie übergibt. Folgendes Beispiel soll beide Fälle veranschaulichen:
+
+```rust
+fn main() {
+    let s = "Jane Doe".to_string();
+    say_hello(&s);
+}
+
+fn say_hello(name: &str) {
+    println!("Hello {}!", name);
+}
+```
+
+<h3><a href="#what-are-the-differences-between-str-and-string" name="what-are-the-differences-between-str-and-string">
+Worin unterscheiden sich die beiden String-Typen?
+</a></h3>
+
+[`String`][String] ist ein auf dem Heap allokierter Buffer von UTF-8 Bytes, welcher durch eine 'owned'-Referenz gebunden ist. Veränderbare (mutable) [`String`s][String] können modifiziert werden, wobei ihre Kapazität angepasst wird. [`&str`][str] ist lediglich eine "Einsicht" mit fester Größe in einen [`String`][String]. Dieser [`String`][String] ist normalerweise auf dem Heap allokiert, wenn die Slice durch Dereferenzierung eines [`String`s][String] entstanden ist. Er kann auch im statischen Speicher liegen, wenn der String ein Literal aus dem Programmcode ist.
+
+[`&str`][str] ist ein primitiver Typ der Sprache Rust, während [`String`][String] in der Standardbibliothek definiert ist.
+
+<h3><a href="#how-do-i-do-o1-character-access-in-a-string" name="how-do-i-do-o1-character-access-in-a-string">
+Wie kann ich in O(1) auf ein Zeichen in einem <code>String</code> zugreifen?
+</a></h3>
+
+Das ist unmöglich, außer wenn über den String im Vornherein so viel bekannt ist, dass der Index eines Zeichens genau berechnet werden kann.
+[comment] <> (You cannot. At least not without a firm understanding of what you mean by "character", and preprocessing the string to find the index of the desired character)
+
+In Rust sind Strings in UTF-8-kodiert. In ASCII wäre ein einzelnes Zeichen auch genau ein Byte, aber dies ist in UTF-8 nicht zwingend der Fall. Ein Byte wird _Code Unit_ genannt (in UTF-16 sind Code Units 2 Bytes lang; in UTF-32 sind es 4 Bytes). Ein _Code Point_ besteht aus einem oder mehreren Code Units, und mehrere Code Points formen _Grapheme Cluster_, welche am ehesten als Zeichen interpretiert werden können.
+
+Obwohl man einfach auf den Bytes eines UTF-8 Strings indizieren könnte, kann man nicht in konstanter Zeit den `i`ten Code Point oder Grapheme Cluster erreichen, da sie alle unterschiedlich lang sein können. Es ist allerdings möglich, einen konkreten Grapheme Cluster oder Code Point zu erreichen, wenn man genau weiß, wo er beginnt.
+Funktionen wie [`str::find()`][str__find] und Regex-Matches geben Byte-Indizes an, wodurch dieser Zugriff auf Byte-Ebene ermöglicht wird.
+
+<h3><a href="#why-are-strings-utf-8" name="why-are-strings-utf-8">
+Warum sind Strings standardmäßig UTF-8-kodiert?
+</a></h3>
+
+Der [`str`][str]-Typ ist UTF-8-kodiert, weil Text (vor allem in Endian-agnostischen Netzwerkübertragungen) sehr häufig in dieser Form vorkommt. Wir sind der Meinung, dass Eingabe/Ausgabe standardmäßig nicht das Neukodieren von Text erfordern sollte.
+
+Das bedeutet, dass auf einen spezifischen Code Point in einem String nur durch eine O(n)-Operation zugegriffen werden kann (wobei ein Byte an bekannter Position natürlich weiterhin nur O(1) kostet). Einerseits ist das ein unerwünschter Nachteil; Andererseits ist dieses Problem voller Abwägungen und Trade-Offs. Ein paar wichtige Merkmale:
+
+Einen [`str`][str] nach ASCII-Codepoints zu durchsuchen kann immer noch sicher Byte für Byte geschehen. Mit [`.as_bytes()`][str__as_bytes] kann man mit O(1)-Kosten einen [`u8`][u8] gewinnen, welcher zu einem ASCII-[`char`][char] umgewandelt oder mit einem ASCII-[`char`][char] verglichen werden kann. Durch das gute Design von UTF-8 kann zum Beispiel ein `'\n'`-Byte weiterhin als Zeilenumbruch interpretiert werden.
+
+Die meisten „zeichenorientierten“ Operationen auf Text funktionieren nur bei sehr einschränkenden Annahmen, wie etwa dass der Text nur ASCII-Bytes enthält. Außerhalb des ASCII-Bereiches wird häufig sowieso ein komplexerer (nicht laufzeitkonstanter) Algorithmus zur Ermittlung der linguistischen Einheit (Glyph, Wort, Abschnitt) verwendet. Wir empfehlen, einen „ehrlichen“, linguistisch korrekten, anerkannten Unicode-Algorithmus zu verwenden.
+
+Der [`char`][char]-Typ ist UTF-32-kodiert. Wenn du sicher bist, dass du einen Algorithmus verwenden musst, welcher jeden Codepoint einzeln betrachtet, kannst du einfach einen `type wstr = [char]` definieren. Dann kannst du in einem einen [`str`][str] in ihn entpacken, mit welchem du dann als `wstr` arbeiten kannst. In anderen Worten: Die Tatsache, das die Sprache standardmäßig nicht in UTF-32 enkodiert, soll dich nicht daran hindern, Strings in irgendeinem anderen Enkoding zu verarbeiten.
+
+Eine detailliertere Erklärung, warum UTF-8 üblicherweise UTF-16 oder UTF-32 vorgezogen werden sollte, findet sich im [UTF-8 Everywhere Manifesto](http://utf8everywhere.org/).
+
+<h3><a href="#what-string-type-should-i-use" name="what-string-type-should-i-use">
+Welchen String-Typ sollte ich verwenden?
+</a></h3>
+
+Rust hat vier Paare von Stringtypen, von welchen [jeder einen bestimmten Sinn hat](http://www.suspectsemantics.com/blog/2016/03/27/string-types-in-rust/). In jedem dieser Paare befindet sich ein _Owned_-Typ sowie ein _Slice_-Typ. Die Typen sind folgendermaßen organisiert:
+
+|               | _Slice_-Typ | _Owned_-Typ |
+|:--------------|:-------------|:-------------|
+| UTF-8         | `str`        | `String`     |
+| Betriebssystemkompatibel | `OsStr`      | `OsString`   |
+| C-kompatibel  | `CStr`       | `CString`    |
+| Systempfad   | `Path`       | `PathBuf`    |
+
+Jeder String-Typen dient einem anderen Zweck. `String` und `str` sind UTF-8-kodierte, allgemein verwendbare Strings. `OsString` und `OsStr` sind nach den Vorgaben der jeweiligen Plattform enkodiert und sollten benutzt werden, um mit dem Betriebssystem zu interagieren. `CString` und `CStr` sind Rusts Gegenstück zu C-Strings und werden in FFI (Foreign Function Interface)-Code genutzt. `PathBuf` und `Path` sind bequeme Wrapper um `OsString` und `OsStr`, welche Methoden zur Dateipfad-Manipulation anbieten.
+
+<h3><a href="#why-are-there-multiple-types-of-strings" name="why-are-there-multiple-types-of-strings">
+Wie kann ich eine Funktion schreiben, welche sowohl <code>&str</code> als auch <code>String</code> annimmt?
+</a></h3>
+
+Es gibt je nach Verwendung der Funktion verschiedene Möglichkeiten:
+
+- Wenn die Funktion einen _Owned_-String benötigt, aber jede Art von String empfangen soll, dann nutze einen generischen Typen mit `Into<String>`-Bound.
+- Wenn die Funktion einen String-Slice benötigt, aber jede Art von String empfangen soll, dann nutze einen generischen Typen mit `AsRef<str>`-Bound.
+- Wenn es keine Rolle spielt, welchen String-Typ die Funktion bekommt, und du mit beiden Möglichkeiten einheitlich umgehen willst, dann nutze `Cow<str>` als Parametertyp.
+
+__Nutzung von `Into<String>`__
+
+In diesem Beispiel wird die Funktion sowohl _Owned_-Strings als auch String-Slices akzeptieren und dann entweder nichts tun oder die Eingabe innerhalb des Funktionskörpers zu einem _Owned_-String umwandeln. Diese Konversion muss explizit geschehen und wird ansonsten nicht stattfinden.
+
+```rust
+fn accepts_both<S: Into<String>>(s: S) {
+    let s = s.into();   // This will convert s into a `String`.
+    // ... the rest of the function
+}
+```
+
+__Nutzung von `AsRef<str>`__
+
+In diesem Beispiel wird die Funktion sowohl _Owned_-Strings als auch String-Slices akzeptieren und dann entweder nichts tun oder die Eingabe innerhalb der Funktion zu einem String-Slice umwandeln. Dies kann automatisch geschehen, indem die Eingabe als Referenz betrachtet wird:
+
+```rust
+fn accepts_both<S: AsRef<str>>(s: &S) {
+    // ... the body of the function
+}
+```
+
+__Nutzung von `Cow<str>`__
+
+In diesem Beispiel akzeptiert die Funktion einen `Cow<str>`, der nicht ein generischer Typ ist, sondern ein Container, welcher je nach Nutzung einen _Owned_-String oder String-Slice enthält.
+
+```rust
+fn accepts_cow(s: Cow<str>) {
+    // ... the body of the function
+}
+```
+
+
+<h2 id="collections">Collections</h2>
+
+<h3><a href="#can-i-implement-linked-lists-in-rust" name="can-i-implement-linked-lists-in-rust">
+Ist es möglich, Datenstrukturen wie Vektoren oder verkettete Listen in Rust effizient zu implementieren?
+</a></h3>
+
+Es ist unnötig, diese Datenstrukturen zu Nutzung in deinem eigenen Programm selber zu schreiben, da effiziente Implementierungen durch die Standardbibliothek angeboten werden.
+
+Wenn du aber [einfach nur lernen willst](http://cglab.ca/~abeinges/blah/too-many-lists/book/), dann wirst du wahrscheinlich _unsafe_-Code verwenden müssen. Diese Datenstrukturen _können_ zwar direkt in sicherem Rust implementiert werden, aber die Leistung einer _unsafe_-Implementierung wird wahrscheinlich besser sein. Der einfache Grund dafür ist, dass die Implementierung von Vektoren und verketteten Listen Zeigermanipulationen und Speicherzugriffe erfordert, welche in sicherem Rust verboten sind.
+
+Doppelt verkettete Listen erfordern zum Beispiel, dass auf jeden Knoten zwei veränderliche Referenzen verweisen. Dies verletzt aber die Aliasing-Regeln für veränderliche Referenzen (es darf nur höchstens eine auf ein Objekt bestehen). Du kannst dieses Problem umgehen, indem du [`Weak<T>`][Weak] nutzt, aber darunter wird die Leistung stark leiden. Mit unsicherem Code kannst du die _Mutable-Aliasing_-Regel umgehen, aber dann musst du manuell sicherstellen, dass dein Code die Speichersicherheit nicht verletzt.
+
+<h3><a href="#how-can-i-iterate-over-a-collection-without-consuming-it" name="how-can-i-iterate-over-a-collection-without-consuming-it">
+Wie kann ich über eine Collection iterieren ohne sie zu konsumieren / zu verschieben?
+</a></h3>
+
+Die einfachste Art ist, die [`IntoIterator`][IntoIterator]-Implementierung der Referenzen auf Collections zu nutzen. Zum Beispiel für [`&Vec`][Vec]:
+
+```rust
+let v = vec![1,2,3,4,5];
+for item in &v {
+    print!("{} ", item);
+}
+println!("\nLength: {}", v.len());
+```
+
+In Rust nutzen die `for`-Schleifen die `into_iter()`-Funktion aus dem [`IntoIterator`][IntoIterator]-Trait der zu iterierenden Collection. Über alle Typen, die den [`IntoIterator`][IntoIterator]-Trait anbieten, kann mit einer `for`-Schleife iteriert werden. Für [`&Vec`][Vec] und [`&mut Vec`][Vec] ist [`IntoIterator`][IntoIterator] ebenfalls implementiert. Das bedeutet, dass ein Iterator durch `into_iter()` den Inhalt der Collection als Referenz betrachtet, statt ihn durch einen _Move_ zu konsumieren. Dies gilt auch für die anderen Standard-Collections.
+
+Wenn du einen konsumierenden Iterator benötigst, dann schreibe die `for`-Schleife ohne `&` oder `&mut` in der Iteration.
+
+Direkten Zugriff auf einen Iterator, welcher Referenzen auf den Inhalt anbietet, erhältst du normalerweise durch den Aufruf der `iter()`-Methode.
+
+<h3><a href="#why-do-i-need-to-type-the-array-size-in-the-array-declaration" name="why-do-i-need-to-type-the-array-size-in-the-array-declaration">
+Warum muss ich die Größe eines Arrays in der Deklaration angeben?
+</a></h3>
+
+Du musst das nicht zwingend tun. Wenn du ein Array direkt deklarierst, wird die Größe durch die Anzahl der Elemente bestimmt. Aber wenn du eine Funktion deklarierst, welche ein Array fester Größe annimmt, muss der Compiler wissen wie groß dieses Array sein wird.
+
+Anzumerken ist, dass Rust momentan keine Generics für Arrays verschiedener Größe anbietet. Wenn du einen zusammenhängenden Container einer Variablen Anzahl von Werten annehmen willst, nutze einen [`Vec`][Vec] oder ein Slice (abhängig davon, ob du Ownership benötigst).
+
+<h2 id="ownership">Ownership</h2>
+
+<h3><a href="#how-can-i-implement-a-data-structure-that-contains-cycles" name="how-can-i-implement-a-data-structure-that-contains-cycles">
+Wie kann ich eine Datenstruktur mit Zyklen implementieren?
+</a></h3>
+
+Es gibt mindestens vier Möglichkeiten, welche ausführlich in [Too Many Linked Lists](http://cglab.ca/~abeinges/blah/too-many-lists/book/)) beschrieben werden:
+
+- Du kannst [`Rc`][Rc] und [`Weak`][Weak] nutzen, um geteilte Ownership zu Knoten zu erhalten.
+Dann musst du die Kosten von Memory Management in Kauf nehmen.
+- Du kannst `unsafe`-Code mit rohen Pointern nutzen.
+Dies wird effizient sein, aber es umgeht die Sicherheitsgarantien.
+- Du kannst Vektoren und Indexe in diesen Vektoren benutzen. Hier sind einige Beispiele und Erklärungen für diese Herangehensweise: [several](http://smallcultfollowing.com/babysteps/blog/2015/04/06/modeling-graphs-in-rust-using-vector-indices/) [available](https://featherweightmusings.blogspot.com/2015/04/graphs-in-rust.html).
+- Du kannst 'borrowed' Referenzen mit [`UnsafeCell`][UnsafeCell] nutzen. Es gibt für diese Herangehensweise [Erklärungen und Beispielcode](https://github.com/nrc/r4cppp/blob/master/graphs/README.md#node-and-unsafecell).
+
+<h3><a href="#how-can-i-define-a-struct-that-contains-a-reference-to-one-of-its-own-fields" name="how-can-i-define-a-struct-that-contains-a-reference-to-one-of-its-own-fields">
+Wie kann ich ein Struct mit Referenzen zu seinen eigenen Feldern definieren?
+</a></h3>
+
+Das ist möglich, aber nutzlos. Das Struct ist dann permanent von sich selbst „ausgeliehen“ und kann nicht bewegt werden. Hier ein Beispiel:
+
+```rust
+use std::cell::Cell;
+
+#[derive(Debug)]
+struct Unmovable<'a> {
+    x: u32,
+    y: Cell<Option<&'a u32>>,
+}
+
+
+fn main() {
+    let test = Unmovable { x: 42, y: Cell::new(None) };
+    test.y.set(Some(&test.x));
+
+    println!("{:?}", test);
+}
+```
+
+<h3><a href="#what-is-the-difference-between-consuming-and-moving" name="what-is-the-difference-between-consuming-and-moving">
+Was ist der Unterschied zwischen Pass-By-Value, Konsumieren, Verschieben (Moving), und der Übertragung von Ownership?
+</a></h3>
+
+Alle diese Begriffe sind äquivalent. In jedem Fall bedeuten sie, dass der Wert zu einem neuen Besitzer übertragen und aus dem Besitz des vorherigen entfernt wurde. Der vorherige Besitzer kann den Wert nicht mehr nutzen. Wenn ein Typ den `Copy`-Trait anbietet, dann wird der Wert des ursprünglichen Besitzers nicht invalidiert und kann weiterhin benutzt werden.
+
+<h3><a href="#why-can-values-of-some-types-by-reused-while-others-are-consumed" name="why-can-values-of-some-types-by-reused-while-others-are-consumed">
+Warum können Werte eines Typs nach dem übergeben an eine Funktion wiederverwendet werden, während die Wiederverwendung von Werten anderen Typs zu einem Fehler führt?
+</a></h3>
+
+Wenn ein Typ den [`Copy`][Copy]-Trait anbietet, dann wird ein Wert dieses Typs bei der Übergabe an eine Funktion kopiert. Alle numerischen Typen in Rust implementieren [`Copy`][Copy], aber Struct-Typen implementieren den Trait nicht standardmäßig. Sie werden also standardmäßig mit _Ownership_ übergeben. Das bedeutet, dass ein Struct nach der Übergabe nicht mehr benutzt werden kann, wenn es nicht (samt Ownership) am Ende der aufgerufenen Funktion wieder zurückgegeben wird.
+
+<h3><a href="#how-do-you-deal-with-a-use-of-moved-value-error" name="how-do-you-deal-with-a-use-of-moved-value-error">
+Wie gehe ich mit einem „Use of moved Value“-Fehler um?
+</a></h3>
+
+Diese Fehlermeldung bedeutet, dass du versuchst auf einen Wert zuzugreifen, der den Besitzer gewechselt hat. Die erste Frage ist, ob die Übergabe des Besitzes nötig war: Wenn der Wert einer Funktion übergeben wurde, dann könnte es möglich sein die Funktion so umzuschreiben, dass sie nur eine Referenz entgegennimmt.
+Wenn der übergebene Typ den [`Clone`][Clone]-Trait implementiert, dann wird ein Aufruf zu `clone()` vor der Übergabe eine Kopie des Wertes erstellen und das Original zur weiteren Verwendung freigeben. Da durch Klonen weitere Allokationen notwendig werden, sollte dies der letzte Ausweg sein.
+
+Wenn der Übergebene Wert dein eigener Typ ist, dann könntest du [`Copy`][Copy] (für implizites Kopieren anstelle von Klonen) oder [`Clone`][Clone] (explizite Kopie) selbst implementieren. [`Copy`][Copy] kann häufig durch `#[derive(Copy, Clone)]` erhalten werden ([`Copy`][Copy] erfordert [`Clone`][Clone]), und [`Clone`][Clone] mit `#[derive(Clone)]`.
+
+Wenn diese Möglichkeiten nicht gegeben sind, dann könntest du die Funktion, welche den Besitz des Wertes erfordert so modifizieren, dass sie den Besitz am Ende wieder zurückgibt.
+
+<h3><a href="#what-are-the-rules-for-different-self-types-in-methods" name="what-are-the-rules-for-different-self-types-in-methods">
+Nach welchen Regeln richtet sich die Verwendung von <code>self</code>, <code>&amp;self</code>, oder <code>&amp;mut self</code> in Methodendeklarationen?
+</a></h3>
+
+- Nutze `self`, wenn eine Methode Besitz vom Wertes ergreifen soll.
+- Nutze `&self`, wenn eine Methode lediglich eine Nur-Lese-Referenz auf den Wert benötigt.
+- Nutze `&mut self`, wenn eine Methode den Wert verändern, aber nicht davon Besitz ergreifen soll.
+
+<h3><a href="#how-can-i-understand-the-borrow-checker" name="how-can-i-understand-the-borrow-checker">
+Wie kann ich den Borrow-Checker verstehen?
+</a></h3>
+
+Zum Evaluieren von Rust-Code nutzt der Borrow Checker nur ein paar wenige Regeln, welche im [Abschnitt über Borrowing](https://doc.rust-lang.org/stable/book/references-and-borrowing.html#the-rules) erklärt werden. Diese Regeln sind:
+
+> Erstens darf ein _Borrow_ höchstens so lange bestehen wie der eigentliche Besitzer. Zweitens darfst du zu jedem Zeitpunnkt nur eine dieser beiden Arten von Borrow haben:
+>
+> - Eine oder mehr Referenzen (&T) zu einer Ressource.
+> - Genau eine veränderbare Referenz (&mut T).
+
+Diese Regeln sind zwar einfach, sie konsistent zu befolgen aber nicht, vor allem wenn man nicht gewohnt ist, über Lifetimes und Ownership nachzudenken.
+
+Der erste Schritt zum Verständnis des Borrow Checkers ist es, seine Fehlermeldungen zu studieren. Es wurde viel Arbeit investiert, um die Qualität der Hilfestellungen des Borrow Checkers zu erhöhen. Wenn du ein Problem mit dem Borrow Checker hast, ist der erste Schritt, langsam und vorsichtig die Fehlermeldung zu lesen. Verändere deinen Code erst, nachdem du den Fehler verstanden hast.
+
+Der zweite Schritt ist, die Container-Typen der Standardbibliothek, welche mit Ownership und Mutability zu tun haben, kennenzulernen. Dies sind zum Beispiel [`Cell`][Cell], [`RefCell`][RefCell], und [`Cow`][Cow]. Diese Typen sind nützliche und notwendige Werkzeuge, um bestimmte Ownership- und Mutabilityverhältnisse auszudrücken, und wurden für minimale Leistungskosten entworfen.
+
+Der wichtigste Bestandteil, um den Borrow Checker zu verstehen, ist Übung. Die starke Garantien der statischen Analyse von Rust sind streng und von anderen Programmiersprachen verschieden. Es wird einige Zeit dauern, mit Allem vollständig zurechtzukommen.
+
+Wenn du dich mit dem Borrow Checker allzu sehr abmühen musst und dir die Geduld ausgeht, ist die [Rust-Community](community.html) jederzeit für dich da.
+
+<h3><a href="#when-is-rc-useful" name="when-is-rc-useful">
+Wann sollte ich <code>Rc</code> verwenden?
+</a></h3>
+
+Die Funktion des nichtatomaren, referenzzählenden Containers [`Rc`][Rc] wird in der offiziellen Dokumentation erläutert. Kurz gesagt kann man [`Rc`][Rc] und seinen threadsicheren Cousin [`Arc`][Arc] verwenden, um gemeinsamen Besitz einer Ressource auszudrücken und diese Ressource automatisch freizugeben, wenn kein Besitzer mehr Zugriff darauf hat.
+
+<h3><a href="#how-do-i-return-a-closure-from-a-function" name="how-do-i-return-a-closure-from-a-function">
+Wie gebe ich eine Closure aus einer Funktion zurück?
+</a></h3>
+
+Um eine Closure aus einer Funktion herausreichen zu können, muss sie eine _Move Closure_ sein, welche mit dem Schlüsselwort `move` deklariert wird. Wie [im Buch zu Rust erklärt](https://doc.rust-lang.org/book/closures.html#move-closures), gibt dies der Closure eine eigene Kopie ihrer eingefangenen Variablen, die vom Stack Frame der Elternfunktion unabhängig sind. Eine andere Rückgabe von Closures wäre unsicher, da dies Zugriff auf nicht mehr gültige Variablen gewähren würde. In anderen Worten: Es würde das Auslesen potentiell ungültigen Speichers ermöglichen. Die Closure muss außerdem von einer [`Box`][Box] umgeben werden, damit sie auf dem Heap allokiert wird. [Im Buch](https://doc.rust-lang.org/book/closures.html#returning-closures) kannst du mehr darüber lesen.
+
+<h3><a href="#what-are-deref-coercions" name="what-are-deref-coercions">
+Was sind <i>Deref Coercions</i> und wie funktionieren sie?
+</a></h3>
+
+Eine [Deref Coercion](https://doc.rust-lang.org/book/deref-coercions.html) ist eine nützliche Umwandlung, die automatisch Referenzen auf Zeigertypen (also zum Beispiel `&Rc<T>` or `&Box<T>`) zu Referenzen auf ihren Inhalt konvertiert.
+Deref Coercions existieren, um einen ergonomischeren Umgang mit Rust zu ermöglichen und werden durch den [`Deref`][Deref]-Trait implementiert.
+
+Eine Implementierung von Deref gibt an, dass der implementierende Typ durch den Aufruf der `deref`-Methode zu einem Zieltyp konvertiert werden kann. Dabei nimmt die Methode eine unveränderliche Referenz zum aufrufenden Typ an und gibt eine Referenz mit derselben Lifetime zum Zieltyp zurück. Der `*`-Präfix ist eine Kurznotation für die `deref`-Methode.
+
+Der Name „Coercion“ kommt aus der [hier im Buch erklärten Regel](https://doc.rust-lang.org/stable/book/deref-coercions.html):
+
+> Wenn du einen Typ `U` hast, welcher `Deref<Target=T>` implementiert, dann können Werte von `&U` automatisch in `&T` konvertiert (_coerced_) werden.
+
+Wenn du beispielsweise einen `&Rc<String>` hast, wird er nach dieser Regel automatisch zu einem `&String`, welcher dann auf die gleiche Weise zu einem `&str` wird. Wenn also eine Funktion einen `&str`-Parameter entgegennimmt, kannst du einen `&Rc<String>` direkt übergeben, woraufhin alle Umwandlungen automatisch durch den `Deref`-Trait geschehen.
+
+Die häufigsten Arten der Deref Coercion sind:
+
+- `&Rc<T>` zu `&T`
+- `&Box<T>` zu `&T`
+- `&Arc<T>` zu `&T`
+- `&Vec<T>` zu `&[T]`
+- `&String` zu `&str`
+
+<h2 id="lifetimes">Lifetimes</h2>
+
+<h3><a href="#why-lifetimes" name="why-lifetimes">
+Welchen Zweck haben Lifetimes?
+</a></h3>
+
+Lifetimes sind Rusts Antwort auf die Frage der Speichersicherheit. Sie erlauben es Rust, Speichersicherheit ohne die Laufzeitkosten von Garbage-Collection zu erlangen. Sie basieren auf einer Vielzahl akademischer Arbeiten, welche im [Rust book](https://doc.rust-lang.org/stable/book/bibliography.html#type-system) nachgeschlagen werden können.
+
+<h3><a href="#why-is-the-lifetime-syntax-the-way-it-is" name="why-is-the-lifetime-syntax-the-way-it-is">
+Warum ist die Syntax für Lifetimes so, wie sie ist?
+</a></h3>
+
+Die `'a`-Syntax kommt aus der ML-Familie der Programmiersprachen, wo `'a` benutzt wird, um einen generischen Parameter zu markieren. In Rust sollte der Syntax eindeutig und auffällig sein und neben Traits und Referenzen in eine Typdeklaraion (Signatur) passen. Alternative syntaktische Repräsentationen wurden diskutiert, von denen aber keine eindeutige Vorteile vorwiesen.
+
+<h3><a href="#how-do-i-return-a-borrow-to-something-i-created-from-a-function" name="how-do-i-return-a-borrow-to-something-i-created-from-a-function">
+Wie kann ich in einer Funktion einen Wert alloziieren, um dann eine Referenz darauf zurückzugeben?
+</a></h3>
+
+Du musst sicherstellen, dass das alloziierte Objekt länger lebt als die Funktion. Das kannst du erreichen, indem du die Ausgabe-Lifetime an eine Eingabe-Lifetime bindest:
+
+```rust
+type Pool = TypedArena<Thing>;
+
+// (Die Lifetime 'a ist nur zur Erklärung explizit angegeben.
+// Du kannst sie nach den in einem späteren FAQ-Eintrag
+// erklärten Elision-Regeln weglassen.)
+fn create_borrowed<'a>(pool: &'a Pool,
+                       x: i32,
+                       y: i32) -> &'a Thing {
+    pool.alloc(Thing { x: x, y: y })
+}
+```
+
+Eine Alternative Vorgehensweise wäre, die Referenzen vollständig wegzulassen und einen Typ mit _Ownership_ wie zum Beispiel [`String`][String] zurückzugeben:
+
+```rust
+fn happy_birthday(name: &str, age: i64) -> String {
+    format!("Hello {}! You're {} years old!", name, age)
+}
+```
+
+Diese Vorgehensweise ist einfacher, aber hat oft unnötige Allokationen zufolge.
+
+<h3><a href="#when-are-lifetimes-required-to-be-explicit" name="when-are-lifetimes-required-to-be-explicit">
+Warum haben manche Referenzen Lifetimes, wie <code>&amp;'a T</code>, und manche anderen wie <code>&amp;T</code> nicht?
+</a></h3>
+
+Eigentlich haben *alle* Referenzen eine Lifetime, aber meistens musst du sie nicht explizit angeben.
+Die Regeln sind wie folgt:
+
+1. Innerhalb eines Funktionskörpers musst du nie explizit
+   eine Lifetime angeben;
+   Der korrekte Wert sollte immer inferiert werden.
+2. Innerhalb einer Funktions*signatur* (zum Beispiel für die Typen der
+   Parameter oder den Rückgabetyp), sind explizite Lifetimes manchmal notwendig.
+   Hier nutzen Lifetimes ein einfaches Vorgabeschema namens
+   [_Lifetime elision_](https://doc.rust-lang.org/book/lifetimes.html#lifetime-elision),
+   welches aus den drei folgenden Regeln besteht:
+  - Jede ausgelassene Lifetime in den Funktionsparametern wird ein eigener Lifetime-Parameter.
+  - Wenn es genau eine explizite oder ausgelassene Eingabe-Lifetime gibt, dann
+    wird diese Lifetime allen ausgelassenen Lifetimes der Rückgabetypen
+    dieser Funktion zugewiesen.
+  - Wenn es mehrere Eingabe-Lifetimes gibt, von denen eine `&self` oder `&mut self` ist,
+    dann wird die Lifetime von `self` allen ausgelassenen Rückgabe-Lifetimes zugeordnet.
+3. In einer `struct`- oder `enum`-Definition müssen alle Lifetimes explizit angegeben werden.
+
+Wenn diese Regeln nicht anwendbar sind, wird der Rust-Compiler eine Fehlermeldung zusammen mit einer potenziellen Lösung ausgegeben. Diese Lösung hängt vom konkreten Schritt des Inferenzvorganges ab,
+in dem der Fehler aufgetreten ist.
+
+<h3><a href="#how-can-rust-guarantee-no-null-pointers" name="how-can-rust-guarantee-no-null-pointers">
+Wie kann Rust Freiheit von Nullzeigern und „hängenden Zeigern“ garantieren?
+</a></h3>
+
+Der einzige Weg, einen Wert vom Typ `&Foo` oder `&mut Foo` zu konstruieren ist, einen existierenden Wert vom Typ `Foo` anzugeben, auf den die Referenz zeigt. Die Referenz „borgt“ sich den originalen Wert für einen gegeben Abschnitt des Codes (nämlich der Lifetime der Referenz) aus. Während der Dauer der „Ausborgung“ kann der Wert nicht an einen neuen Besitzer übergeben, verändert oder freigegeben werden.
+
+<h3><a href="#how-do-i-express-the-absense-of-a-value-without-null" name="how-do-i-express-the-absense-of-a-value-without-null">
+Wie drücke ich die Abwesenheit eines Wertes aus, ohne <code>null</code> zu verwenden?
+</a></h3>
+
+Das kannst du mit dem [`Option`][Option]-Typ erreichen, welcher entweder ein `Some(T)` oder `None` sein kann. `Some(T)` zeigt an, dass ein Wert vom Typ `T` in der Option vorhanden ist, während `None` die Abwesenheit anzeigt.
+
+<h2 id="generics">Generics</h2>
+
+<h3><a href="#what-is-monomorphisation" name="what-is-monomorphisation">
+Was ist Monomorphisierung?
+</a></h3>
+
+Monomorphisierung spezialisiert jeden Aufruf einer generischen Funktion oder Struktur mit einer spezifischen Instanz
+basierend auf den Parametertypen der Funktionaufrufe (oder Verwendungen der Struktur).
+
+Für jede einzigartige Menge von Typen, mit welcher eine generische Funktion instanziiert wird, erstellt der Compiler eine neue Kopie der Funktion. Diese Strategie wird auch von C++ genutzt und resultiert in schnellem Code, welcher für jeden Aufruf spezialisiert ist und frühe Bindung nutzen kann. Allerdings kann sie bei vielen voneinander verschiedenen Aufruftypen auch dazu führen, dass die Größe der generierten Ausführbaren Datei größer ist als bei anderen Aufrufstrategien.
+
+Für Funktionen, welche anstelle von Typparametern [Trait Objects](https://doc.rust-lang.org/book/trait-objects.html) annehmen, wird keine Monomorphisierung durchgeführt. Stattdessen werden Methoden für Trait Objects dynamisch zur Laufzeit entschieden.
+
+<h3><a href="#whats-the-difference-between-a-function-and-a-closure-that-doesnt-capture" name="whats-the-difference-between-a-function-and-a-closure-that-doesnt-capture">
+Was ist der Unterschied zwischen einer Funktion und einer Closure, welche keine Variablen einfängt?
+</a></h3>
+
+Funktionen und Closures sind äquivalente Operationen, haben aber zur Laufzeit aufgrund ihrer verschiedenen Implementierungen unterschiedliche Repräsentationen.
+
+Funktionen sind eingebaute Primitive der Sprache, während Closures eigentlich syntaktischer Zucker für einen von drei Traits sind: [`Fn`][Fn], [`FnMut`][FnMut], und [`FnOnce`][FnOnce]. Beim Kompilieren einer Closure wird der Rust-Compiler automatisch ein Struct erstellen, für das der entsprechende Trait implementiert ist und der die entgegengenommenen Variablen als Attribute enthält. der Trait ermöglicht es, dieses Struct wie eine Funktion aufzurufen. Reguläre Funktionsdefinitionen können keine Variablen aus ihrer Umgebung einfangen.
+
+Der große Unterschied zwischen diesen Traits ist, wie sie mit dem `self`-Parameter umgehen. [`Fn`][Fn] nimmt `&self`, [`FnMut`][FnMut] nimmt `&mut self`, und [`FnOnce`][FnOnce] nimmt `self`.
+
+Sogar wenn eine Closure gar keine Umgebungsvariablen entgegennimmt, wird sie zur Laufzeit als zwei Zeiger repräsentiert, genau wie jede andere Closure.
+
+<h3><a href="#what-are-higher-kinded-types" name="what-are-higher-kinded-types">
+Was sind Typen höherer Ordnung, wozu brauche ich sie, und warum hat Rust sie nicht?
+</a></h3>
+
+Typen höherer Ordnung sind Typen mit noch ausstehenden Parametern. Typkonstruktoren wie [`Vec`][Vec], [`Result`][Result], und [`HashMap`][HashMap] sind Beispiele für Typen höherer Ordnung: Sie erfordern einige weitere Typparameter um einen tatsächlichen Typ wie `Vec<u32>` darzustellen. Unterstützung für Typen höherer Ordnung würde bedeuten, dass diese „unvollständigen“ Typen überall dort benutzt werden können, wo sonst auch „vollständige“ Typen verwendet werden können, also auch als generische Parameter für Funktionen.
+
+Jeder vollständige Typ wie [`i32`][i32], [`bool`][bool], oder [`char`][char] ist von der Art `*` (diese Notation kommt aus der Typtheorie). Ein Typ mit einem Parameter, wie [`Vec<T>`][Vec] ist von der Art `* -> *`, was bedeutet, dass [`Vec<T>`][Vec] einen vollständigen Typ wie [`i32`][i32] nimmt und einen vollständigen Typ wie `Vec<i32>` zurückgibt.
+Ein Typ mit drei Parametern, wie [`HashMap<K, V, S>`][HashMap] ist von der Art `* -> * -> * -> *`, und nimmt drei vollständige Typen (wie [`i32`][i32], [`String`][String], and [`RandomState`][RandomState]) entgegen, um einen neuen vollständigen Typ `HashMap<i32, String, RandomState>` zu konstruieren.
+
+Zusätzlich zu diesen Beispielen können Typkonstruktoren auch *Lifetime*-Argumente entgegennehmen, welche wir mit `Lt` bezeichnen wollen. Der Typ `slice::Iter` hat zum Beispiel die Art `Lt -> * -> *`, weil er mit einer Lifetime und einem vollständigen Typ konstruiert werden muss: `Iter<'a, u32>`.
+
+Die fehlende Unterstützung von Typen höherer Ordnung erschwert das Schreiben von bestimmten Arten generischen Codes. Es ist insbesondere problematisch, Konzepte wie Iteratoren zu abstrahieren, da diese oft mit mindestens einer Lifetime parametrisiert sind. Dies hat die Erstellung von Traits verhindert, die über Collections abstrahieren.
+
+Ein weiteres häufiges Beispiel sind Konzepte wie Funktoren oder Monaden. Beide sind Typkonstruktoren statt einfacher Typen.
+
+Bisher hat Rust keine Typen höherer Ordnung weil ihnen gegenüber anderen Verbesserungen keine Priorität zugewiesen wurde. Weil der Entwurf eine große, querschneidende Veränderung ist, wollen wir auch vorsichtig damit umgehen. Aber es gibt keinen tiefgreifenden Grund, der Typen höherer Ordnung unmöglich machen würde.
+
+<h3><a href="#what-do-named-type-parameters-in-generic-types-mean" name="what-do-named-type-parameters-in-generic-types-mean">
+Was bedeuten benannte Parameter wie <code>&lt;T=Foo&gt;</code> in generischen Typen?
+</a></h3>
+
+Diese werden [Assoziierte Typen](https://doc.rust-lang.org/stable/book/associated-types.html) genannt und erlauben es, Trait-Bounds auszudrücken, für die eine `where`-Klausel nicht ausreicht.
+Eine generische Einschränkung `X: Bar<T=Foo>` bedeutet: „`X` muss den Trait `Bar` implementieren, und die Implementierung von `Bar` muss für den assoziierten Typ `T` den Typ `Foo` annehmen.“. Beispiele für Typ-Einschränkungen, welche nicht mit einer `where`-Klausel ausgedrückt werden können, sind zum Beispiel Trait-Objekte wie `Box<Bar<T=Foo>>`.
+
+Assoziierte Typen existieren, weil Generics oft mit Familien von Typen umgehen müssen, wobei ein Typ alle anderen in der Familie bestimmt. Ein Trait eines Graphen zum Beispiel könnte als `Self`-Typ den Graphen selber haben, sowie assoziierte Typen für Knoten und Kanten. Jeder Graph-Typ bestimmt dann eindeutig die assoziierten Typen. Die Verwendung von assoziierten Typen vereinfacht die Arbeit mit solchen Typfamilien stark und bietet in vielen Fällen auch bessere Typinferenz.
+
+<h3><a href="#how-do-i-overload-operators" name="how-do-i-overload-operators">
+Kann ich Operatoren überladen? Welche und wie?
+</a></h3>
+
+Du kannst eigene Implementierung bestimmte Operatoren über die zugehörigen Traits definieren: [`Add`][Add] für `+`, [`Mul`][Mul] für `*` und so weiter. Das Ganze sieht folgendermaßen aus:
+
+```rust
+use std::ops::Add;
+
+struct Foo;
+
+impl Add for Foo {
+    type Output = Foo;
+    fn add(self, rhs: Foo) -> Self::Output {
+        println!("Addition");
+        self
+    }
+}
+```
+
+Die folgenden Operatoren können überladen werden:
+
+| Operation            | Trait                          |
+|:---------------------|:-------------------------------|
+| `+`                  | [`Add`][Add]                   |
+| `+=`                 | [`AddAssign`][AddAssign]       |
+| `binary -`           | [`Sub`][Sub]                   |
+| `-=`                 | [`SubAssign`][SubAssign]       |
+| `*`                  | [`Mul`][Mul]                   |
+| `*=`                 | [`MulAssign`][MulAssign]       |
+| `/`                  | [`Div`][Div]                   |
+| `/=`                 | [`DivAssign`][DivAssign]       |
+| `unary -`            | [`Neg`][Neg]                   |
+| `%`                  | [`Rem`][Rem]                   |
+| `%=`                 | [`RemAssign`][RemAssign]       |
+| `&`                  | [`BitAnd`][BitAnd]             |
+| <code>&#124;</code>  | [`BitOr`][BitOr]               |
+| <code>&#124;</code>= | [`BitOrAssign`][BitOrAssign]   |
+| `^`                  | [`BitXor`][BitXor]             |
+| `^=`                 | [`BitXorAssign`][BitXorAssign] |
+| `!`                  | [`Not`][Not]                   |
+| `<<`                 | [`Shl`][Shl]                   |
+| `<<=`                | [`ShlAssign`][ShlAssign]       |
+| `>>`                 | [`Shr`][Shr]                   |
+| `>>=`                | [`ShrAssign`][ShrAssign]       |
+| `*`                  | [`Deref`][Deref]               |
+| `mut *`              | [`DerefMut`][DerefMut]         |
+| `[]`                 | [`Index`][Index]               |
+| `mut []`             | [`IndexMut`][IndexMut]         |
+
+<h3><a href="#why-the-split-between-eq-partialeq-and-ord-partialord" name="why-the-split-between-eq-partialeq-and-ord-partialord">
+Warum gibt es die Unterscheidung zwischen <code>Eq</code>/<code>PartialEq</code> und <code>Ord</code>/<code>PartialOrd</code>?
+</a></h3>
+
+Die Werte mancher Typen in Rust sind nur partiell geordnet oder kennen nur partielle Gleichheit. In einer partiellen Ordnung kann es vorkommen, dass bei zwei verschiedenen Werte eines Typs der eine weder kleiner noch größer als der andere ist. Partielle Gleichheit bedeutet, dass Werte des Typs ungleich sich selbst sein können.
+
+Gleitkommazahlen ([`f32`][f32] and [`f64`][f64]) sind gute Beispiele für beide Fälle. Gleitkommatypen können den Wert `NaN` ("Not a Number") annehmen. `NaN` ist ungleich sich selbst (`NaN == NaN` ist `false`) und nicht kleiner oder größer als jeder beliebige Gleitkommawert. Deshalb implementieren sowohl [`f32`][f32] als auch [`f64`][f64] [`PartialOrd`][PartialOrd] und [`PartialEq`][PartialEq], nicht aber [`Ord`][Ord] oder [`Eq`][Eq].
+
+Wie in der obigen [Frage zu Gleitkommazahlen](#why-cant-i-compare-floats) erklärt, ist diese Unterscheidung wichtig, da manche Collection-Typen eine totale Ordnung oder Vergleichbarkeit benötigen, um korrekt zu funktionieren.
+
+<h2 id="input-output">Ein- und Ausgabe</h2>
+
+<h3><a href="#how-do-i-read-a-file-into-a-string" name="how-do-i-read-a-file-into-a-string">
+Wie lese ich eine Datei in einen <code>String</code> ein?
+</a></h3>
+
+Mit der [`read_to_string()`][read__read_to_string]-Methode, die auf dem [`Read`][Read]-Trait in [`std::io`][std-io] definiert ist.
+
+```rust
+use std::io::Read;
+use std::fs::File;
+
+fn read_file(path: &str) -> Result<String, std::io::Error> {
+    let mut f = try!(File::open(path));
+    let mut s = String::new();
+    try!(f.read_to_string(&mut s));  // `s` enthält den Inhalt von "foo.txt"
+    Ok(s)
+}
+
+fn main() {
+    match read_file("foo.txt") {
+        Ok(_) => println!("Datei gelesen!"),
+        Err(err) => println!("Fehler beim Lesen der Datei: {}", err)
+    };
+}
+```
+
+<h3><a href="#how-do-i-read-file-input-efficiently" name="how-do-i-read-file-input-efficiently">
+Wie lese ich effektiv aus einer Datei?
+</a></h3>
+
+Der Typ [`File`][File] implementiert den [`Read`][Read]-Trait, der eine Reihe an Funktionen zum Lesen und Schreiben von Daten bereitstellt, etwa [`read()`][read__read], [`read_to_end()`][read__read_to_end], [`bytes()`][read__bytes], [`chars()`][read__chars], und [`take()`][read__take]. Jede dieser Funktionen liest einen bestimmte Menge an Daten aus der jeweiligen Datei. [`read()`][read__read] liest so viele Daten, wie das Eingabe-Ausgabe-System in einem einzigen Aufruf zur Verfügung stellt. [`read_to_end()`][read__read_to_end] liest den gesamten Puffer in einen Vektor ein und fordert dabei so viel Speicher an wie notwendig. [`bytes()`][read__bytes] und [`chars()`][read__chars] liefern Iteratoren über die Bytes bzw. Zeichen einer Datei. Zu guter Letzt ermöglicht es [`take()`][read__take], eine beliebige Anzahl Bytes aus der Datei zu lesen. Zusammen genommen sollten diese Funktionen ausreichen, um effektiv aus jeder beliebigen Datei zu lesen.
+
+Für gepufferte Eingabe gibt es den [`BufReader`][BufReader]-Struct, der hilft, die Anzahl der Systemaufrufe während des Lesens zu verringern.
+
+<h3><a href="#how-do-i-do-asynchronous-input-output-in-rust" name="how-do-i-do-asynchronous-input-output-in-rust">
+Wie setze ich asynchrone Ein- und Ausgabe in Rust um?
+</a></h3>
+
+Es gibt mehrere aktive Bibliotheken zu asynchronem I/O in Rust, wie etwa [mio](https://github.com/carllerche/mio), [tokio](https://github.com/tokio-rs/tokio-core), [mioco](https://github.com/dpc/mioco), [coio-rs](https://github.com/zonyitoo/coio-rs), und [rotor](https://github.com/tailhook/rotor).
+
+<h3><a href="#how-do-i-get-command-line-arguments" name="how-do-i-get-command-line-arguments">
+Wie kann ich auf die Kommandozeilenargumente meines Programms zugreifen?
+</a></h3>
+
+Die einfachste Möglichkeit ist [`Args`][Args], das einen Iterator über die Argumente zur Verfügung stellt.
+
+Wenn du nach etwas mächtigeren suchst, gibt es eine [Reihe an Optionen auf crates.io](https://crates.io/keywords/argument).
+
+<h2 id="error-handling">Fehlerbehandlung</h2>
+
+<h3><a href="#why-doesnt-rust-have-exceptions" name="why-doesnt-rust-have-exceptions">
+Warum kennt Rust keine Exceptions?
+</a></h3>
+
+Exceptions erschweren das Verständnis von Kontrollfluss, drücken Gültigkeit und Ungültigkeit außerhalb des Typsystems aus und spielen schlecht mit Multithreading zusammen (ein wichtiges Ziel von Rust).
+
+Rust zieht einen typbasierten Ansatz zur Fehlerbehandlung vor, der [ausführlich im Buch](https://doc.rust-lang.org/stable/book/error-handling.html) beschrieben wird. Dieser passt besser zum Kontrollfluss, der Nebenläufigkeit und dem Rest der Sprache.
+
+<h3><a href="#whats-the-deal-with-unwrap" name="whats-the-deal-with-unwrap">
+Was hat es mit den dauernden <code>unwrap()</code>-Aufrufen auf sich?
+</a></h3>
+
+`unwrap()` ist eine Funktion, die den Wert aus einer [`Option`][Option] oder einem [`Result`][Result] entpackt und eine Panic auslöst, wenn dieser Wert nicht vorhanden ist.
+
+`unwrap()` ist kein guter Weg, um Fehlersituationen wie falsche Benutzereingaben abzufangen. In Produktionscode dient `unwrap()` eher als Assertion, um das Vorhandensein eines Werts als Invariante sicherzustellen, deren Verletzung einen Bug darstellt und das Programm sofort abbrechen soll.
+
+Die Funktion ist auch für Prototypen geeignet, in denen noch keine Fehlerbehandlung implementiert werden soll. Außerdem ist sie für Codebeispiele praktisch, in denen die Fehlerbehandlung vom Ziel des Programms ablenken würde.
+
+<h3><a href="#why-do-i-get-errors-with-try" name="why-do-i-get-errors-with-try">
+Warum bekomme ich einen Compilerfehler in Beispielcode, der das <code>try!</code>-Makro benutzt?
+</a></h3>
+
+Das liegt wahrscheinlich am Rückgabetyp der Funktion. Das [`try!`][TryMacro]-Makro entpackt im Erfolgsfall den Wert aus einem [`Result`][Result] oder kehrt aus der aufrufenden Funktion mit dem Fehler zurück, den das [`Result`][Result] beschreibt. Damit funktioniert `try!` nur in Funktionen die ihrerseits ein `Result` zurückgeben. Dessen `Err`-Wert muss außerdem mit `From::from(err)` aus dem Fehlertyp des `try!`-Arguments konstruiert werden können. Insbesondere kann `try!` somit auch nicht in der `main`-Funktion verwendet werden.
+
+<h3><a href="#error-handling-without-result" name="error-handling-without-result">
+Gibt es einen einfacheren Fehlerbehandlungsmechanismus, als überall <code>Result</code> zu verwenden?
+</a></h3>
+
+[`Result`s][Result]-Werte wirst du immer mit einem [`unwrap()`][unwrap] los, nur ist das meistens nicht das was du möchtest. [`Result`][Result] ist ein Anzeichen dafür, dass eine Operation möglicherweise fehlschlagen kann. Rust zwingt dich diese Fehlerpfade explizit zu behandeln, um die Robustheit von Programmen gegenüber Fehlersituationen zu fördern. Es gibt Helfer wie das [`try!`-Makro][TryMacro], das das Propagieren von Fehlern angenehmer macht.
+
+Wenn du einen Fehler wirklich nicht behandeln möchtest kannst du auf [`unwrap()`][unwrap] zurückgreifen. Das bedeutet aber, dass dein Code im Fehlerfall eine Panic erzeugt, die im Normalfall den Prozess sofort beendet.
+
+<h2 id="concurrency">Nebenläufigkeit</h2>
+
+<h3><a href="#can-i-use-static-values-across-threads-without-an-unsafe-block" name="can-i-use-static-values-across-threads-without-an-unsafe-block">
+Kann ich statische Werte in mehreren Threads benutzen, ohne auf <code>unsafe</code>-Code zurückzugreifen?
+</a></h3>
+
+Schreibende Zugriffe sind sicher, solange sie synchronisiert erfolgen. Dazu kann etwa ein [`Mutex`][Mutex] (spät initialisiert über [lazy-static](https://crates.io/crates/lazy_static/)) oder ein [`AtomicUsize`][AtomicUsize] (regulär initialisiert) verwendet werden.
+
+Allgemein gesprochen können all die Typen in einer [statischen Variablen benutzt werden](https://doc.rust-lang.org/book/const-and-static.html#static), die [`Sync`][Sync] aber nicht [`Drop`][Drop] implementieren.
+
+<h2 id="macros">Makros</h2>
+
+<h3><a href="#can-i-write-a-macro-to-generate-identifiers" name="can-i-write-a-macro-to-generate-identifiers">
+Kann ich ein Makro schreiben, das neue Bezeichner erzeugt?
+</a></h3>
+
+Momentan nicht. Rust-Makros sind [&„hygiensich“](https://en.wikipedia.org/wiki/Hygienic_macro) und vermeiden damit absichtlich das Reservieren oder Erzeugen von Bezeichnern, die unerwartete Kollisionen mit anderem Code auslösen können. Ihre Fähigkeiten unterscheiden sich grundsätzlich von Makros, wie sie vom C-Präprozessor bekannt sind. Makro-Aufrufe können nur an explizit erlaubten Positionen im Code auftauchen: An Stelle von Definitionen (_items_) auf Modulebene, Methodendeklarationen, Statements, Ausdrücken, und Patterns. Sie können nicht benutzt werden, um eine partielle Methodendeklaration oder Variablendeklaration zu vervollständigen.
+
+<h2 id="debugging">Fehlersuche und Werkzeuge</h2>
+
+<h3><a href="#how-do-i-debug-rust-programs" name="how-do-i-debug-rust-programs">
+Wie finde ich Fehler in meinem Rust-Programm?
+</a></h3>
+
+Rust-Programme können mit [gdb](https://sourceware.org/gdb/current/onlinedocs/gdb/) oder [lldb](http://lldb.llvm.org/tutorial.html) debuggt werden - genau wie C und C++. Jede Rust-Installation kommt mit rust-gdb, rust-lldb oder beidem, je nachdem was die Plattform unterstützt. Dabei handelt es sich um Wrapper um gdb und lldb, die Rust-Datenstrukturen lesbar ausgeben können (_pretty printing_).
+
+<h3><a href="#how-do-i-locate-a-panic" name="how-do-i-locate-a-panic">
+<code>rustc</code> behauptet, dass eine Panic im Code er Standardbibliothek aufgetreten ist. Wie kann ich den Fehler in meinem Code finden?
+</a></h3>
+
+Dieser Fehler tritt meistens auf, wenn aus Anwendungscode heraus [`unwrap()`][unwrap] auf einem `None`- oder `Err`-Wert aufgerufen wird. Ist beim Start des Programms die Umgebungsvariable `RUST_BACKTRACE=1` gesetzt, wird zusammen mit der Panic der Aufrufstapel ausgegeben, der zum Fehler geführt hat. Es hilft auch, das Projekt im Debug-Modus zu übersetzen (Standardverhalten für `cargo build`) und einen Debugger wie `rust-gdb` oder `rust-lldb` einzusetzen.
+
+<h3><a href="#what-ide-should-i-use" name="what-ide-should-i-use">
+Welche IDE sollte ich benutzen?
+</a></h3>
+
+Es gibt eine ganze Reihe an Entwicklungsumgebungen für Rust, die alle auf der [Seite zu IDEs](https://forge.rust-lang.org/ides.html) vorgestellt werden.
+
+<h3><a href="#wheres-rustfmt" name="wheres-rustfmt">
+<code>gofmt</code> ist toll! Wo ist <code>rustfmt</code>?
+</a></h3>
+
+`rustfmt` findest du [hier](https://github.com/rust-lang-nursery/rustfmt). Das Tool wird aktiv weiterentwickelt, um Rust-Code so leserlich und vorhersagbar wie möglich zu gestalten.
+
+<h2 id="low-level">Low-Level</h2>
+
+<h3><a href="#how-do-i-memcpy-bytes" name="how-do-i-memcpy-bytes">
+Kann ich Bytes wie mit <code>memcpy</code> kopieren?
+</a></h3>
+
+Wenn du nur einen Slice klonen möchtest, kannst du dafür [`clone_from_slice`][clone_from_slice] verwenden.
+
+Bytesequenzen, die sich möglicherweise überlappen, können mit [`copy`][copy] kopiert werden. Bist du dir sicher, dass sich Quelle und Ziel nicht überlappen, funktioniert auch das (etwas schnellere) [`copy_nonoverlapping`][copy_nonoverlapping]. Beide Funktionen sind `unsafe`, da sie die Sicherheitsgarantien von Rust verletzen können. Sie sollten nur mit Vorsicht eingesetzt werden.
+
+<h3><a href="#does-rust-work-without-the-standard-library" name="does-rust-work-without-the-standard-library">
+Kann Rust auch ohne Standardbibliothek vernünftig funktionieren?
+</a></h3>
+
+Absolut. Rust-Programme können die Standardbibliothek mit dem `#![no_std]`-Attribut abwählen. Damit kann weiterhin die Rust-Core-Bibliothek verwendet werden, die nur die plattformunabhängigen Primitive der Standardbibliothek enthält. Damit enthält sie keine Funktionalität zu I/O, Nebenläufigkeit, Heap-Allokation oder ähnlichem.
+
+<h3><a href="#can-i-write-an-operating-system-in-rust" name="can-i-write-an-operating-system-in-rust">
+Ist es möglich, ein Betriebssystem in Rust schreiben?
+</a></h3>
+
+Ja! Es gibt tatsächlich bereits [mehrere Projekte, die genau dieses Ziel verfolgen](http://wiki.osdev.org/Rust).
+
+<h3><a href="#how-can-i-write-endian-independent-values" name="how-can-i-write-endian-independent-values">
+Wie kann ich numerische Datentypen wie <code>i32</code> oder <code>f64</code> in Little- oder Big-Endian-Kodierung von einem Stream lesen oder in einen Stream schreiben?
+</a></h3>
+
+Diese Funktionalität wird vom [byteorder-Crate](http://burntsushi.net/rustdoc/byteorder/) zur Verfügung gestellt.
+
+<h3><a href="#does-rust-guarantee-data-layout" name="does-rust-guarantee-data-layout">
+Garantiert Rust ein spezifisches Layout von Datenstrukturen?
+</a></h3>
+
+Standardmäßig nicht. Allgemein gesprochen ist das Layout von `enum`s und `struct`s undefiniert. Das erlaubt Compileroptimierungen wie das Wiederverwenden von Padding für Enum-Diskriminanten, Kombinieren von Varianten verschachtelter Enums und Umordnen von Struct-Feldern, um Padding zu verringern. C-ähnlichen Enums (solchen ohne Daten innerhalb der Varianten) kann eine definierte Repräsentation zugewiesen werden:
+
+```rust
+enum CLike {
+    A,
+    B = 32,
+    C = 34,
+    D
+}
+```
+
+Solche Enums dürfen das Attribut `#[repr(C)]` tragen, um sie auf die Repräsentation festzulegen, die sie in äquivalentem C-Code hätten. Das erlaubt die Verwendung von Rust-Enums in FFI-Code, der nach C-Enums übersetzt. Das Attribut kann auch auf Structs angewendet werden, um ihnen das Layout des entsprechenden C-Structs zu verpassen.
+
+<h2 id="cross-platform">Plattformübergreifende Programmierung</h2>
+
+<!--
+### How do I build a Windows binary that doesn't display the console window?
+
+TODO: Write this answer.
+-->
+
+<!--
+### How do I make the console-less binary not crash on panic!?
+
+TODO: Write this answer.
+-->
+
+<h3><a href="#how-do-i-express-platform-specific-behavior" name="how-do-i-express-platform-specific-behavior">
+Was ist der idiomatische Weg, plattformspezifisches Verhalten in Rust auszudrücken?
+</a></h3>
+
+Plattformspezifisches Verhalten kann mit [Attributen zur bedingten Übersetzung](https://doc.rust-lang.org/reference/attributes.html#conditional-compilation) wie `target_os`, `target_family` oder `target_endian` beschrieben werden.
+
+<h3><a href="#can-rust-be-used-for-android-ios-programs" name="can-rust-be-used-for-android-ios-programs">
+Ist Rust für die Android/iOS-Programmierung tauglich?
+</a></h3>
+
+Ja! Es gibt bereits einige Beispiele für funktionierende Rust-Programme unter [Android](https://github.com/tomaka/android-rs-glue) und [iOS](https://www.bignerdranch.com/blog/building-an-ios-app-in-rust-part-1/). Das Aufsetzen erfordert etwas Arbeit, Rust kommt mit beiden Plattformen aber wunderbar zurecht.
+
+<h3><a href="#can-i-run-my-rust-program-in-a-web-browser" name="can-i-run-my-rust-program-in-a-web-browser">
+Kann ich mein Rust-Programm in einem Webbrowser ausführen?
+</a></h3>
+
+Wahrscheinlich. Rust hat [experimentelle Unterstützung][wasm] für [asm.js] und [WebAssembly].
+
+[wasm]: https://davidmcneil.gitbooks.io/the-rusty-web/
+[asm.js]: http://asmjs.org/
+[WebAssembly]: http://webassembly.org/
+
+<h3><a href="#how-do-i-cross-compile-rust" name="how-do-i-cross-compile-rust">
+Wie funktioniert Cross-Compilation in Rust?
+</a></h3>
+
+Rust kann Code für andere Systeme übersetzen, erfordert dafür aber [etwas Vorbereitsungsarbeit](https://github.com/japaric/rust-cross/blob/master/README.md). Jeder Rust-Compiler kann als Cross-Compiler arbeiten, Bibliotheken müssen aber zunächst für die Zielplattform übersetzt werden.
+
+Rust vertreibt [Kopien der Standardbibliothek](https://static.rust-lang.org/dist/index.html) für jede unterstützte Plattform; sie liegen in den `rust-std-*`-Dateien der Distribution für die jeweilige Plattform. Es existiert jedoch noch kein Automatismus, um diese Bibliotheken für Cross-Compilation zu installieren.
+
+<h2 id="modules-and-crates">Module und Crates</h2>
+
+<h3><a href="#what-is-the-relationship-between-a-module-and-a-crate" name="what-is-the-relationship-between-a-module-and-a-crate">
+Wie verhalten sich Crates und Module zueinander?
+</a></h3>
+
+- Ein Crate ist eine Übersetzungseinheit, also die kleinste Einheit, auf der der Rust-Compiler arbeiten kann.
+- Ein Modul ist eine (möglicherweise verschachtelte) Organisationseinheit innerhalb eines Crates.
+- Ein Crate enthält ein implizites, unbenanntes Modul auf Wurzelebene.
+- Rekursive Definitionen können sich über mehrere Module erstrecken, nicht aber über mehrere Crates.
+
+<h3><a href="#why-cant-the-rust-compiler-find-a-library-im-using" name="why-cant-the-rust-compiler-find-a-library-im-using">
+Warum kann der Rust-Compiler die Bibliothek nicht finden, die ich eingebunden habe?
+</a></h3>
+
+Hier gibt es eine Reihe von Möglichkeiten, aber ein häufiger Grund ist, dass die `use`-Deklaration nicht relativ zur Crate-Wurzel angegeben wurde. Versuche deine Deklarationen so zu schreiben, dass sie den gleichen Pfad haben wie wenn sie in der Wurzeldatei deines Projekts importiert würden.
+
+Es gibt außerdem noch die Schlüsselwörter `self` und `super`, die es erlauben, Pfade relativ zum aktuellen oder zum Elternmodul anzugeben.
+
+Mehr Informationen findest du im Kapitel ["Crates and Modules"](https://doc.rust-lang.org/stable/book/crates-and-modules.html) des Rust Book.
+
+<h3><a href="#why-do-i-have-to-declare-modules-with-mod" name="why-do-i-have-to-declare-modules-with-mod">
+Warum muss ich Moduldateien mit <code>mod</code> im Crate deklarieren, anstatt sie einfach mit <code>use</code> einzubinden?
+</a></h3>
+
+Module können in Rust auf zwei Arten deklariert werden: Direkt im Code, oder in einer separaten Datei. Hier ein Beispiel beider Varianten:
+
+```rust
+// In main.rs
+mod hello {
+    pub fn f() {
+        println!("Hallo!");
+    }
+}
+
+fn main() {
+    hello::f();
+}
+```
+
+```rust
+// In main.rs
+mod hello;
+
+fn main() {
+    hello::f();
+}
+
+// In hello.rs
+pub fn f() {
+    println!("Hallo!");
+}
+```
+
+Im ersten Beispiel wird das Modul in der Datei definiert, in der es auch benutzt wird. Im zweiten Beispiel weist die Moduldeklaration den Compiler darauf hin, die Definition aus `hello.rs` oder `hello/mod.rs` zu laden.
+
+`mod` deklariert also ein neues Modul, wogegen sich `use` auf ein anderswo existierendes Modul bezieht und dessen Inhalte in den aktuellen Gültigkeitsbereich übernimmt.
+
+<h3><a href="#how-do-i-configure-cargo-to-use-a-proxy" name="how-do-i-configure-cargo-to-use-a-proxy">
+Wie kann ich Cargo dazu bringen, einen Proxy zu verwenden?
+</a></h3>
+
+Wie in der [Cargo-Dokumentation](http://doc.crates.io/config.html) (englisch) beschrieben, kann ein Proxyserver eingerichtet werden, indem die `proxy`-Variable in der `[http]`-Sektion der Konfigurationsdatei gesetzt wird.
+
+<h3><a href="#why-cant-the-compile-find-method-implementations" name="why-cant-the-compile-find-method-implementations">
+Warum kann der Compiler eine Implementierung nicht finden, obwohl ich das Modul des Typs bereits importiert habe?
+</a></h3>
+
+Für Methoden, die über einen Trait definiert werden, muss die Trait-Deklaration explizit mit importiert werden. Es genügt also nicht, das Modul zu importieren, in dem der Trait für den Struct implementiert wird, sondern der Trait selbst muss zusätzlich eingebunden werden.
+
+<h3><a href="#why-cant-the-compiler-infer-use-statements" name="why-cant-the-compiler-infer-use-statements">
+Warum kann der Compiler <code>use</code>-Deklarationen nicht einfach herleiten?
+</a></h3>
+
+Er könnte wahrscheinlich, aber das willst du wahrscheinlich gar nicht. In einfachen Fällen könnte der Compiler wohl das korrekte Modul finden, indem er nach passenden Deklarationen zu einem Bezeichner sucht, das klappt im Allgemeinen aber nicht. Jede Entscheidungsregel bei Namenskonflikten würde in einigen Fällen für Überraschung sorgen, und Rust zieht es vor die Herkunft von Symbolen explizit zu benennen.
+
+So könnte der Compiler etwa festlegen, dass bei einem Namenskonflikt das erste importierte Modul Vorrang hat. Definieren also die beiden Module `foo` und `bar` jeweils den Bezeichner `baz`, `foo` ist aber das erste registrierte Modul, so würde der Compiler ein `use foo::baz;` einfügen.
+
+```rust
+mod foo;
+mod bar;
+
+// use foo::baz  // wird vom Compiler eingefügt
+
+fn main() {
+  baz();
+}
+```
+
+Wenn du sicher weißt, dass das passieren wird, kann das einige wenige Tastenanschläge einsparen. Dieser Gewinn wird aber mit deutlich höheren Wahrscheinlichkeit an überraschenden Fehlermeldungen erkauft, falls mit `baz()` eigentlich `bar::baz` gemeint war. Auch reduziert diese Logik die Lesbarkeit des Codes, weil ein Funktionsaufruf plötzlich von der Importreihenfolge abhängt. Diesen Trade-Off wollen wir nicht eingehen.
+
+Zukünftig könnten jedoch IDEs die Auflösung von Deklarationen erleichtern: Hilfestellung beim Finden des richtigen Imports, aber explizite Modulpfade im Code.
+
+<!--
+### How do I package and archive crates from [https://crates.io](https://crates.io)?
+
+TODO: Write this answer.
+-->
+
+<h3><a href="#how-do-i-do-dynamic-rust-library-loading" name="how-do-i-do-dynamic-rust-library-loading">
+Wie kann ich in Rust dynamische Bibliotheken laden?
+</a></h3>
+
+Dynamische Bibliotheken können mit [libloading](https://crates.io/crates/libloading) importiert werden, das ein plattformübergreifendes System für dynamisches Linken bereitstellt.
+
+<h3><a href="#why-doesnt-crates-io-have-namespaces" name="why-doesnt-crates-io-have-namespaces">
+Warum hat crates.io keine Namensräume?
+</a></h3>
+
+Übersetzung der [offiziellen Erklärung](https://internals.rust-lang.org/t/crates-io-package-policies/1041) zum Design von [https://crates.io](https://crates.io):
+
+> Im ersten Monat nach der Veröffentlichung von crates.io wurden wir von mehreren Nutzern nach der Möglichkeit gefragt, [Pakete mit Namensräumen](https://github.com/rust-lang/crates.io/issues/58) einzuführen.<br><br>
+>
+> Auch wenn Namensräume es Autoren einfacher macht, generische Namen für Pakete zu wählen, erhöhen sie die Komplexität, mit der Crates im Rust-Code und in der Kommunikation zwischen Entwicklern referenziert werden. Auf den ersten Blick erlauben sie mehreren Entwicklern, Namen wie `http` zu wählen, das sorgt aber nur dafür, dass diese Pakete als `wycats' http` oder `reem's http` bekannt werden, was keine wirkliche Verbesserung gegenüber längeren Namen wie `wycats-http` oder `reem-http` bringt.<br><br>
+>
+> Es hat sich herausgestellt, dass Entwickler in Ökosystemen ohne Namensräume dazu tendieren, kreativere Namen (wie `nokogiri` statt `tenderlove's libxml2`) zu wählen. Diese Namen sind meist kurz und gut zu merken, gerade aufgrund der fehlenden Hierarchie. Das macht es einfacher, unmissverständlich über Pakete zu sprechen und erschafft spannende Markennamen. Auch haben wir den Erfolg von Umgebungen mit zigtausenden Paketen wie NPM und RubyGems gesehen, die wunderbar mit einem einheitlichen Namensraum zurechtkommen.<br><br>
+>
+> Kurz gesagt sind wir nicht der Meinung, dass das das Cargo-Ökosystem davon profitieren würde, wenn Piston einen Namen wie `bvssvni/game-engine` statt dem einfach zu merkenden `piston` bekommen hätte (mit der Möglichkeit, dass ein Anderer Entwickler `wycats/game-engine` veröffentlicht).
+>
+> Da Namensräume auf verschiedene Arten strikt komplexer ist und sie bei bedarf später hinzugefügt werden können, sollten sie irgendwann nötig werden, werden wir vorerst bei einem gemeinsamen Namensraum bleiben.<br><br>
+
+<h2 id="libraries">Bibliotheken</h2>
+
+<h3><a href="#how-can-i-make-an-http-request" name="how-can-i-make-an-http-request">
+Wie kann ich eine HTTP-Anfrage absetzen?
+</a></h3>
+
+Die Standardbibliothek stellt keine HTTP-Implementierung zur Verfügung, deshalb musst du dafür einen externen Crate bemühen.
+[reqwest](http://docs.rs/reqwest) ist einer der einfachsten.  Er setzt auf [hyper](https://github.com/hyperium/hyper) auf und ist in Rust geschrieben,
+es gibt jedoch [eine Vielzahl an Alternativen](https://crates.io/keywords/http).
+Der [curl](https://docs.rs/curl)-Crate ist beispielsweise weit verbreitet und bildet eine Anbindung an die curl-Bibliothek.
+
+<h3><a href="#how-can-i-write-a-gui-application" name="how-can-i-write-a-gui-application">
+Wie kann ich in Rust eine grafische Benutzeroberfläche schreiben?
+</a></h3>
+
+Es gibt eine große Auswahl von [GUI-Frameworks](https://github.com/kud1ing/awesome-rust#gui) für Rust.
+
+<h3><a href="#how-can-i-parse-json-xml" name="how-can-i-parse-json-xml">
+Wie kann ich JSON oder XML parsen?
+</a></h3>
+
+[Serde](https://github.com/serde-rs/serde) ist die empfohlene Bibliothek für (De-)Serialisierung von Rust-Datenstrukturen von und in eine Reihe von Datenformaten.
+
+<h3><a href="#is-there-a-standard-2d-vector-crate" name="is-there-a-standard-2d-vector-crate">
+Gibt es einen Standard-Crate für 2D-Vektorgrafik?
+</a></h3>
+
+Noch nicht! Lust einen zu bauen?
+
+<h3><a href="#how-do-i-write-an-opengl-app" name="how-do-i-write-an-opengl-app">
+Wie kann ich in Rust ein OpenGL-Programm schreiben?
+</a></h3>
+
+[Glium](https://github.com/tomaka/glium) ist die größte Bibliothek für OpenGL-Programmierung in Rust. [GLFW](https://github.com/bjz/glfw-rs) ist auch eine solide Option.
+
+<h3><a href="#can-i-write-a-video-game-in-rust" name="can-i-write-a-video-game-in-rust">
+Kann ich in Rust ein Computerspiel schreiben?
+</a></h3>
+
+Ja! Die wichtigste Bibliothek für Spieleprogrammierung in Rust ist [Piston](http://www.piston.rs/), und es gibt sowohl ein [Subreddit für Spieleprogrammierung in Rust](https://www.reddit.com/r/rust_gamedev/), als auch einen IRC-Kanal (`#rust-gamedev` im [Mozilla-IRC](https://wiki.mozilla.org/IRC)) zu diesem Thema.
+
+<h2 id="design-patterns">Design Patterns</h2>
+
+<h3><a href="#is-rust-object-oriented" name="is-rust-object-oriented">
+Ist Rust objektorientiert?
+</a></h3>
+
+Rust ist eine Mehrparadigmensprache. Viele Konzepte aus OOP-Sprachen können nach Rust übernommen werden, aber nicht alle, und nicht immer mit dem gewohnten Abstraktionsmechanismus.
+
+<h3><a href="#how-do-i-map-object-oriented-concepts-to-rust" name="how-do-i-map-object-oriented-concepts-to-rust">
+Wie kann ich objektorientierte Konzepte in Rust abbilden?
+</a></h3>
+
+Kommt darauf an. Es _gibt_ Möglichkeiten, um objektorientierte Konzepte wie [Mehrfachvererbung](https://www.reddit.com/r/rust/comments/2sryuw/ideaquestion_about_multiple_inheritence/) nach Rust zu übersetzen, das Ergebnis kann aber aufgrund der nicht objektorientierten Natur von Rust deutlich von seinem Äquivalent in einer OOP-Sprache abweichen.
+
+<h3><a href="#how-do-i-configure-a-struct-with-optional-parameters" name="how-do-i-configure-a-struct-with-optional-parameters">
+Wie kann ich einen Struct mit optionalen Parametern konfigurieren?
+</a></h3>
+
+Die einfachste Möglichkeit ist es, den Typ [`Option`][Option] als Parameter für Funktionen wie `new` zu verwenden. Alternativ kannst du das [Builder Pattern](https://aturon.github.io/ownership/builders.html) implementieren, mit dem einzelne Attribute durch Funktionsaufrufe an einen Builder belegt werden, bevor der eigentliche Struct konstruiert wird.
+
+<h3><a href="#how-do-i-do-global-variables" name="how-do-i-do-global-variables">
+Wie benutze ich globale Variablen in Rust?
+</a></h3>
+
+Globale Konstanten werden mit dem Schlüsselwort `const` deklariert, globale Variablen mit `static`. Beachte, dass das Verändern einer `static mut`-Variablen `unsafe`-Code erfordert, da es Data Races erlaubt, deren Absenz von Safe Rust garantiert wird. Ein wichtiger Unterschied zwischen `const` und `static` ist, dass auf `static`-Variablen Referenzen gebildet werden können - `const`-Werte haben keine definierte Speicheradresse. Für weitere Informationen zum Thema `const` vs. `static` sei auf das [Buch](https://doc.rust-lang.org/book/const-and-static.html) verwiesen.
+
+<h3><a href="#how-can-i-set-compile-time-constants-that-are-defined-procedurally" name="how-can-i-set-compile-time-constants-that-are-defined-procedurally">
+Wie kann ich Compilezeit-Konstanten definieren, die prozedural berechnet werden?
+</a></h3>
+
+Rust hat momentan nur eingeschränkte Unterstützung für Compilezeit-Konstanten. Du kannst Werte eines primitiven Typs mittels `const`-Deklarationen definieren (ähnlich zu `static`, aber unveränderlich und ohne eine feste Speicheradresse). Funktionen können ebenfalls `const` sein.
+
+Konstanten, die sich mit diesen Mechanismen nicht beschreiben lassen, können mit dem [`lazy-static`](https://github.com/rust-lang-nursery/lazy-static.rs)-Crate erzeugt werden, der Compilezeit-Berechnung durch Auswertung bei der ersten Benutzung einer globalen Variablen emuliert.
+
+<h3><a href="#can-i-run-code-before-main" name="can-i-run-code-before-main">
+Kann ich vor Betreten der `main`-Funktion Initialisierungscode ausführen?
+</a></h3>
+
+Rust kennt keine Programmausführung vor `main`. Am nächsten kommt dem Konzept der [`lazy-static`](https://github.com/Kimundi/lazy-static.rs)-Crate, der dieses Verhalten nachbildet, indem globale Variablen bei ihrer ersten Benutzung initialisiert werden.
+
+<!--
+
+This answer needs significant work. Let's revise after the initial posting. --aturon
+
+<h3><a href="#why-doesnt-rust-have-inheritance" name="why-doesnt-rust-have-inheritance">
+Warum hat Rust keine Vererbung?
+</a></h3>
+
+Es gibt für das Wort "Vererbung" (eng.: "Inheritance") zwei verschiedene Bedeutungen: _subtyping_ und _interface sharing_. Beide Zwecke werden durch Traits bereits erfüllt.
+
+Traits erlauben es, Subtypen zu definieren, was Polymorphismus ermöglicht.
+
+Interface sharing wird durch Trait-Methoden ermöglicht. Diese definieren eine Menge von zusammengehörigen Funktionen, welche für jede Implementierung dieses Traits vorhanden sein müssen.
+
+Rust hat stets daran gearbeitet, keine Features zu haben, deren Zwecke sich überlappen - dadurch bleiben Features orthogonal. Aus diesem Grund, und weil die nützlichen Aspekte von Vererbung durch Traits abgedeckt werden, hat man sich entschieden, Vererbung in Rust nicht zu unterstützen.
+
+-->
+
+<h3><a href="#does-rust-allow-non-constant-expression-values-for-globals" name="does-rust-allow-non-constant-expression-values-for-globals">
+Erlaubt Rust Werte für globale Variablen, die keine Compilezeit-Konstanten sind?
+</a></h3>
+
+Nein. Globale Variablen können keine nicht-compilezeit-konstanten Konstruktoren und überhaupt keine Destruktoren besitzen. Statische Konstruktoren sind unerwünscht, da bei gegenseitigen Abhängigkeiten eine Initialisierungsreihenfolge nicht ohne weiteres garantiert werden kann. Codeausführung vor Beginn der `main`-Funktion wird weithin als Misfeature gesehen, weswegen es in Rust nicht umgesetzt ist.
+
+Das [C++ FQA](http://yosefk.com/c++fqa/ctors.html#fqa-10.12) hat einen Eintrag zum "static initialization order fiasco", und [Eric Lipperts Blog](https://ericlippert.com/2013/02/06/static-constructors-part-one/) schreibt über die Herausforderungen, die das Feature in C# mit sich gebracht hat.
+
+Nicht-konstante Initialisierer in globalen Variablen können mit dem [lazy-static](https://crates.io/crates/lazy_static/) nachgebildet werden.
+
+<h2 id="other-languages">Andere Sprachen</h2>
+
+<h3><a href="#how-can-i-use-static-fields" name="how-can-i-use-static-fields">
+Wie kann ich ein C-Konstrukt wie <code>struct X { static int X; }</code> in Rust implementieren?
+</a></h3>
+
+Rust kennt keine `static`-Attribute wie im obigen Programmausschnitt. Stattdessen kannst du eine `static`-Variable auf Modulebene deklarieren, die nur im umgebenden Modul sichtbar ist.
+
+<h3><a href="#how-can-i-convert-a-c-style-enum-to-an-integer" name="how-can-i-convert-a-c-style-enum-to-an-integer">
+Wie kann ich einen C-ähnlichen Enum in einen Integer konvertieren und umgekehrt?
+</a></h3>
+
+Ein Enum kann mit einem `as`-Cast in einen Integer überführt werden, wie etwa `e as i64` (wobei `e` ein Enum ist).
+
+Die Gegenrichtung kann mit einem `match`-Statement erreicht werden, das Zahlenwerte auf Enum-Werte abbildet.
+
+<h3><a href="#why-do-rust-programs-have-larger-binary-sizes-than-C-programs" name="why-do-rust-programs-have-larger-binary-sizes-than-C-programs">
+Warum erzeugen Rust-Programme größere Binaries als C?
+</a></h3>
+
+Mehrere Faktoren tragen dazu bei, dass Rust-Programme standardmäßig größere Binaries erzeugen als funktionell äquivalente C-Programme. Grundsätzlich optimiert Rust die Performance komplexer Anwendungen, nicht die Größe kleiner Beispielprogramme.
+
+__Monomorphisierung__
+
+Rust monomorphisiert seine Generics, was bedeutet, dass eine generische Funktion oder ein generischer Typ für jeden konkreten Typ, mit dem er instanziiert wird, neu übersetzt wird. Das ist ähnlich zum Verhalten von Templates in C++. Zum Beispiel werden im folgenden Programm
+
+```rust
+fn foo<T>(t: T) {
+    // ... tu irgendwas
+}
+
+fn main() {
+    foo(10);       // i32
+    foo("hello");  // &str
+}
+```
+
+zwei unabhängige Versionen von `foo` im fertigen Programm auftauchen, jeweils für `i32` und `&str` spezialisiert. Das erlaubt effiziente frühe Bindung der generischen Funktion, sorgt aber für größere Binaries.
+
+__Debug-Symbole__
+
+Rust-Programme beinhalten auch im Release-Modus einige Debug-Symbole. Diese ermöglichen Backtraces bei Panics und können mit `strip` oder einem ähnlichen Tool aus dem Binary entfernt werden. Der Release-Modus in Cargo ist zum Optimierungslevel 3 in rustc äquivalent. [Mittlerweile](https://github.com/rust-lang/rust/pull/32386) kennt Rust eine alternative Optimierungsstrategie (Level `s` oder `z`),  mit der der Compiler versucht, die Größe statt der Performance des Programms zu optimieren.
+
+__Jemalloc__
+
+Rust benutzt standardmäßig jemalloc als Allokator, was die erzeugten Binaries etwas vergrößert. Jemalloc bietet einen konsistentere Allokation mit günstigerer Performance als viele systemeigenen Allokatoren. In Zukunft wird es auch einfacher sein, [benutzerdefinierte Allokatoren](https://github.com/rust-lang/rust/issues/32838) in Rust einzubinden.
+
+__Link-Time Optimization__
+
+Rust benutzt standardmäßig keine Link-Time-Optimization, kann aber so eingerichtet werden. Das erhöht das Optimierungspotential des Rust-Compilers und kann einen kleinen Effekt auf die Größe der Binaries haben. Dieser Effekt wird vor allem in Kombination mit den oben genannten Optimierungsstrategien sichtbar.
+
+__Standardbibliothek__
+
+Die Standardbibliothek von Rust beinhaltet libbacktrace und libunwind, die in manchen Programmen unerwünscht sein können. Mit dem Crate-Attribut `#![no_std]` können ohne diese Bibliotheken kleinere Binaries erzeugt werden, die aber üblicherweise wesentliche Änderungen am Code nach sich ziehen. Rust-Code, der ohne die Standardbibliothek geschrieben wurde, ist funktionell äquivalentem C-Code ähnlich.
+
+Als Beispiel liest das folgende C-Programm einen Namen ein und begrüßt den Benutzer mit diesem Namen.
+
+```c
+#include <stdio.h>
+
+int main(void) {
+    printf("Wie heißt du?\n");
+    char input[100] = {0};
+    scanf("%s", input);
+    printf("Hallo %s!\n", input);
+    return 0;
+}
+```
+
+In Rust würde man dieses Programm womöglich wie folgt schreiben:
+
+```rust
+use std::io;
+
+fn main() {
+    println!("Wie heißt du?");
+    let mut input = String::new();
+    io::stdin().read_line(&mut input).unwrap();
+    println!("Hallo {}!", input);
+}
+```
+
+Dieses Programm wird übersetzt ein größeres Binary produzieren und mehr Speicher in Anspruch nehmen als das C-Programm. Es ist aber nicht wirklich gleichwertig zum obigen C-Code. Das äquivalente Rust-Programm würde eher so aussehen:
+
+```rust
+#![feature(lang_items)]
+#![feature(libc)]
+#![feature(no_std)]
+#![feature(start)]
+#![no_std]
+
+extern crate libc;
+
+extern "C" {
+    fn printf(fmt: *const u8, ...) -> i32;
+    fn scanf(fmt: *const u8, ...) -> i32;
+}
+
+#[start]
+fn start(_argc: isize, _argv: *const *const u8) -> isize {
+    unsafe {
+        printf(b"Wie heißt du?\n\0".as_ptr());
+        let mut input = [0u8; 100];
+        scanf(b"%s\0".as_ptr(), &mut input);
+        printf(b"Hallo %s!\n\0".as_ptr(), &input);
+        0
+    }
+}
+
+#[lang="eh_personality"] extern fn eh_personality() {}
+#[lang="panic_fmt"] fn panic_fmt() -> ! { loop {} }
+#[lang="stack_exhausted"] extern fn stack_exhausted() {}
+```
+
+Dieser Code sollte in seinem Speicherverbrauch grob der C-Version entsprechen. Diese Reduktion wird mit zusätzlicher Komplexität und dem Fehlen statischer Garantien erkauft, die Rust üblicherweise gewährt (und die hier mit dem Schlüsselwort `unsafe` umgangen wurden).
+
+<h3><a href="#why-no-stable-abi" name="why-no-stable-abi">
+Warum hat Rust keine stabile ABI wie C, und warum muss ich Symbole mit extern annotieren?
+</a></h3>
+
+Das Festlegen einer ABI ist eine große Entscheidung, die zukünftige Änderungen an der Sprache behindern könnte. Da Rust erst im Mai 2015 Version 1.0 erreicht hat, ist es noch zu früh, sich an dieser Stelle festzulegen. Das bedeutet nicht, dass es nie eine stabile ABI geben wird (auch wenn C++ es viele Jahre ohne Spezifikation einer ABI geschafft hat).
+
+Über das Rust-Schlüsselwort `extern` kann mit spezifischen ABIs wie der C-ABI interagiert werden.
+
+<h3><a href="#can-rust-code-call-c-code" name="can-rust-code-call-c-code">
+Kann Rust-Code C-Code aufrufen?
+</a></h3>
+
+Ja. Rust wurde so entworfen, dass C-Code genauso effizient aufgerufen kann wie aus C++.
+
+<h3><a href="#can-c-code-call-rust-code" name="can-c-code-call-rust-code">
+Kann C-Code Rust-Code Aufrufen?
+</a></h3>
+
+Ja. Der Rust-Code muss mit einer `extern`-Deklaration versehen werden, die ihn C-ABI-kompatibel macht. Eine solche Funktion kann als Funktionszeiger an C übergeben werden oder sogar direkt aus C aufgerufen werden, wenn sie mit dem `#[no_mangle]`-Attribut erhält, um Symbol-Mangling zu unterdrücken.
+
+<h3><a href="#why-rust-vs-cxx" name="why-rust-vs-cxx">
+Ich kann bereits perfektes C++ schreiben. Welche Vorteile bietet mir Rust?
+</a></h3>
+
+Modernes C++ implementiert viele Features, die das Schreiben sicheren und korrekten Codes weniger fehleranfällig macht. Es ist jedoch immer noch sehr einfach, Speicherfehler zu verursachen. Die C++-Hauptentwickler arbeiten daran die Prävalenz dieser Problematik zu verringern, die Sprache lässt aber durch ihre lange Geschichte und die notwendige Rückwärtskompatibilität nur eingeschränkt Änderungen zu.
+
+Rust wurde vom ersten Tag an mit dem Ziel entworfen, eine sichere Systemprogrammiersprache zu sein. Sie ist damit nicht von historischen Entscheidungen belastet, die das Entwickeln sicheren Codes in C++ so kompliziert machen. In C++ wird Sicherheit durch strenge Selbstdisziplin erreicht und kann leicht verletzt werden. In Rust ist Sicherheit die Vorgabe. Die Sprache eröffnet so die Möglichkeit, mit weniger erfahrenen Entwicklern zusammenzuarbeiten, ohne den Code wieder und wieder auf Sicherheitslücken prüfen zu müssen.
+
+<h3><a href="#how-to-get-cxx-style-template-specialization" name="how-to-get-cxx-style-template-specialization">
+Wie lässt sich die Templatespezialisierung aus C++ in Rust umsetzen?
+</a></h3>
+
+Rust hat zur Zeit noch kein Äquivalent zu Templatespezialisierung, daran [wird jedoch gearbeitet](https://github.com/rust-lang/rfcs/pull/1210). Ähnliche Effekte können aber mittels [Assoziierter Typen](https://doc.rust-lang.org/stable/book/associated-types.html) erzielt werden.
+
+<h3><a href="#how-does-ownership-relate-to-cxx-move-semantics" name="how-does-ownership-relate-to-cxx-move-semantics">
+Was hat das Ownership-System von Rust mit Move Semantics aus C++ zu tun?
+</a></h3>
+
+Die zugrundeliegenden Konzepte sind ähnlich, in der Praxis funktionieren die beiden Systeme jedoch grundsätzlich verschieden. In beiden Fällen fungiert das Verschieben (Move) eines Werts als Möglichkeit, den Besitz zugrundeliegender Ressourcen zu übertragen. So überträgt der Move eines Strings etwa den Stringpuffer, anstatt ihn zu kopieren.
+
+In Rust ist Ownership Transfer das Standardverhalten. So wird eine Funktion, die einen `String` als Argument nimmt, den Besitz am übergebenen String-Wert übernehmen:
+
+```rust
+fn process(s: String) { }
+
+fn caller() {
+    let s = String::from("Hello, world!");
+    process(s); // Überträgt den Besitz von `s` an `process`
+    process(s); // Fehler: `caller` besitzt `s` an dieser Stelle nicht mehr
+}
+```
+
+Wie im Codebeispiel oben zu sehen, überträgt der erste Aufruf an `process` den Besitz an der Variablen `s`. Der Compiler führt über den Besitz von Werten Buch, sodass der zweite Aufruf an `process` einen Fehler zur Folge hat - ein gültiges Programm darf den Besitz eines Werts nicht zweimal aufgeben. Rust wird das Verschieben eines Werts auch verhindern, solange noch eine aktive Referenz darauf existiert.
+
+C++ verfolgt einen anderen Ansatz. In C++ werden Werte per Vorgabe kopiert, in dem ihr Kopierkonstruktor aufgerufen wird. Es ist allerdings möglich, Funktionen zu deklarieren, die ihre Argumente als "rvalue-Referenz", wie etwa `string&&` übernehmen. Dies deutet darauf hin, dass die aufgerufene Funktion den Besitz an Ressourcen des Werts übernimmt. Der Aufrufer muss dazu entweder einen temporären Wert übergeben oder einen gebundenen Wert explizit mit `std::move` verschieben. Das obige Beispiel würde in C++ etwa wie folgt aussehen:
+
+```cpp
+void process(string&& s) { }
+
+void caller() {
+    string s("Hello, world!");
+    process(std::move(s));
+    process(std::move(s));
+}
+```
+
+C++-Compiler müssen über Ownership nicht Buch führen, sodass der obige Code ohne Warnungen oder Fehler übersetzt. In C++ bleibt der Besitz der Variablen `s` weiterhin bei `caller` (nicht aber der interne Puffer des Strings), sodass trotzdem der Destruktor von `s` ausgeführt wird, sobald `caller` zurückkehrt. In Rust wird `drop` dagegen nur durch den neuen Besitzer des Werts aufgerufen.
+
+<h3><a href="#how-to-interoperate-with-cxx" name="how-to-interoperate-with-cxx">
+Wie kann ich aus Rust C++-Funktionen aufrufen und umgekehrt?
+</a></h3>
+
+Rust und C++ können C als gemeinsame Schnittstelle benutzen. Sowohl Rust als auch C++ besitzen ein [Foreign Function Interface](https://doc.rust-lang.org/book/ffi.html) nach C über das sie miteinander kommunizieren können. Falls das Schreiben von C-Bindings zu langwierig wird, kannst du jederzeit auf [rust-bindgen](https://github.com/servo/rust-bindgen) zurückgreifen, ein Tool, das dir hilft automatisch funktionierende C-Bindings für Rust zu bauen.
+
+<h3><a href="#does-rust-have-cxx-style-constructors" name="does-rust-have-cxx-style-constructors">
+Hat Rust Konstruktoren, wie sie aus C++ bekannt sind?
+</a></h3>
+
+Nein. Funktionen erfüllen den gleichen Zweck wie Konstruktoren, ohne die Sprachkomplexität zu erhöhen. Der übliche Name für eine Konstrukorfunktion in Rust ist `new()`, dabei handelt es sich aber lediglich um eine Namenskonvention. `new()` ist tatsächlich eine Funktion wie jede andere. Hier ein Beispiel:
+
+```rust
+struct Foo {
+    a: i32,
+    b: f64,
+    c: bool,
+}
+
+impl Foo {
+    fn new() -> Foo {
+        Foo {
+            a: 0,
+            b: 0.0,
+            c: false,
+        }
+    }
+}
+```
+
+<h3><a href="#does-rust-have-copy-constructors" name="does-rust-have-copy-constructors">
+Hat Rust Kopierkonstruktoren?
+</a></h3>
+
+Nicht direkt. Typen, die den `Copy`-Trait implementieren, führen eine C-artige, "flache Kopie" ohne zusätzliche Arbeit oder Funktionsaufrufe durch. Das entspricht dem Konzept der *trivially copyable types* aus C++. Es ist nicht möglich, `Copy` mit abweichendem Verhalten zu implementieren. Dazu dient der `Clone`-Trait, dessen Funktionalität durch einen expliziten Aufruf an die `clone`-Methode angesprochen wird. Die benutzerdefininerte Kopieroperation wird absichtlich explizit gehalten um die zugrundeliegende Komplexität und potentiell teure Operationen sichtbar zu machen.
+
+<h3><a href="#does-rust-have-move-constructors" name="does-rust-have-move-constructors">
+Hat Rust Move-Konstruktoren?
+</a></h3>
+
+Nein. Die Werte aller Typen werden Byte für Byte via `memcpy` verschoben. Das macht das Schreiben generischen `unsafe`-Codes deutlich einfacher, da das Zuweisen, Übergeben und Zurückgeben eines Werts nie Seiteneffekte wie Unwinding zur Folge haben kann.
+
+<h3><a href="#compare-go-and-rust" name="compare-go-and-rust">
+Was haben Go und Rust gemeinsam, und wo unterscheiden sich die Sprachen?
+</a></h3>
+
+Rust und Go haben grundsätzlich verschiedene Designziele. Alle Unterschiede aufzuzählen wäre zu umfangreich, im Folgenden werden einige der wichtigsten genannt.
+
+- Rust arbeitet auf einer niedrigeren Ebene als Go. So setzt Rust im Gegensatz zu Go beispielsweise keinen Garbage Collector voraus. Allgemein bietet Rust ähnlich viel Kontrolle über das Verhalten eines Programms wie C oder C++.
+- Der Fokus von Rust liegt darin, Sicherheit und Effizienz zu gewährleisten, gleichzeitig aber für High-Level-Abstraktionen zugänglich zu sein. Go konzentriert sich darauf, eine kleine, einfache Sprache zu sein, die schnell kompiliert und gut mit einer großen Auswahl an Tools zusammenzuarbeiten.
+- Rust hat im Gegensatz zu Go gute Unterstützung für Generics.
+- Rust ist stark von der Welt der Funktionalprogrammierung beeinflusst, was sich etwa im Typsystem äußert, das die Typklassen aus Haskell in der Form von Traits übernimmt. Go hat ein einfacheres Typsystem, das mit Interfaces einfache generische Programmierung ermöglicht.
+
+<h3><a href="#how-do-rust-traits-compare-to-haskell-typeclasses" name="how-do-rust-traits-compare-to-haskell-typeclasses">
+Wie lassen sich Traits in Rust mit den Typklassen von Haskell vergleichen?
+</a></h3>
+
+Rust-Traits sind ähnlich, aber weniger mächtig als Haskell-Typklassen, da Rust keine typen höherer Ordnung unterstützt. Assoziierte Typen in Rust entsprechen Typfamilien in Haskell.
+
+Einige spezifische Unterschiede zwischen Haskell und Rust:
+
+- Rust-Traits haben einen impliziten ersten Parameter `Self`. `trait Bar` in Rust entspricht damit `class Bar self` in Haskell, und `trait Bar<Foo>` entspricht `class Bar foo self`.
+- "Supertraits" oder "Superklassen-Constraints" werden in Rust `trait Sub: Super` geschrieben, in Haskell `class Super self => Sub self`.
+- Rust erlaubt keine verwaisten Instanzen (orphan instances), d.h. Trait-Implementierungen, die weder im Modul des Traits noch im Modul des Typs liegen. Haskell erlaubt dies, was zu abweichenden Kohärenzregeln führt.
+- Die Auflösung von `impl`-Blöcken berücksichtigt die relevanten `where`-Klauseln, um zwischen `impl`-Instanzen zu wählen oder Überlappungen festzustellen. Haskell berücksichtigt dabei nur die Bedingungen der `instance`-Deklaration und vernachlässigt Einschränkungen, die an anderen Stellen angegeben wurden.
+- Eine Teilmenge der Traits in Rust ([Object Safe Traits](https://github.com/rust-lang/rfcs/blob/master/text/0255-object-safety.md)) können für späte Bindung mittels Traitobjekten benutzt werden. Das selbe ist in Haskell mit dem `ExistentialQuantification`-Feature von GHC verfügbar.
+
+<h2 id="documentation">Dokumentation</h2>
+
+<h3><a href="#why-are-so-many-rust-answers-on-stackoverflow-wrong" name="why-are-so-many-rust-answers-on-stackoverflow-wrong">
+Warum gibt es so viele falsche Antworten zu Rust auf Stack Overflow?
+</a></h3>
+
+Rust hatte bis zur Veröffentlichung von Version 1.0 im Mai 2015 eine lange Entwicklungsgeschichte hinter sich. Währenddessen hat sich die Sprache signifikant geändert, und einige Antworten auf Stack Overflow beziehen sich auf Sprach- und Bibliothekskonstrukte, die sich mittlerweile geändert haben.
+
+Mit der Zeit werden immer mehr Antworten für die aktuelle Version von Rust entstehen, sodass der Anteil der veralteten Antworten abnehmen wird.
+
+<h3><a href="#where-do-i-report-issues-in-the-rust-documentation" name="where-do-i-report-issues-in-the-rust-documentation">
+Wie kann ich die Entwickler auf Fehler in der Rust-Dokumentation hinweisen?
+</a></h3>
+
+Probleme in der Dokumentation kannst du im Rust-Compiler [Issue Tracker](https://github.com/rust-lang/rust/issues) melden. Lies vorab unsere [Richtlinien](https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md#writing-documentation), um effektiv mitwirken zu können.
+
+<h3><a href="#how-do-i-view-rustdoc-documentation-for-a-library-my-project-depends-on" name="how-do-i-view-rustdoc-documentation-for-a-library-my-project-depends-on">
+Wo finde ich die rustdoc-Dokumentation für eine Bibliothek, von der mein Projekt abhängt?
+</a></h3>
+
+Wenn du `cargo doc` aufrufst, um Dokumentation für dein Projekt zu generieren, wird automatisch auch die Dokumentation für aktiven Versionen aller Abhängigkeiten erzeugt. Diese landet im Unterverzeichnis `target/doc` deines Projekts. Um die Dokumentation nach der Erstellung zu öffnen, kannst du `cargo doc --open` benutzen oder einfach direkt `target/doc/index.html` in deinem Browser öffnen.
+
+[Vec]: https://doc.rust-lang.org/stable/std/vec/struct.Vec.html
+[HashMap]: https://doc.rust-lang.org/stable/std/collections/struct.HashMap.html
+[Into]: https://doc.rust-lang.org/stable/std/convert/trait.Into.html
+[From]: https://doc.rust-lang.org/stable/std/convert/trait.From.html
+[Eq]: https://doc.rust-lang.org/stable/std/cmp/trait.Eq.html
+[PartialEq]: https://doc.rust-lang.org/stable/std/cmp/trait.PartialEq.html
+[Ord]: https://doc.rust-lang.org/stable/std/cmp/trait.Ord.html
+[PartialOrd]: https://doc.rust-lang.org/stable/std/cmp/trait.PartialOrd.html
+[f32]: https://doc.rust-lang.org/stable/std/primitive.f32.html
+[f64]: https://doc.rust-lang.org/stable/std/primitive.f64.html
+[i32]: https://doc.rust-lang.org/stable/std/primitive.i32.html
+[i64]: https://doc.rust-lang.org/stable/std/primitive.i64.html
+[bool]: https://doc.rust-lang.org/stable/std/primitive.bool.html
+[Hash]: https://doc.rust-lang.org/stable/std/hash/trait.Hash.html
+[BTreeMap]: https://doc.rust-lang.org/stable/std/collections/struct.BTreeMap.html
+[VecMacro]: https://doc.rust-lang.org/stable/std/macro.vec!.html
+[String]: https://doc.rust-lang.org/stable/std/string/struct.String.html
+[to_string]: https://doc.rust-lang.org/stable/std/string/trait.ToString.html#tymethod.to_string
+[str]: https://doc.rust-lang.org/stable/std/primitive.str.html
+[str__find]: https://doc.rust-lang.org/stable/std/primitive.str.html#method.find
+[str__as_bytes]: https://doc.rust-lang.org/stable/std/primitive.str.html#method.as_bytes
+[u8]: https://doc.rust-lang.org/stable/std/primitive.u8.html
+[char]: https://doc.rust-lang.org/stable/std/primitive.char.html
+[Weak]: https://doc.rust-lang.org/stable/std/rc/struct.Weak.html
+[IntoIterator]: https://doc.rust-lang.org/stable/std/iter/trait.IntoIterator.html
+[Rc]: https://doc.rust-lang.org/stable/std/rc/struct.Rc.html
+[UnsafeCell]: https://doc.rust-lang.org/stable/std/cell/struct.UnsafeCell.html
+[Copy]: https://doc.rust-lang.org/stable/std/marker/trait.Copy.html
+[Clone]: https://doc.rust-lang.org/stable/std/clone/trait.Clone.html
+[Cell]: https://doc.rust-lang.org/stable/std/cell/struct.Cell.html
+[RefCell]: https://doc.rust-lang.org/stable/std/cell/struct.RefCell.html
+[Cow]: https://doc.rust-lang.org/stable/std/borrow/enum.Cow.html
+[Deref]: https://doc.rust-lang.org/stable/std/ops/trait.Deref.html
+[Arc]: https://doc.rust-lang.org/stable/std/sync/struct.Arc.html
+[Box]: https://doc.rust-lang.org/stable/std/boxed/struct.Box.html
+[Option]: https://doc.rust-lang.org/stable/std/option/enum.Option.html
+[Fn]: https://doc.rust-lang.org/stable/std/ops/trait.Fn.html
+[FnMut]: https://doc.rust-lang.org/stable/std/ops/trait.FnMut.html
+[FnOnce]: https://doc.rust-lang.org/stable/std/ops/trait.FnOnce.html
+[Result]: https://doc.rust-lang.org/stable/std/result/enum.Result.html
+[RandomState]: https://doc.rust-lang.org/stable/std/collections/hash_map/struct.RandomState.html
+[Add]: https://doc.rust-lang.org/stable/std/ops/trait.Add.html
+[AddAssign]: https://doc.rust-lang.org/stable/std/ops/trait.AddAssign.html
+[Sub]: https://doc.rust-lang.org/stable/std/ops/trait.Sub.html
+[SubAssign]: https://doc.rust-lang.org/stable/std/ops/trait.SubAssign.html
+[Mul]: https://doc.rust-lang.org/stable/std/ops/trait.Mul.html
+[MulAssign]: https://doc.rust-lang.org/stable/std/ops/trait.MulAssign.html
+[Div]: https://doc.rust-lang.org/stable/std/ops/trait.Div.html
+[DivAssign]: https://doc.rust-lang.org/stable/std/ops/trait.DivAssign.html
+[Neg]: https://doc.rust-lang.org/stable/std/ops/trait.Neg.html
+[Rem]: https://doc.rust-lang.org/stable/std/ops/trait.Rem.html
+[RemAssign]: https://doc.rust-lang.org/stable/std/ops/trait.RemAssign.html
+[BitAnd]: https://doc.rust-lang.org/stable/std/ops/trait.BitAnd.html
+[BitAndAssign]: https://doc.rust-lang.org/stable/std/ops/trait.BitAndAssign.html
+[BitOr]: https://doc.rust-lang.org/stable/std/ops/trait.BitOr.html
+[BitOrAssign]: https://doc.rust-lang.org/stable/std/ops/trait.BitOrAssign.html
+[BitXor]: https://doc.rust-lang.org/stable/std/ops/trait.BitXor.html
+[BitXorAssign]: https://doc.rust-lang.org/stable/std/ops/trait.BitXorAssign.html
+[Not]: https://doc.rust-lang.org/stable/std/ops/trait.Not.html
+[Shl]: https://doc.rust-lang.org/stable/std/ops/trait.Shl.html
+[ShlAssign]: https://doc.rust-lang.org/stable/std/ops/trait.ShlAssign.html
+[Shr]: https://doc.rust-lang.org/stable/std/ops/trait.Shr.html
+[ShrAssign]: https://doc.rust-lang.org/stable/std/ops/trait.ShrAssign.html
+[Deref]: https://doc.rust-lang.org/stable/std/ops/trait.Deref.html
+[DerefMut]: https://doc.rust-lang.org/stable/std/ops/trait.DerefMut.html
+[Index]: https://doc.rust-lang.org/stable/std/ops/trait.Index.html
+[IndexMut]: https://doc.rust-lang.org/stable/std/ops/trait.IndexMut.html
+[read__read_to_string]: https://doc.rust-lang.org/stable/std/io/trait.Read.html#method.read_to_string
+[Read]: https://doc.rust-lang.org/stable/std/io/trait.Read.html
+[std-io]: https://doc.rust-lang.org/stable/std/io/index.html
+[File]: https://doc.rust-lang.org/stable/std/fs/struct.File.html
+[read__read]: https://doc.rust-lang.org/stable/std/io/trait.Read.html#tymethod.read
+[read__read_to_end]: https://doc.rust-lang.org/stable/std/io/trait.Read.html#method.read_to_end
+[read__bytes]: https://doc.rust-lang.org/stable/std/io/trait.Read.html#method.bytes
+[read__chars]: https://doc.rust-lang.org/stable/std/io/trait.Read.html#method.chars
+[read__take]: https://doc.rust-lang.org/stable/std/io/trait.Read.html#method.take
+[BufReader]: https://doc.rust-lang.org/stable/std/io/struct.BufReader.html
+[Args]: https://doc.rust-lang.org/stable/std/env/struct.Args.html
+[TryMacro]: https://doc.rust-lang.org/stable/std/macro.try!.html
+[unwrap]: https://doc.rust-lang.org/stable/core/option/enum.Option.html#method.unwrap
+[Mutex]: https://doc.rust-lang.org/stable/std/sync/struct.Mutex.html
+[AtomicUsize]: https://doc.rust-lang.org/stable/std/sync/atomic/struct.AtomicUsize.html
+[Sync]: https://doc.rust-lang.org/stable/std/marker/trait.Sync.html
+[Drop]: https://doc.rust-lang.org/stable/std/ops/trait.Drop.html
+[clone_from_slice]: https://doc.rust-lang.org/stable/std/primitive.slice.html#method.clone_from_slice
+[copy]: https://doc.rust-lang.org/stable/std/ptr/fn.copy.html
+[copy_nonoverlapping]: https://doc.rust-lang.org/stable/std/ptr/fn.copy_nonoverlapping.html
+[clone]: https://doc.rust-lang.org/stable/std/clone/trait.Clone.html#tymethod.clone

--- a/de-DE/friends.html
+++ b/de-DE/friends.html
@@ -1,0 +1,74 @@
+---
+layout: de-DE/basic
+title:  Der Rust-Freundeskreis &middot; Die Programmiersprache Rust
+---
+
+<div id="users">
+
+  <h1>Der Rust-Freundeskreis</h1>
+  <h2>(Organisationen, die Rust produktiv einsetzen)</h2>
+
+  {% for user in site.data.users %}
+    {% assign mod = forloop.index | minus:1 | modulo:3 %}
+    {% if mod != 0 %}
+    {% continue %}
+    {% endif %}
+
+    {% assign offset = forloop.index | minus:1 %}
+
+    <div class="row">
+      {% for user in site.data.users limit:3 offset:offset %}
+        <div class="col-md-4 friend"
+             id="user-logo-{{offset}}-{{forloop.index}}">
+          <div class="user-container">
+            <a href="{{user.url}}" rel="nofollow" alt="{{user.name}}">
+              <img src="../user-logos/{{user.logo}}">
+            </a>
+          </div>
+          <div class="details user-detail fade-out"
+            id="user-details-{{offset}}-{{forloop.index}}">
+            <p><em>{{user.name}}</em> : {{user.how}}</p>
+          </div>
+        </div>
+
+        <script type="text/javascript">
+          var logo = document.getElementById("user-logo-{{offset}}-{{forloop.index}}");
+          logo.onmouseover = function() {
+            var allDetails = document.querySelectorAll(".user-detail");
+            for (var i = 0; i < allDetails.length; i++) {
+              var details = allDetails[i];
+              details.className = details.className.replace(" fade-in", "");
+              details.className = details.className.replace(" fade-out", "");
+              details.className += " fade-out";
+            }
+
+            var details = document.getElementById("user-details-{{offset}}-{{forloop.index}}");
+            details.className = details.className.replace(" fade-in", "");
+            details.className = details.className.replace(" fade-out", "");
+            details.className += " fade-in";
+          };
+
+          logo.onmouseout = function() {
+            var details = document.getElementById("user-details-{{offset}}-{{forloop.index}}");
+            details.className = details.className.replace(" fade-in", "");
+            details.className = details.className.replace(" fade-out", "");
+            details.className += " fade-out";
+          };
+        </script>
+      {% endfor %}
+
+  </div>
+
+  {% endfor %}
+
+  <p id="user-add-info">
+    Falls deine Organisation Rust produktiv einsetzt und du auf dieser Seite stehen möchtest,<br/>bitte
+    <a href="https://github.com/rust-lang/rust-www/issues/new?title=New+Website+Logo%3A+[insert+name]%0A&body=To+list+your+organization%27s+logo+on+the+Rust+website%2C+fill+out+the+following+information+and+click+%22submit+new+issue%22.+Alternately%2C+you+may+edit+_data%2Fusers.yml+as+described+therein+and+submit+a+pull+request.%0D%0A%0D%0A-+Organization+name%3A+%28as+you+want+it+displayed%29%0D%0A-+Homepage+url%3A+%28homepage%2Fprimary+entry+point+for+users%29%0D%0A-+Logo+url%3A+%28svg+if+possible%2C+pngs+over+400x200px+with+transparent+backgrounds+are+also+acceptable%29%0D%0A-+How+you+are+using+Rust%3A+%28one+sentence+describing+your+use+of+Rust%29%0D%0A-+Url+describing+Rust+usage%3A+%28optional+link+to+e.g.+blog+post+explaining+how+you+use+Rust%29%0D%0A-+Organization+contact%3A+%28name+and+email.+we+may+contact+you+when+updating+this+page.+alternately+you+may+email+this+information+to+user-logos%40rust-lang.org+and+it+will+be+kept+secret%29.%0D%0A">
+        erstelle ein neues Ticket und trage die nötigen Informationen ein</a>.
+  </p>
+
+</div>
+
+<script type="text/javascript">
+  {% include friends.js %}
+</script>

--- a/de-DE/index.html
+++ b/de-DE/index.html
@@ -1,0 +1,63 @@
+---
+layout: de-DE/basic
+title: Die Programmiersprache Rust
+---
+
+    <div class="row pitch-row">
+      <div class="col-md-8">
+        <p class="pitch">
+          <b>Rust</b> ist eine Systemprogrammiersprache
+          die blitzschnell läuft,
+          Speicherfehler vermeidet
+          und Threadsicherheit garantiert.
+          <br/>
+          <b><a href="friends.html">Erfahre, wer Rust benutzt.</a></b>
+        </p>
+      </div>
+      <div class="col-md-4">
+        <a class="release-button" href="install.html">
+          <div class="release-version">Rust <span>{{ site.stable }}</span> installieren</div>
+        </a>
+        <div class="release-date">{{ site.stable_date | date: "%d. %B %Y" }}</div>
+      </div>
+    </div>
+
+    <div class="row code-row">
+      <div class="col-md-4">
+      <h2>Features:</h2>
+      <ul class="laundry-list">
+        <li>Zero-Cost-Abstraktionen</li>
+        <li>Move-Semantiken</li>
+        <li>Garantierte Speichersicherheit</li>
+        <li>Threads ohne Data Races</li>
+        <li>Trait-basierte Generics</li>
+        <li>Pattern Matching</li>
+        <li>Typinferenz</li>
+        <li>Minimales Laufzeitsystem</li>
+        <li>Effiziente Schnittstelle zu C</li>
+      </ul>
+      </div>
+      <div class="col-md-8">
+        <div id="active-code">
+          <button type="button" class="btn btn-primary btn-sm" id="run-code">Run</button>
+          <div id="editor">{% include example.rs %}</div>
+          <div id="result" data-msg-running="Running...">
+            <a id="playlink"><i class="icon-link-ext"></i></a>
+          </div>
+        </div>
+        <div id="static-code">{% include example.rs.html %}</div>
+        <div class="more-examples">
+          <a href="http://rustbyexample.com/">Weitere Beispiele (Englisch)</a>
+        </div>
+      </div>
+    </div>
+
+  <script type="text/javascript">
+    {% include include.js %}
+
+    include("https://cdn.jsdelivr.net/ace/1.1.3/noconflict/ace.js", function () {
+      include("https://cdn.jsdelivr.net/ace/1.1.3/noconflict/mode-rust.js", function () {
+        {% include editor.js %}
+      });
+    });
+  </script>

--- a/de-DE/install.html
+++ b/de-DE/install.html
@@ -1,0 +1,204 @@
+---
+layout: de-DE/default
+title: Installation &middot; Die Programmiersprache Rust
+---
+    <h1 class="rustup">Rust installieren</h1>
+
+    <div class="row rustup-row">
+      <div class="col-md-8 instr-column">
+        <div id="platform-instructions-unix" class="instructions" style="display: none;">
+          <p>Führe den folgenden Befehl in deinem Terminal aus und folge den Instruktionen auf
+          dem Bildschirm, um Rust zu installieren.</p>
+          <pre>curl https://sh.rustup.rs -sSf | sh</pre>
+        </div>
+
+        <div id="platform-instructions-win" class="instructions" style="display: none;">
+          <p>
+            Um Rust zu installieren, lade das folgende Installationsprogram herunter und führe es aus:
+            <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+            Folge dann den Anweisungen des Installers.
+          </p>
+        </div>
+
+        <div id="platform-instructions-unknown" class="instructions" style="display: none;">
+          <!-- unrecognized platform: ask for help -->
+          <p>Deine Plattform wurde nicht erkannt.</p>
+          <p>
+            Rust ist mit Windows, Linux, Mac OS X, FreeBSD und NetBSD kompatibel. Wenn du dich auf einem
+            dieser Betriebssysteme befindest,
+            <a href="https://github.com/rust-lang/rust-www/issues/new">reiche bitte eine Fehlermeldung</a>,
+            zusammen mit den folgenden Werten ein:
+          </p>
+
+          <div>
+            <div>navigator.platform:</div>
+            <div id="nav-plat"></div>
+            <div>navigator.appVersion:</div>
+            <div id="nav-app"></div>
+          </div>
+
+          <!-- duplicate the default cross-platform instructions -->
+          <div>
+            <p>Um Rust unter Unix zu installieren, führe den folgenden Befehl in einem Terminal aus und
+            folge den Anweisungen auf dem Bildschirm.</p>
+            <pre>curl https://sh.rustup.rs -sSf | sh</pre>
+          </div>
+
+          <hr/>
+
+          <div>
+            <p>
+              Um Rust unter Windows zu installieren, lade das folgende Installationsprogramm
+              herunter und führe es aus:
+              <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+              Folge dann den Anweisungen des Installers.
+            </p>
+          </div>
+        </div>
+
+        <div id="platform-instructions-default" class="instructions">
+          <div>
+            <p>Um Rust unter Unix zu installieren, führe den folgenden Befehl in einem Terminal aus und
+            folge den Anweisungen auf dem Bildschirm.</p>
+            <pre>curl https://sh.rustup.rs -sSf | sh</pre>
+          </div>
+
+          <hr/>
+
+          <div>
+            <p>
+              Um Rust unter Windows zu installieren, lade das folgende Installationsprogramm herunter und
+              führe es aus:
+              <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+              Folge dann den Anweisungen des Installers.
+            </p>
+          </div>
+        </div>
+
+      </div>
+
+      <div class="col-md-4 release-info-column">
+        <div>
+          <div class="release-version">Rust <span>{{ site.stable }}</span></div>
+          <a href="{{ site.stable_blog }}">
+            <div class="release-date">{{ site.stable_date | date: "%d. %B %Y" }}</div>
+          </a>
+
+          <br>
+
+          <a id="platform-button" style="display: none;" href="#">
+            click or press "n" to cycle platforms
+          </a>
+        </div>
+      </div>
+
+    </div>
+
+    <h2>Hinweise zur Installation von Rust</h2>
+
+    <div class="row">
+      <div class="col-md-12">
+
+        <h3>Verwaltung der Toolchains mit <code>rustup</code></h3>
+
+        <p>
+          Rust wird über das
+          <a href="https://github.com/rust-lang-nursery/rustup.rs"><code>rustup</code></a>-Werkzeug
+          installiert. Rust hat einen sechswöchigen
+          <a href="https://github.com/rust-lang/rfcs/blob/master/text/0507-release-channels.md">
+              Veröffentlichungszyklus
+          </a> und unterstützt eine
+          <a href="https://forge.rust-lang.org/platform-support.html">
+              große Anzahl an Plattformen
+          </a>, sodass zu jeder Zeit eine große Auswahl an Rust-Builds existiert.
+          <code>rustup</code> verwaltet diese Builds konsistent auf jeder
+          Plattform, die von Rust unterstützt wird, und erlaubt die Installation aus den
+          Beta- und Nightly-Veröffentlichungskanälen sowie Toolchains für Cross Compilation
+          auf andere Prozessorarchitekturen.
+        </p>
+
+        <p>
+          Weitere Informationen findest du in der
+          <a href="https://github.com/rust-lang-nursery/rustup.rs/blob/master/README.md">
+              <code>rustup</code>-Dokumentation</a>.
+        </p>
+
+        <h3>Konfiguration der <code>PATH</code>-Umgebungsvariable</h3>
+
+        <p>
+          In der Rust-Umgebung werden alle Tools in das Verzeichnis
+          <span class="platform-specific not-win" style="display: inline;">
+            <code>~/.cargo/bin</code>
+          </span>
+          <span class="platform-specific win" style="display: none;">
+            <code>%USERPROFILE%\.cargo\bin</code>
+          </span> installiert, dort findet sich auch die Rust-Toolchain mit
+          <code>rustc</code>, <code>cargo</code>, und <code>rustup</code>.
+        </p>
+
+        <p>
+          Deshalb ist es gebräuchlich, dieses Verzeichnis in die
+          <a href="https://en.wikipedia.org/wiki/PATH_(variable)">
+          <code>PATH</code>-Umgebungsvariable</a> aufzunehmen.
+          Während der Installation wird <code>rustup</code> versuchen,
+          <code>PATH</code> selbst zu setzten,
+          doch wegen Unterschieden zwischen den Plattformen, Shells und Fehlern
+          in <code>rustup</code> haben die Anpassungen an <code>PATH</code>
+          unter Umständen keine Effekt, bis das Terminal neu gestartet wurde
+          oder sich der Nutzer ab- und wieder angemeldet hat. In Einzelfällen
+          kann es Vorkommen, dass das Anpassen von <code>PATH</code> überhaupt
+          nicht erfolgt.
+        </p>
+
+        <p>
+          Falls nach der Installation der Befehl <code>rustc --version</code>
+          im Terminal fehlschlägt, ist das der wahrscheinlichste Grund dafür.
+        </p>
+
+        <div class="platform-specific win">
+
+          <h3>Windows-Spezifisches</h3>
+          <!-- This anchor is probably linked in the wild and should not be broken -->
+          <a id="win-foot"></a>
+
+	  <p>
+            Unter Windows setzt Rust außerdem die C++ Build Tools für Visual Studio
+            2013 oder später voraus. Die einfachste Möglichkeit, an die Build Tools
+            zu kommen, ist die
+        <a href="https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2017">
+             Microsoft Visual C++ Build Tools 2017
+        </a>
+            direkt zu installieren. Alternativ dazu kannst du auch
+            Visual Studio 2017, Visual Studio 2015 oder Visual Studio 2013
+	    <a href="https://www.visualstudio.com/downloads/">herunterladen</a>
+        und im Installer die "C++-Tools" auswählen.
+	  </p>
+
+          <p>
+            Für weiterführende Informationen über die Konfiguration von Rust unter Windows,
+            besuche die
+            <a href="https://github.com/rust-lang-nursery/rustup.rs/blob/master/README.md#working-with-rust-on-windows">Windows-spezifische <code>rustup</code>-Dokumentation
+            </a>.
+          </p>
+
+        </div>
+
+      </div>
+    </div>
+
+    <h2>Andere Installationsmöglichkeiten</h2>
+
+    <div class="row">
+      <div class="col-md-12">
+        <p>
+          Die oben beschriebene Weg via <code>rustup</code> ist für die meisten Entwickler die
+          bevorzugte Methode, um Rust zu installieren. Es gibt aber auch
+          <a href="other-installers.html">alternative Installationsmöglichkeiten</a>.
+        </p>
+      </div>
+    </div>
+
+    <script type="text/javascript">
+      {% include rustup.js %}
+    </script>
+

--- a/de-DE/legal.md
+++ b/de-DE/legal.md
@@ -1,0 +1,207 @@
+---
+layout: de-DE/default
+title: Richtlinien zu Urheber- und Markenrecht &middot; Die Programmiersprache Rust
+---
+
+# Urheberrecht
+
+## Code
+
+Der [Quelltext][code](https://github.com/rust-lang/rust) von Rust wird primär unter den Bedingungen
+der MIT-Lizenz und der Apache-Lizenz in Version 2.0 verbreitet. Für manche Teile werden
+verschiedene BSD-artige Lizenzen verwendet.
+Details finden sich in [LICENSE-APACHE](https://github.com/rust-lang/rust/blob/master/LICENSE-APACHE),
+[LICENSE-MIT](https://github.com/rust-lang/rust/blob/master/LICENSE-MIT),
+und [COPYRIGHT](https://github.com/rust-lang/rust/blob/master/COPYRIGHT).
+
+## Artwork
+
+Die Logos für Rust und Cargo (als Bitmap- und Vektorgrafiken) gehören Mozilla
+und werden unter den Bedingungen der
+[Creative Commons Attribution license (CC-BY)](https://creativecommons.org/licenses/by/4.0/) verbreitet.
+Diese Creative-Commons Lizenz lässt sehr viel Freiheit und erlaubt die Wiederverwendung sowie die
+Veränderung zu jedwedem Zweck. Die einzigen Bedingungen fordern, dass jeder Nutzer der Lizenz bei der
+Verbreitung seiner Version von Logos oder Artwork angemessen den ursprünglichen Ersteller erwähnen und
+einen Link zur Lizenz beifügen muss. Außerdem muss angegeben werden, ob Veränderungen gemacht wurden.
+**Anzumerken ist, dass die Benutzung der Logos sowie der Namen Rust und Cargo, auch Markenrechtlich reguliert wird.
+Unsere Markenzeichen-Richtlinie wird unten beschrieben.**.
+
+Varianten des Rust-Logos können hier gefunden werden:
+
+* [rust-logo-128x128-blk.png](/logos/rust-logo-128x128-blk.png)
+* [rust-logo-128x128-blk-v2.png](/logos/rust-logo-128x128-blk-v2.png)
+* [rust-logo-128x128.png](/logos/rust-logo-128x128.png)
+* [rust-logo-16x16-blk.png](/logos/rust-logo-16x16-blk.png)
+* [rust-logo-16x16.png](/logos/rust-logo-16x16.png)
+* [rust-logo-256x256-blk.png](/logos/rust-logo-256x256-blk.png)
+* [rust-logo-256x256.png](/logos/rust-logo-256x256.png)
+* [rust-logo-32x32-blk.png](/logos/rust-logo-32x32-blk.png)
+* [rust-logo-32x32.png](/logos/rust-logo-32x32.png)
+* [rust-logo-512x512-blk.png](/logos/rust-logo-512x512-blk.png)
+* [rust-logo-512x512.png](/logos/rust-logo-512x512.png)
+* [rust-logo-64x64-blk.png](/logos/rust-logo-64x64-blk.png)
+* [rust-logo-64x64.png](/logos/rust-logo-64x64.png)
+* [rust-logo-blk.svg](/logos/rust-logo-blk.svg)
+
+# Markenzeichen-Richtlinie
+
+Die Namen (und Marken) Rust und Cargo ermöglichen es, offizielle Teile
+der Rust-Community klar zu kennzeichnen. Deshalb sind wir bei ihrer Verwendung vorsichtig.
+Gleichzeitig wollen wir aber die kreative Verwendung in keinster Weise einschränken.
+Die hier beschriebenen Richtlinien erklären, wie wir dieses Gleichgewicht erhalten.
+Wenn du diese Namen und Marken (insbesondere in einem kommerziellen Umfeld) nutzen willst, dann
+lies diese Seite. Bei Fragen [kannst du dich gerne an uns wenden](mailto:trademark@rust-lang.org)!
+
+**TL;DR**: Die meiste nicht-kommerzielle Verwendung der Markennamen und Logos von Rust und Cargo sind erlaubt und
+benötigen keine spezielle Erlaubnis, während die Verwendung im kommerziellen Umfeld meistens eine Erlaubnis benötigt.
+In beiden Fällen ist es sehr wichtig, dass die Verwendung des Markenzeichens nicht offiziell erscheinen darf oder in
+irgendeiner Form Befürwortung durch das Rust-Projekt impliziert.
+
+## Die Rust-Markenzeichen
+
+Die Programmiersprache Rust ist eine quelloffenes, von der Gemeinschaft entwickeltes Projekt,
+welches von einem Kernteam verwaltet wird. Es wird auch von der Mozilla Foundation ("Mozilla")
+gesponsert, welche die Markennamen und Logos von Rust und Cargo ("Die Rust-Markenzeichen")
+besitzt und schützt.
+Dieses Dokument bietet Informationen zur Verwendung der Rust-Markenzeichen bezüglich der
+Programmiersprache allgemein sowie Beispiele allgemein häufiger Verwendungsfälle der Rust-Markenzeichen
+und Erklärungen, ob diese Fälle in Ordnung sind oder spezielle Erlaubnis benötigen.
+Es ergänzt die [offizielle Mozilla Markenzeichen-Richtlinie](https://www.mozilla.org/foundation/trademarks/policy/),
+welche die Verwendung aller Mozilla-Markenzeichen bestimmt.
+
+Die Markenzeichen von Rust beinhalten zwei Wortmarken und zwei Logos:
+
+* Rust
+* Cargo
+* <img src="https://www.rust-lang.org/logos/rust-logo-blk.svg">
+* <img src="https://www.rust-lang.org/logos/cargo.png">
+
+Markenzeichen sind Namen und Designs, welche jedem mitteilen, woher ein Gut
+oder Dienst stammt. Es ist besonders wichtig, Markenzeichen eines quelloffenen
+Projektes zu schützen. Jeder kann den Quelltext ändern und ein weiteres Produkt
+aus diesem Code aufbauen, also ist es wichtig, dass nur das Originalprodukt und
+durch das Projekt anerkannte Variationen davon die Projekt-Markenzeichen verwenden.
+Mozilla und das Rust-Projekt erreichen durch die Einschränkung der Verwendung der
+Markenzeichen, dass Nutzer und Entwickler wissen, dass sie das offizielle,
+vom Rust-Projekt entwickelte Produkt und nicht eine von Dritten
+abgewandelte Form erhalten.
+Die Markenzeichen versichern den Nutzern und Entwicklern die Qualität und
+Sicherheit des Produktes, welches sie nutzen.
+
+## Verwendung der Markenzeichen
+
+### Offizielles, durch das Rust-Projekt befürwortetes oder mit ihm verbundenes Erscheinen
+
+Die grundlegendste Regel ist, dass die Rust-Markenzeichen nicht auf eine Weise
+verwendet werden dürfen, welche für einen oberflächlichen Beobachter erscheinen,
+als wären sie offiziell, durch das Rust-Projekt oder Mozilla befürwortet oder mit ihm in
+irgendeiner Weise verbunden (außer wenn du eine schriftliche Zulassung durch das Rust-Kernteam hast).
+Auf diese grundlegende Art und Weise stellen wir sicher, dass Nutzer und Entwickler nicht
+verwirrt werden.
+
+Da diese Regel mit Wahrnehmung zu tun hat, ist sie subjektiv und etwas
+schwierig konkret festzulegen. Es gibt ein paar klar ersichtliche Wege,
+Probleme zu vermeiden; zum Beispiel durch die ersichtliche Nutzung des Wortes
+„inoffiziell“. Wenn du Fragen oder Zweifel hast, dann helfen wir dir sehr gerne
+weiter. Sende eine Mail an [trademark@rust-lang.org](mailto:trademark@rust-lang.org).
+
+### Die Grundlagen: Erwähnung und Bezug auf Rust oder Cargo
+
+Die Markenwörter Rust und Cargo können wie bei jedem Markenzeichen mit minimaler Einschränkung
+dazu verwendet werden, um sich auf die Programmiersprache Rust und
+den Paketmanager / das Repository Cargo zu beziehen.
+
+Sie dürfen nicht verwendet werden:
+
+- um sich auf irgendeine andere Programmiersprache zu beziehen;
+- auf eine missverständliche Art oder auf eine Art, welche Verbindungen
+  der Rust-Programmiersprache zu nicht verwandten Modulen, Werkzeugen,
+  Dokumentation oder anderen Ressourcen impliziert;
+- auf eine Art, welche die Gemeinschaft hinsichtlich der Quelloffenheit oder
+  Möglichkeit der kostenlosen Benutzung von Rust und Cargo irreführen kann;
+
+### Verwendungen, welche keine ausdrückliche Genehmigung erfordern
+
+Es gibt eine Vielzahl von Verwendungen, welche keine ausdrückliche Genehmigung erfordern.
+**Es muss allerdings sichergestellt werden, dass die Nutzung der Rust-Markenzeichen nicht wie oben beschrieben offiziell erscheint.**
+
+* Richtigerweise Aussagen, dass eine Software in der Rust-Programmiersprache geschrieben ist, kompatibel mit der Sprache ist,
+  oder dass sie die Sprache enthält, ist erlaubt. In diesen Fällen darfst du die Rust-Markenzeichen
+  ohne ausdrückliche Genehmigung verwenden, um dies zu unterstreichen.
+  Dies gilt sowohl für kommerzielle als auch für nicht-kommerzielle Zwecke.
+
+* Verwendung der Rust-Markenzeichens in Namen nicht-kommerzieller Produkte wie
+  RustPostgres oder Rustymine, oder in Namen von Code-Repositories innerhalb von
+  beispielsweise GitHub, ist erlaubt, wenn die Verwendung sich auf die Nutzung von
+  oder Eignung für die Rust-Programmiersprache bezieht. Diese Verwendungen können
+  auch das Rust Logo, sogar in modifizierter Form, enthalten.
+  Spreche bitte die Verwendung für kommerzielle Produkte (einschließlich gesponserte oder durch Crowdfunding
+  finanzierte) mit [trademark@rust-lang.org](mailto:trademark@rust-lang.org) ab, um sicherzustellen,
+  dass deine Verwendung nicht offiziell erscheint.
+
+* Die Nutzung der Rust-Markenzeichen auf T-Shirts, Mützen/Hüten und anderen
+Artikeln oder Waren, auch in modifizierter Form, ist für deinen persönlichen
+Gebrauch oder die Nutzung durch eine kleine Gruppe gestattet, solange sie nicht
+verkauft werden. Wenn du Werbeartikel zu Rust bei einem thematisch mit Rust
+verwandtem Veranstaltung vertreiben willst, dann kontaktiere uns für die Erlaubnis:
+[trademark@rust-lang.org](mailto:trademark@rust-lang.org).
+
+* Die Verwendung der Rust-Markenzeichen (auch in abgewandelter Form) für
+soziale Veranstaltungen wie Treffen, Tutorials, und ähnlichem, ist erlaubt, wenn die
+Veranstaltungen kostenfrei zugänglich sind. Für kommerzielle Veranstaltungen (auch gesponserte),
+frage bei [trademark@rust-lang.org](mailto:trademark@rust-lang.org) nach. In jedem Fall sind die
+Worte "RustCamp", "RustCon" oder "RustConf" nicht ohne ausdrückliche Erlaubnis zu verwenden.
+Wie mit allen der oben genannten Verwendungen gilt:
+**eine Veranstaltung darf nicht so erscheinen, als wäre sie offiziell vom Rust-Projekt befürwortet oder durch es veranstaltet**,
+wenn keine offizielle Erlaubnis vorliegt.
+
+* Die Verwendung der Rust-Markenzeichen in Veröffentlichungen wie "Rust Journal"
+  oder "Rust Cookbook" ist erlaubt.
+
+* Die Verwendung des Wortes "Rust" auf Webseiten, Broschüren, Dokumentation,
+  akademischen Arbeiten, Büchern oder Verpackungen von Produkten im Bezug auf
+  die Rust Programmiersprache oder das Rust-Projekt sind gestattet.
+
+### Verwendungen, welche ausdrückliche Genehmigung erfordern
+
+* Die Verteilung einer abgewandelten Version der Rust Programmiersprache oder
+  des Cargo Paketmanagers, welche es Rust oder Cargo nennt, erfordert eine
+  ausdrückliche, schriftliche Genehmigung des Rust Kernteams.
+  Wir werden diese Abwandlungen üblicherweise gestatten, solange die Abwandlungen
+  (1) relativ klein und (2) zu den Endbenutzern klar dokumentiert sind.
+
+* Der Verkauf von T-Shirts, Mützen/Hüten, und anderen
+  Artikeln oder Waren erfordert die ausdrückliche, schriftliche Genehmigung
+  des Rust Kernteams. Wir werden diese Verwendungen normalerweise gestatten,
+  wenn (1) klar kommuniziert wird, dass der Vertrieb in keinster Weise
+  Teil des Rust-Projektes ist, und (2) wenn es klar erkenntlich ist, ob
+  der Profit Vorteile für das Rust-Projekt bringt.
+
+* Die Nutzung der Rust-Markenzeichen innerhalb/als Teil eines anderen Markenzeichens
+  erfordert die ausdrückliche schriftliche Genehmigung des Rust Kernteams, wie oben beschrieben.
+
+## Anmerkungen
+
+Wenn du irgendwelche Zweifel über deine beabsichtigte Verwendung eines Rust-Markenzeichens
+hast, kontaktiere uns einfach bei [trademark@rust-lang.org](mailto:trademark@rust-lang.org).
+
+Dieses Dokument entstammt teilweise aus der [Python Software Foundation Trademark Usage Policy](https://www.python.org/psf/trademarks/).
+
+Dieses Dokument ist keine offizielle Erklärung der Mozilla-Markenzeichenrichtlinien,
+sondern dient dazu, die Mozilla-Markenzeichenrichtlinien im Bezug auf Rust zu erklären.
+
+## Mithelfen
+
+Als Teil der Rust-Gemeinschaft, halte bitte nach fraglichen Verwendungen des Rust-Logos und der
+"Rust"-Wortmarke Ausschau. Potenzielle fehlerhafte Verwendungen oder Missbrauch kannst du bei
+[trademark@rust-lang.org](mailto:trademark@rust-lang.org) melden. Wir werden jeden Fall separat evaluieren
+und angemessene Handlungen einleiten.
+
+Bitte wende dich nicht selbst an den Nutzer der Markenzeichen. Das sollte Mozilla
+und seinen Vertretern überlassen werden.
+
+Danke!
+
+## Lizenz
+
+Interessierte können dieses Dokument frei unter den Bedingungen der [Creative Commons CC0 license](https://creativecommons.org/publicdomain/zero/1.0/) adaptieren und Verändern.

--- a/de-DE/other-installers.md
+++ b/de-DE/other-installers.md
@@ -1,0 +1,192 @@
+---
+layout: de-DE/default
+title: Andere Installationsmethoden &middot; The Rust Programming Language
+---
+
+# Andere Installationsmethoden für Rust
+
+- [Welchen Installer sollte ich benutzen?](#which)
+- [Andere Wege, `rustup` zu installieren](#more-rustup)
+- [Standalone Installer](#standalone)
+- [Quellcode](#source)
+
+## Welchen Installer sollte ich benutzen?
+<span id="which"></span>
+
+Rust läuft auf vielen Plattformen, und es gibt viele Wege, es zu installieren.
+Wenn du Rust möglichst einfach installieren willst, dann folge den Schritten
+auf der [Installations-Hauptseite].
+
+Diese Seite beschreibt Installation via [`rustup`], einem Werkzeug, welches
+mehrere Rust-Toolchains auf konsistente Art für alle von Rust unterstützten
+Plattformen verwaltet. Warum sollte man Rust _nicht_ mit [`rustup`]
+installieren wollen?
+
+- Offline-Installation. `rustup` lädt Komponenten je nach Bedarf aus dem
+  Internet nach. Wenn du Rust ohne Internetzugriff installieren willst, dann
+  ist `rustup` ungeeignet.
+- Vorzug des Paketmanagers. Insbesondere auf Linux, aber mit [Homebrew] auch
+  auf macOS, und auf Windows mit [Chocolatey], wollen manche Entwickler Rust
+  lieber mit dem jeweiligen Paketmanager installieren.
+- Vermeidung von `curl | sh`. Auf Unix installieren wir `rustup` normalerweise,
+  indem wir per `curl` ein Shell-Skript ausführen. Manche haben Bedenken
+  zur Sicherheit dieser Methode und würden den Installer lieber selber laden
+  und ausführen.
+- Validierung von Signaturen. Auch wenn `rustup` alle Downloads mit HTTPS
+  durchführt, können die Signaturen des Installers momentan nur über die
+  Verwendung der alleinstehenden Installer durchgeführt werden.
+- GUI-Installation und Integration mit "Programme hinzufügen/entfernen" auf
+  Windows. `rustup` läuft in der Konsole und registriert seine Installation
+  nicht wie andere Windows-Programme. Wenn du Rust lieber mithilfe einer typische
+  GUI installieren willst, nutze die für Windows erhältlichen standalone
+  `.msi`-Installer. Zukünftig wird `rustup` für Windows einen GUI-Installer
+  anbieten.
+
+Die Plattformunterstützung von Rust ist in [drei Stufen] unterteilt, welche
+eng mit den verfügbaren Installationsmethoden korrespondieren:
+im allgemeinen bietet das Rust Projekt ausführbare Dateien für Plattformen mit
+Stufen 1 und 2, und alle sind über `rustup` installierbar. Manche Plattformen
+zweiter Stufe bieten allerdings nur die Standardbibliotheken und nicht den
+Compiler an; das bedeutet, dass diese Plattformen lediglich Ziele für die
+Cross-Compilation sind. Rust läuft auf diesen Plattformen, obwohl der
+Compiler selbst nicht auf ihnen läuft.
+Diese Ziele können mit dem Befehl `rustup target add` installiert werden.
+
+## Andere Wege, `rustup` zu installieren
+<span id="rustup"></span>
+
+Dies hängt stark von der verwendeten Plattform ab:
+
+* Auf Unix, führe in deiner Shell `curl https://sh.rustup.rs -sSf | sh`
+  aus. Dies wird eine Datei [`rustup-init.sh`] herunterladen und ausführen.
+  Dieses Skript wiederum wird die korrekte Version der ausführbaren
+  Datei `rustup-init` herunterladen und ausführen.
+* Auf Windows, lade [`rustup-init.exe`] herunter und führe die Datei aus.
+
+`rustup-init` kann interaktiv konfiguriert werden, und alle Optionen können
+zusätzlich mit Kommandozeilenargumenten angegeben werden, welche durch das
+Shellskript übergeben werden können. Gib das Argument `--help` an `rustup-init`
+folgendermaßen weiter, um die unterstützten Befehle anzuzeigen:
+
+```
+curl https://sh.rustup.rs -sSf | sh -s -- --help
+```
+
+Wenn du lieber kein Shellskript verwenden willst, kannst du direkt
+`rustup-init` für eine Plattform deiner Wahl herunterladen:
+
+<div class="rustup-init-table">
+  {% for column in site.data.platforms.rustup %}
+  <div>
+    {% for target in column %}
+    {% if target contains 'windows' %}
+    <a href="https://static.rust-lang.org/rustup/dist/{{ target }}/rustup-init.exe">
+      {{ target }}
+    </a>
+    {% else %}
+    <a href="https://static.rust-lang.org/rustup/dist/{{ target }}/rustup-init">
+      {{ target }}
+    </a>
+    {% endif %}
+    {% endfor %}
+  </div>
+  {% endfor %}
+</div>
+
+## Standalone-Installer
+<span id="standalone"></span>
+
+Die offiziellen standalone-Installer enthalten eine einzige Version von Rust,
+und sind für eine Installation ohne Internet geeignet. Sie sind als tarball,
+welche in jeder Unix-artigen Umgebung laufen sollten (Erweiterung `.tar.gz`),
+Windows Installer (`.msi`), und Mac-Installer (`.pkg`). Diese Installer
+kommen mit `rustc`, `cargo`, `rustdoc`, der Standardbibliothek, und der
+Standarddokumentation, bieten aber im Gegensatz zu `rustup` keinen Zugriff
+auf weitere cross-targets.
+
+Die häufigsten Gründe, diese zu benutzen, sind:
+
+- Offline-Installation
+- Vorzug der Nutzung eines Plattform-Integrierten, graphischen Installers
+  auf Windows
+
+Jede dieser Binaries sind mit dem [Rust signing key] signiert, welcher
+auf [keybase.io] verfügbar ist. Die Rust build Infrastruktur signiert
+alle Binaries automatisch mit GPG. In der folgenden Tabelle sind
+die Signaturen als `.asc`-Dateien gelistet.
+
+Vergangene Veröffentlichungen können in [den Archiven] gefunden werden.
+
+{% for channel in site.channels %}
+
+### {{ channel.name | capitalize }} ({{ channel.vers }})
+<span id="{{ channel.name }}"></span>
+
+<div class="installer-table {{ channel.name }}">
+  {% for column in site.data.platforms[channel.name] %}
+  <div>
+    {% for target in column %}
+    <div>
+      <span>{{ target }}</span>
+      <a href="https://static.rust-lang.org/dist/rust-{{ channel.package }}-{{ target }}.tar.gz">.tar.gz</a>
+      <a href="https://static.rust-lang.org/dist/rust-{{ channel.package }}-{{ target }}.tar.gz.asc">.asc</a>
+    </div>
+    {% if target contains 'windows' %}
+    <div>
+      <span>{{ target }}</span>
+      <a href="https://static.rust-lang.org/dist/rust-{{ channel.package }}-{{ target }}.msi">.msi</a>
+      <a href="https://static.rust-lang.org/dist/rust-{{ channel.package }}-{{ target }}.msi.asc">.asc</a>
+    </div>
+    {% elsif target contains 'darwin' %}
+    <div>
+      <span>{{ target }}</span>
+      <a href="https://static.rust-lang.org/dist/rust-{{ channel.package }}-{{ target }}.pkg">.pkg</a>
+      <a href="https://static.rust-lang.org/dist/rust-{{ channel.package }}-{{ target }}.pkg.asc">.asc</a>
+    </div>
+    {% endif %}
+    {% endfor %}
+  </div>
+  {% endfor %}
+</div>
+
+{% endfor %}
+
+## Quelltext
+<span id="source"></span>
+
+<div class="installer-table">
+  <div>
+    <div>
+      <span>Stable</span>
+      <a href="https://static.rust-lang.org/dist/rustc-{{ site.stable }}-src.tar.gz">.tar.gz</a>
+      <a href="https://static.rust-lang.org/dist/rustc-{{ site.stable }}-src.tar.gz.asc">.asc</a>
+    </div>
+  </div>
+  <div>
+    <div>
+      <span>Beta</span>
+      <a href="https://static.rust-lang.org/dist/rustc-beta-src.tar.gz">.tar.gz</a>
+      <a href="https://static.rust-lang.org/dist/rustc-beta-src.gz.asc">.asc</a>
+    </div>
+  </div>
+  <div>
+    <div>
+      <span>Nightly</span>
+      <a href="https://static.rust-lang.org/dist/rustc-nightly-src.tar.gz">.tar.gz</a>
+      <a href="https://static.rust-lang.org/dist/rustc-nightly-src.tar.gz.asc">.asc</a>
+    </div>
+  </div>
+</div>
+
+[installation page]: install.html
+[`rustup`]: https://github.com/rust-lang-nursery/rustup.rs
+[other-rustup]: https://github.com/rust-lang-nursery/rustup.rs#other-installation-methods
+[`rustup-init.exe`]: https://static.rust-lang.org/rustup/dist/i686-pc-windows-gnu/rustup-init.exe
+[`rustup-init.sh`]: https://static.rust-lang.org/rustup/rustup-init.sh
+[Homebrew]: http://brew.sh/
+[Chocolatey]: http://chocolatey.org/
+[drei Stufen]: https://forge.rust-lang.org/platform-support.html
+[Rust signing key]: https://static.rust-lang.org/rust-key.gpg.ascii
+[GPG]: https://gnupg.org/
+[available on keybase.io]: https://keybase.io/rust
+[the archives]: https://static.rust-lang.org/dist/index.html

--- a/de-DE/security.html
+++ b/de-DE/security.html
@@ -1,0 +1,58 @@
+---
+layout: de-DE/default
+title: Rust-Sicherheitsrichtlinien &middot; Die Programmiersprache Rust
+---
+
+<h1>Rust-Sicherheitsrichtlinien</h1>
+
+<h2>Fehlerberichte</h2>
+
+<p>Sicherheit ist einer der Kernaspekte von Rust, und zu diesem Zweck möchten wir sicherstellen, dass der Sprache eine sichere Implementierung zugrunde liegt. Wir sind sehr dankbar, dass du dir die Zeit nimmst, Sicherheitslücken verantwortungsvoll offenzulegen.</p>
+
+<p>Alle sicherheitsrelevanten Fehler in Rust und den Rust-Bibliotheken sollten per Mail an <a href="mailto:security@rust-lang.org">security@rust-lang.org</a> gemeldet werden. Diese Mailingliste wird an ein kleines Security-Team weitergeleitet. Deine Nachricht wird innerhalb von 24 Stunden quittiert, und nach spätestens 48 Stunden erhältst du eine detaillierte Antwort mit den nächsten Schritten zur Behandlung der Lücke. Du kannst deine Nachricht mit <a href="../rust-security-team-key.gpg.ascii">unserem PGP-Schlüssel</a> verschlüsseln. Er liegt auch auf
+<a href="https://pgp.mit.edu/pks/lookup?op=vindex&amp;search=0xEFB9860AE7520DAC">dem Schlüsselserver des MIT</a> und ist <a href="#key">weiter unten</a> nochmals aufgeführt.</p>
+
+<p>Diese Mailadresse erhält täglich viele Spamnachrichten, achte daher bitte darauf, dass deine Nachricht einen sprechenden Betreff trägt. Dies verhindert, dass die Mail übersehen wird. Nach der initialen Antwort auf deinen Bericht wird sich das Security-Team bemühen, dich über den Fortschritt hin zu einer Lösung und Veröffentlichung des Problems auf dem Laufenden zu halten. Wie von <a href="https://en.wikipedia.org/wiki/RFPolicy">RFPolicy</a> vorgeschlagen, bekommst du diese Updates mindestens alle fünf Tage. Tatsächlich wirst du eher alle 24 bis 48 Stunden von uns hören.</p>
+
+<p>Falls du 48 Stunden nach deinem Bericht noch keine Antwort erhalten hast oder nach fünf Tagen kein Update erhalten hast, kannst du einen der folgenden Schritte unternehmen:</p>
+
+<ul>
+    <li>Kontaktiere den Security Coordinator (<a href="mailto:steve@steveklabnik.com">Steve Klabnik</a>
+        (<a href="https://pgp.mit.edu/pks/lookup?op=vindex&amp;search=0xDAE717EFE9424541">public key</a>)) persönlich.</li>
+    <li>Kontaktiere seinen Stellvertreter (<a href="mailto:alex@alexcrichton.com">Alex Crichton</a>
+        (<a href="https://pgp.mit.edu/pks/lookup?op=vindex&amp;search=0x5D54B6F551FF5E33">public key</a>)) persönlich.</li>
+    <li>Poste im <a href="https://internals.rust-lang.org/">Rust Internals-Forum</a> oder frage im #rust-internals-Kanal auf irc.mozilla.org nach.</li>
+</ul>
+
+<p>Bitte sei dir bewusst, dass die Diskussionsforen und der #rust-internals-Kanal öffentlich zugänglich sind. Sprich das offene Sicherheitsproblem nicht an, falls du dort nachhakst. Benutze die Plattformen nur, um den Kontakt zu einem Mitglied des Security-Teams zu suchen.</p>
+
+<h2>Veröffentlichungsrichtlinien</h2>
+
+<p>Der Veröffentlichungsprozess von Rust-Sicherheitslücken besteht aus fünf Schritten.</p>
+
+<ol>
+    <li>Der Sicherheitsbericht wird empfangen und einem Hauptverantwortlichen zugewiesen. Diese Person koordiniert den Korrektur- und Veröffentlichungsprozess.</li>
+    <li>Das Problem wird verifiziert und eine Liste der betroffenen Versionen wird ermittelt.</li>
+    <li>Verwandter Code wird auditiert, um ähnliche Probleme aufzudecken.</li>
+    <li>Für alle noch gewarteten Versionen werden Patches vorbereitet. Diese erscheinen nicht in den öffentlichen Repositories, sondern werden bis zur Ankündigung zurückgehalten.</li>
+    <li>Am Veröffentlichungstag wird eine Kopie des Ankündigungstextes an die <a href="https://groups.google.com/forum/#!forum/rustlang-security-announcements">Rust-Security-Mailingliste</a> gesendet. Innerhalb der nächsten sechs Stunden wird die Ankündigung auf dem Rust-Blog veröffentlicht.</li>
+</ol>
+
+<p>Dieser Prozess kann einige Zeit in Anspruch nehmen, vor allem wenn die Absprache mit Maintainern anderer Projekte notwendig wird. Auch wenn die Bemühung besteht, den Bug in kürzester Zeit zu beseitigen, muss der obige Prozess eingehalten werden um sicherzustellen, dass die Veröffentlichung in konsistenter Art und Weise geschieht.</p>
+
+<h2>Sicherheitsupdates erhalten</h2>
+
+<p>Die beste Möglichkeit, alle sicherheitsrelevanten Ankündigungen zu erhalten, ist die <a href="https://groups.google.com/forum/#!forum/rustlang-security-announcements">Rust Security Announcements - Mailingliste</a> zu abonnieren (Alternativ per E-Mail an <a
++href="mailto:rustlang-security-announcements+subscribe@googlegroups.com">rustlang-security-announcements+subscribe@googlegroups.com</a>). Über die Liste gehen nur sehr wenige Mails, sie erhält jedoch alle Ankündigungen zu Sicherheitslücken, sobald deren Geheimhaltung aufgehoben wurde.</p>
+
+<h3>Frühwarnung für Distributoren</h3>
+
+<p>Alle Sicherheitslücken werden 72 Stunden vor Aufhebung der Geheimhaltung auf <a href="http://oss-security.openwall.org/wiki/mailing-lists/distros">distros@openwall</a> angekündigt, um Linux-Distributionen das Aktualisieren ihrer Pakete zu ermöglichen.
+
+<h2>Anmerkungen zu diesen Richtlinien</h2>
+
+<p>Falls du Verbesserungsvorschläge zu dieser Richtlinie hast, schreibe eine Mail an <a href="mailto:security@rust-lang.org">security@rust-lang.org</a>.</p>
+
+<h2 id="key">PGP-Schlüssel im Klartext</h2>
+
+<pre><code>{% include rust-security-team-key.gpg.ascii %}</code></pre>

--- a/de-DE/team.md
+++ b/de-DE/team.md
@@ -1,0 +1,55 @@
+---
+layout: de-DE/default
+title: Das Rust-Team &middot; Die Programmiersprache Rust
+extra_css:
+  - team.css
+---
+
+# Das Rust-Team
+
+Das Rust-Projekt wird von mehreren Teams [verwaltet](https://github.com/rust-lang/rfcs/blob/master/text/1068-rust-governance.md), welche sich auf verschiedene Themengebiete spezialisiert haben.
+Unten werden sie in alphabetischer Reihenfolge aufgelistet.
+
+Um ein Team zu kontaktieren, poste deine Frage oder deinen Kommentar im [Internals
+Forum](https://internals.rust-lang.org/) und tagge deinen Post mit der zum Teamnamen korrespondierenden Kategorie.
+Sicherheitsmeldungen sollten dem [Veröffentlichungsprozess für Sicherheitslücken](security.html) folgen.
+
+{% for team in site.data.team.teams %}
+<section id="{{ team.name | replace:' ','-' }}">
+<h2> {{ page.localized-teams[team.name].name | default: team.name }} </h2>
+
+<strong>Responsibility</strong>: {{ page.localized-teams[team.name].responsibility | default: team.responsibility }}
+
+<br />
+<br />
+
+{% if team.email %}
+  <strong>Contact</strong>:
+  <a href="mailto:{{ team.email | uri_escape }}">{{ team.email }}</a>
+{% endif %}
+
+<ul class="headshots">
+{% for nick in team.members %}
+  {% assign person = site.data.team.people[nick] %}
+  {% if person.site %}
+    {% assign sitename = person.site %}
+  {% else %}
+    {% assign sitename = "github" %}
+  {% endif %}
+  {% assign website = site.data.team.sites[sitename] %}
+  <li class="person {% if team.lead and team.lead == nick %}lead{% endif %}">
+  <a href="{{ website.url | replace:'%nick',nick }}">
+    <div class="name">{{ person.name }}</div>
+    <div class="details">
+      <div>irc: {% if person.irc %}{{ person.irc }}{% else %}{{ nick }}{% endif %}</div>
+      {% if person.ex-teams %}
+      <div>teams: {% for ex-team in person.ex-teams %}{% if forloop.first == false %}, {% endif %}{{ page.localized-ex-teams[ex-team] | default: ex-team }}{% endfor %}</div>
+      {% endif %}
+    </div>
+    <img class="headshot" src="{{ website.avatar | replace:'%nick',nick }}" alt="{{ person.name }}">
+  </a>
+</li>
+{% endfor %}
+</ul>
+</section>
+{% endfor %}

--- a/de-DE/user-groups.md
+++ b/de-DE/user-groups.md
@@ -1,0 +1,17 @@
+---
+layout: de-DE/default
+title: Rust-Benutzergruppen &middot; Die Programmiersprache Rust
+---
+
+# Rust-Benutzergruppen
+
+Es gibt weltweit über 90 Benutzergruppen in mehr als 35 Ländern.
+Viele Rust-Begeisterte treffen sich regelmäßig in diesen Gruppen.
+Es ist eine gute Möglichkeit, die Community kennenzulernen und andere
+Menschen mit ähnlichen Interessen zu finden. Die Treffen sind normalerweise
+locker und für jeden offen. Wenn du eine neue Benutzergruppe gestartet
+hast und sie gerne zu dieser Liste hinzufügen würdest, dann kontaktiere
+das [Rust Community Team](./team.html#Community) oder besser, öffne ein
+Pull Request für [diese Website](https://github.com/rust-lang/rust-www/blob/master/_data/usergroups.yml).
+
+{% include user-group-list.html %}


### PR DESCRIPTION
First of all, credit to @medium-endian for doing at least half of the work, even if it's lost in the rebase!

All pages have been translated and all changes that happened since our fork were applied.

A few remarks:

- We used the informal/friendly "du" form of address instead of the professional/distant "Sie", which we think fits the community better.
- For consistency with the locale ordering (`de_DE`), German now appears as the first language in the footer - this might not be desirable.
- No attempt was made at keeping the phrasing gender-neutral everywhere, as this is notoriously hard to get right without sounding weird. If somebody is willing to look into this, please do not hesitate to correct us.