### PR TITLE
Retaining the fragment identifier when redirecting

### DIFF
--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -42,7 +42,7 @@
       // if we didn't find a supporting language, default to en-US
       if (!language) { language = "en-US"; }
 
-      document.location = "/" + language + '{{ page.url }}';
+      document.location = "/" + language + '{{ page.url }}' + document.location.hash;
     </script>
     <noscript>
       <meta http-equiv="refresh" content="0; url=/en-US{{ page.url }}">


### PR DESCRIPTION
This PR changes the site redirect to propagate fragment identifiers when redirecting. For example, the [US English conduct page](https://www.rust-lang.org/en-US/conduct.html) contains a link to https://www.rust-lang.org/team.html#Moderation. If you navigate to that, the client-side redirect code will send you to a language-specific destination with #Moderation removed. A link followed on an instance of the site that has this change _will_ have #Moderation after the redirect.

_Note that #Moderation is not the correct anchor, so clicking on it will land you at the top of the Team Page. That is being corrected in #991._