### PR TITLE
Remove "gender", ensure most translations have "gender identity and expression"

### DIFF
--- a/de-DE/conduct.md
+++ b/de-DE/conduct.md
@@ -9,7 +9,7 @@ title: Der Rust-Verhaltenskodex &middot; Die Programmiersprache Rust
 
 **Kontakt**: [rust-mods@rust-lang.org](mailto:rust-mods@rust-lang.org) (Englisch)
 
-* Wir sind stets bemüht, eine freundliche, sichere und einladende Umgebung für alle zu bieten - unabhängig von Erfahrung, Geschlecht, Geschlechteridentität, sexueller Orientierung, körperlicher Einschränkung, Aussehen, ethnischer Herkunft, Alter, Religion, Nationalität oder ähnlichem.
+* Wir sind stets bemüht, eine freundliche, sichere und einladende Umgebung für alle zu bieten - unabhängig von Erfahrung, Geschlechteridentität und -ausdruck, sexueller Orientierung, körperlicher Einschränkung, Aussehen, ethnischer Herkunft, Alter, Religion, Nationalität oder ähnlichem.
 * Bitte vermeide im IRC offen sexuelle oder andere Nicknames, die eine freundliche, sichere und einladende Umgebung gefährden könnten.
 * Bitte verhalte dich zuvorkommend und höflich. Es gibt keinen Grund, unverschämt zu anderen Teilnehmern zu sein.
 * Bitte respektiere, dass es immer abweichende Meinungen gibt und dass jede Design- oder Implementierungsentscheidung auf Abwägungen basiert und Aufwand verursacht. Es gibt selten eine perfekte Lösung.

--- a/en-US/conduct.md
+++ b/en-US/conduct.md
@@ -9,7 +9,7 @@ title: The Rust Code of Conduct &middot; The Rust Programming Language
 
 **Contact**: [rust-mods@rust-lang.org](mailto:rust-mods@rust-lang.org)
 
-* We are committed to providing a friendly, safe and welcoming environment for all, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, nationality, or other similar characteristic.
+* We are committed to providing a friendly, safe and welcoming environment for all, regardless of level of experience, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, nationality, or other similar characteristic.
 * On IRC, please avoid using overtly sexual nicknames or other nicknames that might detract from a friendly, safe and welcoming environment for all.
 * Please be kind and courteous. There's no need to be mean or rude.
 * Respect that people have differences of opinion and that every design or implementation choice carries a trade-off and numerous costs. There is seldom a right answer.

--- a/es-ES/conduct.md
+++ b/es-ES/conduct.md
@@ -9,7 +9,7 @@ title: El código de conducta de Rust &middot; El lenguaje de programación Rust
 
 **Contacto**: [rust-mods@rust-lang.org](mailto:rust-mods@rust-lang.org)
 
-* Estamos comprometidos en proporcionar un entorno amigable y seguro para todos, independientemente de su nivel de experiencia, género, identidad de género, orientación sexual, discapacidades, apariencia personal, peso, raza, etnia, edad, religión, nacionalidad o cualquier característica similar.
+* Estamos comprometidos en proporcionar un entorno amigable y seguro para todos, independientemente de su nivel de experiencia, identidad y expresión de género, orientación sexual, discapacidades, apariencia personal, peso, raza, etnia, edad, religión, nacionalidad o cualquier característica similar.
 * En IRC, por favor evita usar nombres de usuario sexuales o poco amistosos, para lograr un entorno agradable para todos.
 * Por favor, sé cortés. No hay necesidad de ser rudo u ofensivo.
 * Respeta las diferencias de opinión de otras personas, y recuerda que toda decisión de diseño procura balancear ventajas y desventajas, rara vez hay una única respuesta correcta.

--- a/fr-FR/conduct.md
+++ b/fr-FR/conduct.md
@@ -9,7 +9,7 @@ title: Code de conduite Rust &middot; Rust, le langage de programmation
 
 **Contact**: [rust-mods@rust-lang.org](mailto:rust-mods@rust-lang.org)
 
-* Nous sommes déterminés à fournir un environnement sympathique, sûr et accueillant pour tout le monde, quel que soit le niveau d'expérience, le sexe, l’identité ou l’expression de genre, l’orientation sexuelle, le handicap, l’apparence personnelle, la taille physique, la race, l’origine ethnique, l’âge, la religion, la nationalité, ou toute caractéristique similaire.
+* Nous sommes déterminés à fournir un environnement sympathique, sûr et accueillant pour tout le monde, quel que soit le niveau d'expérience, l’identité ou l’expression de genre, l’orientation sexuelle, le handicap, l’apparence personnelle, la taille physique, la race, l’origine ethnique, l’âge, la religion, la nationalité, ou toute caractéristique similaire.
 * Sur IRC, évitez les pseudonymes ouvertement sexuels ou d’autres pseudonymes qui pourraient nuire à un un environnement sympathique, sûr et accueillant pour tout le monde.
 * Soyez aimable et courtois. Il n’y a aucune raison d’être méchant ou impoli.
 * Respectez que les gens ont des différences d’opinions et que chaque choix de conception ou d’implémentation implique un compromis et de nombreux coûts. Il y a rarement une bonne réponse.

