### PR TITLE
create the "docs peers" subteam on the teams page

### DIFF
--- a/_data/team.yml
+++ b/_data/team.yml
@@ -75,6 +75,8 @@ people:
   Gankro:
     name: Alexis Beingessner
     ex-teams: ["libs"]
+  Havvy:
+    name: Ryan Scheel
   huonw:
     name: Huon Wilson
     irc: huon
@@ -231,6 +233,9 @@ teams:
   - name: Documentation team
     responsibility: "ensuring Rust has fantastic documentation"
     members: [steveklabnik, GuillaumeGomez, frewsxcv, QuietMisdreavus]
+  - name: Documentation peers
+    responsibility: "oversight of specific documentation, and coordination with the docs team"
+    members: ["Havvy"]
   - name: Moderation team
     responsibility: "helping uphold the <a href='https://www.rust-lang.org/conduct.html'>code of conduct</a>"
     members: [mbrubeck, BurntSushi, manishearth, pnkfelix, niconii]


### PR DESCRIPTION
For a while now, the docs team has let Havvy manage, approve, and merge PRs to the reference as a sort of "peer" to the docs team, specifically managing the reference. To call out their contributions (and commit access), we'd like to float the idea of "docs peers", who "own" a given piece of docs, with Havvy as its inaugural member.