### PR TITLE
fix arabic translation for سلام message

### DIFF
--- a/_includes/example.rs
+++ b/_includes/example.rs
@@ -22,7 +22,7 @@ fn main() {
             11 => println!("Dieser Code kann bearbeitet und ausgeführt werden!"),
             12 => println!("Den här koden kan redigeras och köras!"),
             13 => println!("Tento kód můžete upravit a spustit"),
-            14 => println!("این کد قابلیت ویرایش و اجرا دارد!"),
+            14 => println!("هذا الكود قابل للتعديل او التشغيل!"),
             _ =>  {},
         }
     }


### PR DESCRIPTION
"سلام" word is an Arabic word but text below are not in Arabic language at all and Arabic speaker will not understand it completely so here is my correction .