### PR TITLE
Always point to master branch release notes. Fixes #941

### DIFF
--- a/de-DE/documentation.md
+++ b/de-DE/documentation.md
@@ -48,7 +48,7 @@ Wenn du Rust noch nie gesehen hast, solltest du zuerst einen Blick in das Buch [
 [ref]: https://doc.rust-lang.org/reference
 [cargo]: http://doc.crates.io/guide.html
 [err]: https://doc.rust-lang.org/error-index.html
-[release_notes]: https://github.com/rust-lang/rust/blob/stable/RELEASES.md
+[release_notes]: https://github.com/rust-lang/rust/blob/master/RELEASES.md
 [docs.rs]: https://docs.rs
 [crates.io]: https://crates.io
 [platform_support]: https://forge.rust-lang.org/platform-support.html

--- a/en-US/documentation.md
+++ b/en-US/documentation.md
@@ -68,7 +68,7 @@ the errors produced by the Rust compiler.
 [ref]: https://doc.rust-lang.org/reference
 [cargo]: http://doc.crates.io/guide.html
 [err]: https://doc.rust-lang.org/error-index.html
-[release_notes]: https://github.com/rust-lang/rust/blob/stable/RELEASES.md
+[release_notes]: https://github.com/rust-lang/rust/blob/master/RELEASES.md
 [docs.rs]: https://docs.rs
 [crates.io]: https://crates.io
 [platform_support]: https://forge.rust-lang.org/platform-support.html

--- a/es-ES/documentation.md
+++ b/es-ES/documentation.md
@@ -62,7 +62,7 @@ cada lanzamiento.
 [ref]: https://doc.rust-lang.org/reference
 [cargo]: http://doc.crates.io/guide.html
 [err]: https://doc.rust-lang.org/error-index.html
-[release_notes]: https://github.com/rust-lang/rust/blob/stable/RELEASES.md
+[release_notes]: https://github.com/rust-lang/rust/blob/master/RELEASES.md
 [docs.rs]: https://docs.rs
 [crates.io]: https://crates.io
 

--- a/fr-FR/documentation.md
+++ b/fr-FR/documentation.md
@@ -44,7 +44,7 @@ Si vous découvrez Rust, la première chose à lire est l'introduction du livre 
 [ref]: https://doc.rust-lang.org/reference
 [cargo]: http://doc.crates.io/guide.html
 [err]: https://doc.rust-lang.org/error-index.html
-[release_notes]: https://github.com/rust-lang/rust/blob/stable/RELEASES.md
+[release_notes]: https://github.com/rust-lang/rust/blob/master/RELEASES.md
 
 ## Les documents réglementaires
 

--- a/id-ID/documentation.md
+++ b/id-ID/documentation.md
@@ -65,7 +65,7 @@ yang dihasilkan oleh compiler Rust.
 [ref]: https://doc.rust-lang.org/reference
 [cargo]: http://doc.crates.io/guide.html
 [err]: https://doc.rust-lang.org/error-index.html
-[release_notes]: https://github.com/rust-lang/rust/blob/stable/RELEASES.md
+[release_notes]: https://github.com/rust-lang/rust/blob/master/RELEASES.md
 [docs.rs]: https://docs.rs
 [crates.io]: https://crates.io
 [platform_support]: https://forge.rust-lang.org/platform-support.html

--- a/it-IT/documentation.md
+++ b/it-IT/documentation.md
@@ -64,7 +64,7 @@ errori emessi dal compilatore Rust.
 [ref]: https://doc.rust-lang.org/reference
 [cargo]: http://doc.crates.io/guide.html
 [err]: https://doc.rust-lang.org/error-index.html
-[release_notes]: https://github.com/rust-lang/rust/blob/stable/RELEASES.md
+[release_notes]: https://github.com/rust-lang/rust/blob/master/RELEASES.md
 [docs.rs]: https://docs.rs
 [crates.io]: https://crates.io
 

--- a/ja-JP/documentation.md
+++ b/ja-JP/documentation.md
@@ -61,7 +61,7 @@ Rustのコンパイラによって生成されるエラーの補足説明です�
 [ref]: https://doc.rust-lang.org/reference
 [cargo]: http://doc.crates.io/guide.html
 [err]: https://doc.rust-lang.org/error-index.html
-[release_notes]: https://github.com/rust-lang/rust/blob/stable/RELEASES.md
+[release_notes]: https://github.com/rust-lang/rust/blob/master/RELEASES.md
 [docs.rs]: https://docs.rs
 [crates.io]: https://crates.io
 

--- a/ko-KR/documentation.md
+++ b/ko-KR/documentation.md
@@ -62,7 +62,7 @@ Rust의 각 릴리스마다 바뀐 점들을 기록합니다.
 [ref]: https://doc.rust-lang.org/reference
 [cargo]: http://doc.crates.io/guide.html
 [err]: https://doc.rust-lang.org/error-index.html
-[release_notes]: https://github.com/rust-lang/rust/blob/stable/RELEASES.md
+[release_notes]: https://github.com/rust-lang/rust/blob/master/RELEASES.md
 [docs.rs]: https://docs.rs
 [crates.io]: https://crates.io
 [platform_support]: https://forge.rust-lang.org/platform-support.html

--- a/pl-PL/documentation.md
+++ b/pl-PL/documentation.md
@@ -63,7 +63,7 @@ które generuje kompilator Rusta.
 [ref]: https://doc.rust-lang.org/reference
 [cargo]: http://doc.crates.io/guide.html
 [err]: https://doc.rust-lang.org/error-index.html
-[release_notes]: https://github.com/rust-lang/rust/blob/stable/RELEASES.md
+[release_notes]: https://github.com/rust-lang/rust/blob/master/RELEASES.md
 [docs.rs]: https://docs.rs
 [crates.io]: https://crates.io
 

--- a/pt-BR/documentation.md
+++ b/pt-BR/documentation.md
@@ -57,7 +57,7 @@ com referência da seção do livro que a descreve.
 [ref]: https://doc.rust-lang.org/reference
 [cargo]: http://doc.crates.io/guide.html
 [err]: https://doc.rust-lang.org/error-index.html
-[release_notes]: https://github.com/rust-lang/rust/blob/stable/RELEASES.md
+[release_notes]: https://github.com/rust-lang/rust/blob/master/RELEASES.md
 [docs.rs]: https://docs.rs
 [crates.io]: https://crates.io
 

--- a/ru-RU/documentation.md
+++ b/ru-RU/documentation.md
@@ -58,7 +58,7 @@ title: Документация Rust &middot; Язык Программиров�
 [ref]: https://doc.rust-lang.org/reference
 [cargo]: https://rurust.github.io/cargo-docs-ru/
 [err]: https://doc.rust-lang.org/error-index.html
-[release_notes]: https://github.com/rust-lang/rust/blob/stable/RELEASES.md
+[release_notes]: https://github.com/rust-lang/rust/blob/master/RELEASES.md
 
 ## Правила проекта
 

--- a/vi-VN/documentation.md
+++ b/vi-VN/documentation.md
@@ -57,7 +57,7 @@ release.
 [ref]: https://doc.rust-lang.org/reference
 [cargo]: http://doc.crates.io/guide.html
 [err]: https://doc.rust-lang.org/error-index.html
-[release_notes]: https://github.com/rust-lang/rust/blob/stable/RELEASES.md
+[release_notes]: https://github.com/rust-lang/rust/blob/master/RELEASES.md
 [docs.rs]: https://docs.rs
 [crates.io]: https://crates.io
 

--- a/zh-CN/documentation.md
+++ b/zh-CN/documentation.md
@@ -51,7 +51,7 @@ title:  Rust 语言文档 &middot; Rust 程序设计语言
 [ref]: https://doc.rust-lang.org/reference
 [cargo]: http://doc.crates.io/guide.html
 [err]: https://doc.rust-lang.org/error-index.html
-[release_notes]: https://github.com/rust-lang/rust/blob/stable/RELEASES.md
+[release_notes]: https://github.com/rust-lang/rust/blob/master/RELEASES.md
 [docs.rs]: https://docs.rs
 [crates.io]: https://crates.io
 [platform_support]: https://forge.rust-lang.org/platform-support.html


### PR DESCRIPTION
Currently these tend to be outdated by one or two Rust versions, so this way new release notes can be found more easily at the risk of there sometimes being WIP release notes for an upcoming release. (But I think it should be pretty clear when this is the case, as there is usually a date or "in development" message, versus the confusion caused by an absence of the promised release notes.)