--- a/id-ID/conduct.md
+++ b/id-ID/conduct.md
@@ -9,7 +9,7 @@ title: The Rust Code of Conduct &middot; The Rust Programming Language
 
 **Contact**: [rust-mods@rust-lang.org](mailto:rust-mods@rust-lang.org)
 
-* We are committed to providing a friendly, safe and welcoming environment for all, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, nationality, or other similar characteristic.
+* We are committed to providing a friendly, safe and welcoming environment for all, regardless of level of experience, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, nationality, or other similar characteristic.
 * On IRC, please avoid using overtly sexual nicknames or other nicknames that might detract from a friendly, safe and welcoming environment for all.
 * Please be kind and courteous. There's no need to be mean or rude.
 * Respect that people have differences of opinion and that every design or implementation choice carries a trade-off and numerous costs. There is seldom a right answer.

--- a/it-IT/conduct.md
+++ b/it-IT/conduct.md
@@ -9,7 +9,7 @@ title: Il codice di comportamento di Rust &middot; Il linguaggio di programmazio
 
 **Contatto**: [rust-mods@rust-lang.org](mailto:rust-mods@rust-lang.org)
 
-* Noi ci impegniamo a fornire un ambiente amichevole, sicuro e accomodante per tutti, a prescindere dal livello di esperienza, sesso, identità ed espressione sessuale, orientamento sessuale, disabilità, aspetto estetico, dimensione corporea, razza, etnia, età, religione, nazionalità o altre caratteristiche personali.
+* Noi ci impegniamo a fornire un ambiente amichevole, sicuro e accomodante per tutti, a prescindere dal livello di esperienza, identità di genere e rappresentazione dello stesso, orientamento sessuale, disabilità, aspetto estetico, dimensione corporea, razza, etnia, età, religione, nazionalità o altre caratteristiche personali.
 * Su IRC, evita di utilizzare pseudonimi troppo sessualizzanti o altri pseudonimi che potrebbero rovinare un ambiente amichevole, sicuro e accomodante per tutti.
 * Sii gentile e servizievole. Non c'è alcun bisogno di essere cattivi o maleducati.
 * Rispetta le persone che non la pensano come te e che ogni scelta di design o implementazione porta molti compromessi e costi. C'è raramente una vera risposta giusta.

--- a/pt-BR/conduct.md
+++ b/pt-BR/conduct.md
@@ -10,7 +10,7 @@ title: O Código de Conduta de Rust &middot; A linguagem de programação Rust
 **Contato**: [rust-mods@rust-lang.org](mailto:rust-mods@rust-lang.org)
 
 * Nós estamos comprometidos com fornecer um ambiente amigável, seguro e acolhedor para todos, independente di nível de experiência,
-  sexo, identidade e expressão do sexo, orientação sexual, falta de habilidade, aparência pessoal, tamanho do corpo, raça, etinia,
+  sexo, identidade e expressão de gênero, orientação sexual, falta de habilidade, aparência pessoal, tamanho do corpo, raça, etinia,
   idade, religião, nacionalidade ou outra característica pessoal.
 * No IRC, por favor evite usar nomes sugestivos ou outros nomes que podem denegrir a imagem de um ambiente amigável, seguro e           acolhedor para todos.
 * Por favor, seja gentil e cortês. Não há necessidade de ser mau ou rude.

--- a/vi-VN/conduct.md
+++ b/vi-VN/conduct.md
@@ -9,7 +9,7 @@ title: The Rust Code of Conduct &middot; The Rust Programming Language
 
 **Contact**: [rust-mods@rust-lang.org](mailto:rust-mods@rust-lang.org)
 
-* We are committed to providing a friendly, safe and welcoming environment for all, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, nationality, or other similar characteristic.
+* We are committed to providing a friendly, safe and welcoming environment for all, regardless of level of experience, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, nationality, or other similar characteristic.
 * On IRC, please avoid using overtly sexual nicknames or other nicknames that might detract from a friendly, safe and welcoming environment for all.
 * Please be kind and courteous. There's no need to be mean or rude.
 * Respect that people have differences of opinion and that every design or implementation choice carries a trade-off and numerous costs. There is seldom a right answer.

--- a/zh-CN/conduct.md
+++ b/zh-CN/conduct.md
@@ -9,7 +9,7 @@ title: Rust 行为守则 &middot; Rust 程序设计语言
 
 **联系**：[rust-mods@rust-lang.org](mailto:rust-mods@rust-lang.org)
 
-* We are committed to providing a friendly, safe and welcoming environment for all, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, nationality, or other similar characteristic.
+* We are committed to providing a friendly, safe and welcoming environment for all, regardless of level of experience, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, nationality, or other similar characteristic.
 * On IRC, please avoid using overtly sexual nicknames or other nicknames that might detract from a friendly, safe and welcoming environment for all.
 * Please be kind and courteous. There's no need to be mean or rude.
 * Respect that people have differences of opinion and that every design or implementation choice carries a trade-off and numerous costs. There is seldom a right answer.


### PR DESCRIPTION
In mentioning both "gender" and "gender identity and expression" the
code of conduct attempts to draw a distinction which doesn't exist;
i.e. that there is "True Gender" and "gender identity" (a distinction
which is often drawn to marginalize trans/nb folks).

We also in many cases didn't have the "expression" bit in all
translations. I've fixed most; but not the japanese or korean ones.