### PR TITLE
Fix to zh-CN and de-DE on links of \'the archives\' in other installation page

### DIFF
--- a/de-DE/other-installers.md
+++ b/de-DE/other-installers.md
@@ -189,4 +189,4 @@ Vergangene Veröffentlichungen können in [den Archiven] gefunden werden.
 [Rust signing key]: https://static.rust-lang.org/rust-key.gpg.ascii
 [GPG]: https://gnupg.org/
 [available on keybase.io]: https://keybase.io/rust
-[the archives]: https://static.rust-lang.org/dist/index.html
+[den Archiven]: https://static.rust-lang.org/dist/index.html

--- a/zh-CN/other-installers.md
+++ b/zh-CN/other-installers.md
@@ -94,7 +94,7 @@ curl https://sh.rustup.rs -sSf | sh -s -- --help
 这些二进制文件每个均使用了 [Rust signing key]来签名（由 Rust 构建基础设施使用 [GPG]），该密钥也在 
 [keybase.io] 上提供。在下面的表格中，`.asc` 文件即该签名。
 
-过去发布的版本可在[此处存档]中找到。
+过去发布的版本可在[此处存档][the archives]中找到。
 
 {% for channel in site.channels %}
 


### PR DESCRIPTION
other-installation pages of zh-CN and de-DE contain invalid links to 'the archives'.
Fixed de-DE by renaming the anchor.
Fixed zh-CN by add link specifier.

Signed-off-by: Yu Ding <dingyu02@baidu.com>