### PR TITLE
Move Matklad to alumni status

### DIFF
--- a/_data/team.yml
+++ b/_data/team.yml
@@ -245,14 +245,14 @@ teams:
     lead: nikomatsakis
   - name: Dev tools team
     responsibility: "overall direction for tools for working with Rust code"
-    members: [fitzgen, japaric, killercup, matklad, michaelwoerister, nrc]
+    members: [fitzgen, japaric, killercup, michaelwoerister, nrc]
     lead: nrc
   - name: Dev tools peers
     responsibility: "oversight of specific Rust tools, and coordination with dev tools team"
     members: [alexcrichton, emilio, GuillaumeGomez, jwilm, llogiq, manishearth, oli-obk, QuietMisdreavus, steveklabnik, tromey]
   - name: Cargo team
     responsibility: "design and implementation of Cargo"
-    members: [alexcrichton, carols10cents, withoutboats, matklad, wycats, joshtriplett, aturon]
+    members: [alexcrichton, carols10cents, withoutboats, wycats, joshtriplett, aturon]
     lead: aturon
   - name: Infrastructure team
     responsibility: "infrastructure supporting the Rust project itself: CI, releases, bots, metrics"
@@ -287,7 +287,7 @@ teams:
     email: style-team@rust-lang.org
   - name: Rust team alumni
     responsibility: "enjoying a leisurely retirement"
-    members: [aatch, Gankro, pcwalton, huonw, peschkaj, dotdash, bkoropoff, brson, erickt]
+    members: [aatch, Gankro, pcwalton, huonw, peschkaj, dotdash, bkoropoff, brson, erickt, matklad]
 # Information on sites to get profile information from
 sites:
   github:


### PR DESCRIPTION
r? @aturon Could you remove Matklad from the dev-tools and cargo mailing lists too please?