### PR TITLE
Show friends links status in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@ This repository contains the source files for rust-lang.org.
 
 ## Deployment
 
-[![Build Status](https://travis-ci.org/rust-lang/rust-www.svg?branch=master)](https://travis-ci.org/rust-lang/rust-www)
+type | status
+| ---- | ---- |
+| `master` | [![master branch](https://travis-ci.org/rust-lang/rust-www.svg?branch=master)](https://travis-ci.org/rust-lang/rust-www) |
+| `friends` | [![rust-www-friends-verifier](https://img.shields.io/travis/simeg/rust-www-friends-verifier/master.svg?label=friends)](https://travis-ci.org/simeg/rust-www-friends-verifier) |
 
 The site is built with TravisCI and automatically deployed to S3.
 


### PR DESCRIPTION
Background: #1020
Repo where script is run: https://github.com/simeg/rust-www-friends-verifier

The script health checks the websites for all the Friends of Rust once a
day, and if any website is not responsive the badge will turn red in the
README and hopefully someone will take a look and remove that website
from the list.

---

I used a table in the README, but of course if anyone has a better idea on how to display it feel free to contribute. Ideally this script would live in this repo, or in a separate repo in the Rust organisation - I don't think it makes sense that the script lives under my profile.

The script is setup and already running, been running for a week or so. So it's just a matter of showing the badge somewhere so people will see when it turns red.

Pinging people who were involved in the other PR: @bstrie @aturon @alexcrichton @ashleygwilliams @nikomatsakis @davidalber 

Output from the script run on travis where it took 7s to run:

```
6.95s$ /bin/bash ./verify-friends.sh
📥 Fetching source file..
📥 OK!
🔬 Parsing URLs from file..
🔬 OK!
⭐️ Found [ 120 ] URLs, cURLing them...
✅ OK!
✅ OK!
✅ OK!
...
✅ OK!
✅ OK!
⚠️  WARNING: URL [ https://www.theaterdo.de/ ] responded with status code [ 0 ], continuing..

The command "/bin/bash ./verify-friends.sh" exited with 0.
```