### PR TITLE
Remove Sunjay from Community Team

### DIFF
--- a/_data/team.yml
+++ b/_data/team.yml
@@ -328,7 +328,7 @@ teams:
   - name: Community team
     responsibility: "coordinating events, outreach, commercial users, teaching materials, and exposure"
     lead: ashleygwilliams
-    members: [skade, manishearth, sebasmagri, badboy, booyaa, ashleygwilliams, oe, technetos, arshiamufti, parrywinkle, spacekookie, flaki, mattgathu, celaus, wezm, sunjay, carols10cents, bstrie, edunham, jonathandturner]
+    members: [skade, manishearth, sebasmagri, badboy, booyaa, ashleygwilliams, oe, technetos, arshiamufti, parrywinkle, spacekookie, flaki, mattgathu, celaus, wezm, carols10cents, bstrie, edunham, jonathandturner]
     email: community@rust-lang.org
   - name: Documentation team
     responsibility: "ensuring Rust has fantastic documentation"


### PR DESCRIPTION
Hello! I accidentally got myself on the community team! This PR removes me, because as far as I know, I shouldn't be there. :smile: 

---

I was showing someone the Rust team page the other day when I realized that I was listed as a member of the community team.

![image](https://user-images.githubusercontent.com/530939/41364274-163c613a-6eeb-11e8-92be-cf072cda240d.png)

As far as I know, I haven't done anything to be on the team and no one has explicitly asked me to be there. I haven't gone to any meetings, done any significant tasks, or really done much of anything (as far as I know) that would qualify me to be there.

I spoke to @ashleygwilliams about it and this is actually totally my bad for not reading the [GitHub issue](https://github.com/rust-community/team/issues/230#issuecomment-386114569) where I was added.

I believe @booyaa added me because of [something I did for the content team one day](https://github.com/rust-community/team/issues/191). I haven't done anything since that day or gone to any meetings, so I think there may have been some confusion about my role. (I should have realized something was wrong when I was being invited to content team meetings.)

As much as I appreciate being considered one of the team, I don't think I should be there without doing anything and unfortunately I don't have the time to put in to helping out with what needs to be done.

If someone believed that I was doing something, this is my way of calling to attention that I haven't been. :)