### PR TITLE
Update link to rustc-perf monitoring site

### DIFF
--- a/en-US/contribute-compiler.md
+++ b/en-US/contribute-compiler.md
@@ -104,6 +104,6 @@ TODO: some of this RFC description could probably go in the RFC readme
 [rfc-issues]: https://github.com/rust-lang/rfcs/issues
 [rfc]: https://github.com/rust-lang/rfcs#table-of-contents
 [rustc-guide]: https://github.com/rust-lang/rust/blob/master/src/librustc/README.md
-[rustc-perf]: http://ncameron.org/perf-rustc/
+[rustc-perf]: http://perf.rust-lang.org
 [testsuite]: https://github.com/rust-lang/rust-wiki-backup/blob/master/Note-testsuite.md
 [tips]: https://github.com/rust-lang/rust/blob/3d1f3c9d389d46607ae28c51cc94c1f43d65f3f9/Makefile.in#L48


### PR DESCRIPTION
The Rust compiler performance monitoring site has been up at http://perf.rust-lang.org for quite a while now, and the site on the old link fails to fetch performance data.