### PR TITLE
Adding missing period

### DIFF
--- a/en-US/install.html
+++ b/en-US/install.html
@@ -111,7 +111,7 @@ title: Installation &middot; The Rust Programming Language
           <code>rustup</code> manages these builds in a consistent way on every
           platform that Rust supports, enabling installation of Rust from the
           beta and nightly release channels as well as support for additional
-          cross-compilation targets
+          cross-compilation targets.
         </p>
 
         <p>

--- a/es-ES/install.html
+++ b/es-ES/install.html
@@ -124,7 +124,7 @@ title: Instalación &middot; El lenguaje de programación Rust
           consistente en todas las plataformas que Rust soporta, permitiendo la
           instalación de Rust en las versiones <i>beta</i> y <i>nightly</i> así
           como el soporte de compilación para otras plataformas usando
-          <i>cross-compiling</i>
+          <i>cross-compiling</i>.
         </p>
 
         <p>

--- a/id-ID/install.html
+++ b/id-ID/install.html
@@ -110,7 +110,7 @@ title: Instalasi &middot; Bahasa Pemrograman Rust
           </a>, Jadi ada banyak pembuatan Rust yang tersedia kapan saja.
           <code>rustup</code> mengelola ini yang dibangun secara konsisten di setiap
           platform yang didukung Rust, memungkinkan instalasi Rust dari
-          saluran rilis beta dan nightly serta dukungan untuk target cross-compilation tambahan
+          saluran rilis beta dan nightly serta dukungan untuk target cross-compilation tambahan.
         </p>
 
         <p>

--- a/pl-PL/install.html
+++ b/pl-PL/install.html
@@ -89,7 +89,7 @@ title: Instalacja &middot; Język programowania Rust
           <code>rustup</code> zarządza tymi wydaniami w konsekwentny sposób na
           każdej platformie, jaką wspiera Rust, umożliwiając instalację Rusta z
           kanałów beta oraz nightly, a także wsparcie dodatkowych
-          celów kompilacji skrośnej
+          celów kompilacji skrośnej.
         </p>
 
         <p>

--- a/ru-RU/install.html
+++ b/ru-RU/install.html
@@ -111,7 +111,7 @@ title: Установка &middot; The Rust Programming Language
           <code>rustup</code> manages these builds in a consistent way on every
           platform that Rust supports, enabling installation of Rust from the
           beta and nightly release channels as well as support for additional
-          cross-compilation targets
+          cross-compilation targets.
         </p>
 
         <p>

--- a/sv-SE/install.html
+++ b/sv-SE/install.html
@@ -111,7 +111,7 @@ title: Installation &middot; Programmeringsspråket Rust
           <code>rustup</code> hanterar dessa byggningar på ett konsekvent sätt på varje
           plattform som rust stödjer. Detta möjliggör installation av rust från
           de nattliga och beta-release-kanalerna samt stöd för ytterligare
-          kross-kompilerings-mål (cross-compilation targets)
+          kross-kompilerings-mål (cross-compilation targets).
         </p>
 
         <p>


### PR DESCRIPTION
Several translations of the [install page](https://www.rust-lang.org/install.html) is missing a period at the end of one of its paragraphs. For example, from the [English translation](https://www.rust-lang.org/en-US/install.html):

> Rust is installed and managed by the rustup tool. Rust has a 6-week rapid release process and supports a great number of platforms , so there are many builds of Rust available at any time. rustup manages these builds in a consistent way on every platform that Rust supports, enabling installation of Rust from the beta and nightly release channels as well as support for additional cross-compilation targets

This PR adds the missing period.