### PR TITLE
sv-SE: Copy-edits to the translation on documentation.md

### DIFF
--- a/sv-SE/community.md
+++ b/sv-SE/community.md
@@ -5,9 +5,9 @@ title: Rust-communityt &middot; Programmeringsspråket Rust
 
 # Rust-communityt
 
-Programmeringsspråket rust har många kvalitéter, men språkets
+Programmeringsspråket rust har många kvalitéer, men språkets
 största styrka är den gemenskap av människor som samlas för att
-se att användning av språket är en givande upplevelse.
+se till att användning av språket är en givande upplevelse.
 
 Vi är hängivna till och ämnar att tillhandahålla en vänlig, säker
 och välkomnande miljö för alla, oavsett könsidentitet, sexuell läggning,
@@ -19,7 +19,7 @@ Om du känner att du har blivit eller är trakasserad av eller
 obehagligt bemött av någon i communityt, [kontakta][mod_team_email]
 då någon i [rusts modereringsteam][mod_team] omgående. Oavsett om
 du bidrar ofta eller är ny till språket bryr vi oss om att göra
-communityt en säker plats för dig.
+communityt till en säker plats för dig.
 
 [coc]: conduct.html
 [mod_team_email]: mailto:rust-mods@rust-lang.org
@@ -27,13 +27,13 @@ communityt en säker plats för dig.
 ## Att komma igång
 
 Den viktigaste resurserna communityt har att erbjuda för de som
