### PR TITLE
OS detection via navigator.oscpu fallback

### DIFF
--- a/_includes/rustup.js
+++ b/_includes/rustup.js
@@ -33,6 +33,15 @@ function detect_platform() {
         // rust-www/#692 - FreeBSD epiphany!
         if (navigator.appVersion.indexOf("FreeBSD")!=-1) {os = "unix";}
     }
+    
+    // Firefox Quantum likes to hide platform and appVersion but oscpu works
+    if (navigator.oscpu) {
+        if (navigator.oscpu.indexOf("Windows")!=-1) {os = "win";}
+        if (navigator.oscpu.indexOf("Mac")!=-1) {os = "unix";}
+        if (navigator.oscpu.indexOf("Linux")!=-1) {os = "unix";}
+        if (navigator.oscpu.indexOf("FreeBSD")!=-1) {os = "unix";}
+        if (navigator.oscpu.indexOf("NetBSD")!=-1) {os = "unix";}
+    }
 
     return os;
 }


### PR DESCRIPTION
Firefox Quantum seems to be hiding appVersion and os - possibly as part of the latest privacy improvements?

This adds some additional fallback code that uses the unblocked oscpu navigator property.

https://developer.mozilla.org/en-US/docs/Web/API/Navigator/oscpu has information on oscpu and I used https://en.wikipedia.org/wiki/Uname to look for the Linux variant that use `uname`