### PR TITLE
#927 Misaligned characters in Japanese page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -78,7 +78,7 @@ ul.menu li {
 ul.menu h2 {
 	font-size: 20px;
 	font-weight: 500;
-	margin: 1em;
+	margin: 0.8em;
 	display: inline;
 	line-height: 1.5em;
 }


### PR DESCRIPTION
I have changed the margin of the H2 element in the top navigation to prevent the link text from wrapping. I decreased it from 1em to 0.8em as suggested by @magnonellie in the issue comments.