-är nya till språket rust är:
+är nya för språket rust är:
 
 - [#rust-beginners][beginners_irc], en IRC-kanal som gillar att
   svara på frågor oavsett djup.
 - [Användarnas forum][users_forum], för allmän diskussion om Rust.
 
-Du kan också hitta hjälp på fråge-och-svar-siten [Stack Overflow][stack_overflow].
+Du kan också hitta hjälp på fråge-och-svar-webbplatsen [Stack Overflow][stack_overflow].
 
 [stack_overflow]: https://stackoverflow.com/questions/tagged/rust
 
@@ -58,10 +58,10 @@ du också följa vår [Weibo][weibo] på kinesiska.
 ## IRC-kanaler
 
 "Rustaceans" (de som deltar i rust-communityt) tillhandahåller ett antal
-vänliga och högtraffikerade [IRC]-kanaler på Mozillas IRC-nätverk,
+vänliga och högtrafikerade [IRC]-kanaler på Mozillas IRC-nätverk,
 irc.mozilla.org.
 
-[#rust][rust_irc] kanalen är en plats för generell diskussion om rust och
+Kanalen [#rust][rust_irc] är en plats för generell diskussion om rust och
 ett bra ställe att att fråga om hjälp. Där finner du folk som är villiga
 att svara alla sorts frågor om rust. Vanligtvis får du svar snabbt.
 
@@ -71,8 +71,8 @@ Kanalen är också rätt plats för frågor om att bidra till rust.
 
 ### Huvudkanaler
 
-- [#rust][rust_irc] är en allmän kanal för Rust-relaterat
-- [#rust-beginners][beginners_irc] är ett ställe för de som är nya till språket
+- [#rust][rust_irc] är en allmän kanal för allt Rust-relaterat
+- [#rust-beginners][beginners_irc] är ett ställe för de som är nya för språket
 och har lägre traffik än #rust
 - [#rust-internals][internals_irc] är för diskussion om arbete för och på
 Rust-projektet självt.
@@ -89,8 +89,8 @@ Rust-projektet självt.
 
 ### Team-kanaler
 
-- [#cargo][cargo_irc] är för diskussion om Cargo, rusts pakethanterare och [cargo teamets][cargo_team] hemvist
-- [#rust-community][community_irc] är [community teamets][community_team] hemvist
+- [#cargo][cargo_irc] är för diskussion om Cargo, rusts pakethanterare och [cargo-teamets][cargo_team] hemvist
+- [#rust-community][community_irc] är [community-teamets][community_team] hemvist
 - [#rustc][rustc_irc] är [kompilatorteamets][compiler_team] hemvist
 - [#rust-dev-tools][dev_tools_irc] är [utvecklarverktygsteamets][dev_tools_team] hemvist
 - [#rust-docs][docs_irc] är [dokumentationsteamets][doc_team] hemvist

--- a/sv-SE/contribute.md
+++ b/sv-SE/contribute.md
@@ -11,19 +11,19 @@ Om du inte vet hur du ska bli involverad kommer den här sidan att hjälpa till.
 **Hittade du en bugg och behöver rapportera den?**
 [Följ buggrapporteringsguiden][bugs]. Tack på förhand!
 
-Rust är ett expansivt system av projekt, av vilket det mest framträdande
+Rust är ett expansivt system av projekt, av vilket de mest framträdande
 underhålls av [rustprojektets utvecklare][devs] i
 [rust-lang organisationen på GitHub][rust-lang]. Nykomlingar kan vara intresserade
 av projektets [CONTRIBUTING.md]-fil som förklarar hur man bidrar till repot
 [rust-lang/rust].
 
 Det finns många sätt att bidra till rusts framgång.
-Denna guiden fokuserar på nya avenyer för den nya bidragsgivaren:
+Den här guiden fokuserar på några olika vägar in för den nya bidragsgivaren:
 
-* [Att hitta, categorisera, prioritera och fixa problem](contribute-bugs.html).
-  Det grundläggande arbetet att underhålla ett stort och aktivt projekt likt rust.
+* [Att hitta, kategorisera, prioritera och fixa problem](contribute-bugs.html).
+  Det grundläggande arbetet att underhålla ett stort och aktivt projekt som rust.
 * [Dokumentation](contribute-docs.html). Inte bara officiell dokumentation,
-  utan också för crates, bloginlägg och andra inofficiella källor och resurser.
+  utan också för crates, blogginlägg och andra inofficiella källor och resurser.
 * [Bygga communityt](contribute-community.html). Att hjälpa andra rustprogrammerare
   och udvidga rusts räckvidd.
 * [Verktyg, IDE:er och infrastruktur](contribute-tools.html). De viktiga

--- a/sv-SE/documentation.md
+++ b/sv-SE/documentation.md
@@ -5,11 +5,11 @@ title:  Dokumentation om rust &middot; Programmeringsspråket Rust
 
 # Dokumentation om rust
 
-Om du hitintills inte set rust alls så är det första du borde läsa
+Om du hitintills inte sett rust alls så är det första du borde läsa
 introduktionen till boken [Programmeringsspråket Rust][book]. Den kommer ge dig
 en god uppfattning om vad rust är, hur du installerar det, samt förklara språkets
 syntax och koncept. När du har läst klart boken kommer du vara en novis
-rustutvecklare och kommer ha få ett bra grepp på de idéer som ligger till
+rustutvecklare och kommer ha ett bra grepp om de idéer som ligger till
 grund för rust.
 
 ## Att lära sig rust
@@ -19,16 +19,16 @@ som "Boken" kommer introducera huvudämnena som är viktiga för att lära sig r
 och ta dig till den punkt då du kan vara produktiv. Boken är språkets primära
 officiella dokument.
 
-[Rust by Example][rbe]. En samling av själv av fristående exempel skriva i rust
+[Rust by Example][rbe]. En samling av fristående exempel skrivna i rust
 om en rad olika ämnen som är körbara i webbläsaren.
 
 [Vanliga frågor][faq].
 
-[Den sk. Rustonomicon][nomicon]. En hel bok dedikerad till att förklara hur
+[Den sk. Rustonomicon][nomicon]. En hel bok ägnad åt att förklara hur
 man skriver osäker (`unsafe`) rustkod. Den är till för rustprogrammerare på
 en avancerad nivå.
 
-[rust-learning]. En kollektiv av resurser för att lära sig rust som underhålls
+[rust-learning]. Ett kollektiv av resurser för att lära sig rust som underhålls
 av communityt.
 
 [book]: https://doc.rust-lang.org/book/
@@ -44,11 +44,11 @@ standardbiblioteket.
 
 [docs.rs]. Dokumentation för alla crates publicerade på [crates.io].
 
-[Rusts referenshandbok][ref]. Medan rust inte har en formell specifikation
-försöker referensen att beskriva hur rust fungerar i detail. Den tenderar
-att vara utdaterad.
+[Rusts referenshandbok][ref]. Även om rust inte har en formell specifikation
+försöker referensen att beskriva hur rust fungerar i detalj. Den brukar
+vara föråldrad.
 
-[Indexet över syntax][syn]. Denna appendix från Boken innehåller diverse exempel
+[Indexet över syntax][syn]. Detta appendix från Boken innehåller diverse exempel
 för all syntax i rust korsrefererad med det kapitel i boken som beskriver exemplet.
 
 [Guiden till Cargo][cargo]. Dokumentation för cargo, rusts pakethanterare.
@@ -70,16 +70,14 @@ felmeddelande som kompilatorn genererar.
 [crates.io]: https://crates.io
 [platform_support]: https://forge.rust-lang.org/platform-support.html
 
-## Projektets policier
+## Projektets policyer
 
-[Rusts säkerhetspolicy][security]. Projektets policier för att rapportera,
+[Rusts säkerhetspolicy][security]. Projektets policyer för att rapportera,
 fixa och avslöja säkerhetsrelaterade buggar.
 
-[Rusts policy kring upphovsrätt och varumärke][legal]. 
-
-Rusts upphovsrätter ägs av rustsprojektets utvecklare
-("The Rust Project Developers"), och dess varumärken ägs av Mozilla.
-Lämplig användning av Rusts varumärken beskrivs här.
+[Rusts policy kring upphovsrätt och varumärke][legal]. Rusts upphovsrätter
+ägs av rustprojektets utvecklare ("The Rust Project Developers"), och dess
+varumärken ägs av Mozilla. Lämplig användning av Rusts varumärken beskrivs här.
 
 [Uppförandekod][coc]. Gäller för organisationen rust-lang på GitHub,
 de officiella forumen, IRC-kanalerna och olika delar av rust-världen.
@@ -92,7 +90,7 @@ de officiella forumen, IRC-kanalerna och olika delar av rust-världen.
 
 Mycket av den officiella dokumentationen om rust är också tillgänglig för
 [nattliga][nightly] och [beta-][beta]releaser utöver den dokumentationen
-för den stabila versionen av rust ovan länkad.
+för den stabila versionen av rust länkad ovan.
 
 [nightly]: https://doc.rust-lang.org/nightly/
 [beta]: https://doc.rust-lang.org/beta/
@@ -100,6 +98,6 @@ för den stabila versionen av rust ovan länkad.
 ## Icke-engelska resurser
 
 För resurser på andra språk än engelska, se de
-[lokala specifika länkarna i rust-learning][locale].
+[språkspecifika länkarna i rust-learning][locale].
 
 [locale]: https://github.com/ctjhoa/rust-learning#locale-links


### PR DESCRIPTION
This PR has small copy-edits to the Swedish documentation, spelling, tiny things.

- documentation.md
- contribute.md

