### PR TITLE
Bring rustup.js and installation markup into alignment with rustup.rs

### DIFF
--- a/_includes/rustup.js
+++ b/_includes/rustup.js
@@ -1,10 +1,13 @@
+// IF YOU CHANGE THIS FILE IT MUST BE CHANGED ON BOTH rust-www and rustup.rs
+
+var platforms = ["default", "unknown", "win32", "win64", "unix"];
 var platform_override = null;
 
 function detect_platform() {
     "use strict";
 
-    if (platform_override) {
-        return platform_override;
+    if (platform_override !== null) {
+        return platforms[platform_override];
     }
 
     var os = "unknown";
@@ -20,7 +23,10 @@ function detect_platform() {
     if (navigator.platform == "Linux mips") {os = "unix";}
     if (navigator.platform == "Linux mips64") {os = "unix";}
     if (navigator.platform == "Mac") {os = "unix";}
-    if (navigator.platform == "Win32") {os = "win";}
+    if (navigator.platform == "Win32") {os = "win32";}
+    if (navigator.platform == "Win64" ||
+        navigator.userAgent.indexOf("WOW64") != -1 ||
+        navigator.userAgent.indexOf("Win64") != -1) { os = "win64"; }
     if (navigator.platform == "FreeBSD x86_64") {os = "unix";}
     if (navigator.platform == "FreeBSD amd64") {os = "unix";}
     if (navigator.platform == "NetBSD x86_64") {os = "unix";}
@@ -28,15 +34,16 @@ function detect_platform() {
 
     // I wish I knew by now, but I don't. Try harder.
     if (os == "unknown") {
-        if (navigator.appVersion.indexOf("Win")!=-1) {os = "win";}
+        if (navigator.appVersion.indexOf("Win")!=-1) {os = "win32";}
         if (navigator.appVersion.indexOf("Mac")!=-1) {os = "unix";}
         // rust-www/#692 - FreeBSD epiphany!
         if (navigator.appVersion.indexOf("FreeBSD")!=-1) {os = "unix";}
     }
-    
+
     // Firefox Quantum likes to hide platform and appVersion but oscpu works
     if (navigator.oscpu) {
-        if (navigator.oscpu.indexOf("Windows")!=-1) {os = "win";}
+        if (navigator.oscpu.indexOf("Win32")!=-1) {os = "win32";}
+        if (navigator.oscpu.indexOf("Win64")!=-1) {os = "win64";}
         if (navigator.oscpu.indexOf("Mac")!=-1) {os = "unix";}
         if (navigator.oscpu.indexOf("Linux")!=-1) {os = "unix";}
         if (navigator.oscpu.indexOf("FreeBSD")!=-1) {os = "unix";}
@@ -51,26 +58,19 @@ function adjust_for_platform() {
 
     var platform = detect_platform();
 
-    var unix_div = document.getElementById("platform-instructions-unix");
-    var win_div = document.getElementById("platform-instructions-win");
-    var unknown_div = document.getElementById("platform-instructions-unknown");
-    var default_div = document.getElementById("platform-instructions-default");
+    platforms.forEach(function (platform_elem) {
+        var platform_div = document.getElementById("platform-instructions-" + platform_elem);
+        platform_div.style.display = "none";
+        if (platform == platform_elem) {
+            platform_div.style.display = "block";
+        }
+    });
 
-    unix_div.style.display = "none";
-    win_div.style.display = "none";
-    unknown_div.style.display = "none";
-    default_div.style.display = "none";
+    adjust_platform_specific_instrs(platform);
+}
 
-    if (platform == "unix") {
-        unix_div.style.display = "block";
-    } else if (platform == "win") {
-        win_div.style.display = "block";
-    } else if (platform == "unknown") {
-        unknown_div.style.display = "block";
-    } else {
-        default_div.style.display = "block";
-    }
-
+// NB: This has no effect on rustup.rs
+function adjust_platform_specific_instrs(platform) {
     var platform_specific = document.getElementsByClassName("platform-specific");
     for (var el of platform_specific) {
         var el_is_not_win = el.className.indexOf("not-win") !== -1;
@@ -79,7 +79,7 @@ function adjust_for_platform() {
         if (el_is_inline) {
             el_visible_style = "inline";
         }
-        if (platform == "win") {
+        if (platform == "win64" || platform == "win32") {
             if (el_is_not_win) {
                 el.style.display = "none";
             } else {
@@ -97,15 +97,9 @@ function adjust_for_platform() {
 
 function cycle_platform() {
     if (platform_override == null) {
-        platform_override = "default";
-    } else if (platform_override == "default") {
-        platform_override = "unknown";
-    } else if (platform_override == "unknown") {
-        platform_override = "win";
-    } else if (platform_override == "win") {
-        platform_override = "unix";
-    } else if (platform_override == "unix") {
-        platform_override = "default";
+        platform_override = 0;
+    } else {
+        platform_override = (platform_override + 1) % platforms.length;
     }
     adjust_for_platform();
 }
@@ -139,6 +133,19 @@ function set_up_cycle_button() {
     };
 }
 
+function go_to_default_platform() {
+    platform_override = 0;
+    adjust_for_platform();
+}
+
+// NB: This has no effect on rust-lang.org/install.html
+function set_up_default_platform_buttons() {
+    var defaults_buttons = document.getElementsByClassName('default-platform-button');
+    for (var i = 0; i < defaults_buttons.length; i++) {
+        defaults_buttons[i].onclick = go_to_default_platform;
+    }
+}
+
 function fill_in_bug_report_values() {
     var nav_plat = document.getElementById("nav-plat");
     var nav_app = document.getElementById("nav-app");
@@ -149,5 +156,6 @@ function fill_in_bug_report_values() {
 (function () {
     adjust_for_platform();
     set_up_cycle_button();
+    set_up_default_platform_buttons();
     fill_in_bug_report_values();
 }());

--- a/css/style-vi.css
+++ b/css/style-vi.css
@@ -602,8 +602,10 @@ footer a {
 }
 
 #platform-instructions-unix > pre,
-#platform-instructions-win > pre,
-#platform-instructions-default > div > pre {
+#platform-instructions-win32 > pre,
+#platform-instructions-win64 > pre,
+#platform-instructions-default > div > pre,
+#platform-instructions-unknown > div > pre {
     background-color: #515151;
     color: white;
     margin-left: auto;
@@ -617,8 +619,10 @@ footer a {
     margin-bottom: 2rem;
 }
 
-#platform-instructions-win a,
-#platform-instructions-default a {
+#platform-instructions-win32 a.windows-download,
+#platform-instructions-win64 a.windows-download,
+#platform-instructions-default a.windows-download,
+#platform-instructions-unknown a.windows-download {
     display: block;
     padding-top: 0.4rem;
     padding-bottom: 0.6rem;

--- a/css/style.css
+++ b/css/style.css
@@ -649,8 +649,10 @@ footer a {
 }
 
 #platform-instructions-unix > pre,
-#platform-instructions-win > pre,
-#platform-instructions-default > div > pre {
+#platform-instructions-win32 > pre,
+#platform-instructions-win64 > pre,
+#platform-instructions-default > div > pre,
+#platform-instructions-unknown > div > pre {
     background-color: #515151;
     color: white;
     margin-left: auto;
@@ -664,9 +666,11 @@ footer a {
     margin-bottom: 2rem;
 }
 
-#platform-instructions-win a,
-#platform-instructions-default a {
-    display: block;
+#platform-instructions-win32 a.windows-download,
+#platform-instructions-win64 a.windows-download,
+#platform-instructions-default a.windows-download,
+#platform-instructions-unknown a.windows-download {
+   display: block;
     padding-top: 0.4rem;
     padding-bottom: 0.6rem;
     font-family: 'Fira Sans', "Helvetica Neue", Helvetica, Arial, sans-serif;

--- a/de-DE/install.html
+++ b/de-DE/install.html
@@ -12,12 +12,24 @@ title: Installation &middot; Die Programmiersprache Rust
           <pre>curl https://sh.rustup.rs -sSf | sh</pre>
         </div>
 
-        <div id="platform-instructions-win" class="instructions" style="display: none;">
+        <div id="platform-instructions-win32" class="instructions" style="display: none;">
           <p>
             Um Rust zu installieren, lade das folgende Installationsprogram herunter und führe es aus:
-            <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+            <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
             Folge dann den Anweisungen des Installers.
           </p>
+          <p>If you're a Windows Subsystem for Linux user run the following in your terminal, then follow the onscreen instructions to install Rust.</p>
+          <pre>curl https://sh.rustup.rs -sSf | sh</pre>
+        </div>
+
+        <div id="platform-instructions-win64" class="instructions" style="display: none;">
+          <p>
+            Um Rust zu installieren, lade das folgende Installationsprogram herunter und führe es aus:
+            <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
+            Folge dann den Anweisungen des Installers.
+          </p>
+          <p>If you're a Windows Subsystem for Linux user run the following in your terminal, then follow the onscreen instructions to install Rust.</p>
+          <pre>curl https://sh.rustup.rs -sSf | sh</pre>
         </div>
 
         <div id="platform-instructions-unknown" class="instructions" style="display: none;">
@@ -48,9 +60,20 @@ title: Installation &middot; Die Programmiersprache Rust
 
           <div>
             <p>
-              Um Rust unter Windows zu installieren, lade das folgende Installationsprogramm
+              Um Rust unter Windows 64-bit zu installieren, lade das folgende Installationsprogramm
               herunter und führe es aus:
-              <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+              <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
+              Folge dann den Anweisungen des Installers.
+            </p>
+          </div>
+
+          <hr/>
+
+          <div>
+            <p>
+              Um Rust unter Windows 64-bit zu installieren, lade das folgende Installationsprogramm
+              herunter und führe es aus:
+              <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
               Folge dann den Anweisungen des Installers.
             </p>
           </div>
@@ -67,9 +90,18 @@ title: Installation &middot; Die Programmiersprache Rust
 
           <div>
             <p>
-              Um Rust unter Windows zu installieren, lade das folgende Installationsprogramm herunter und
+              Um Rust unter Windows 64-bit zu installieren, lade das folgende Installationsprogramm herunter und
               führe es aus:
-              <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+              <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
+              Folge dann den Anweisungen des Installers.
+            </p>
+          </div>
+
+          <div>
+            <p>
+              Um Rust unter Windows 32-bit zu installieren, lade das folgende Installationsprogramm herunter und
+              führe es aus:
+              <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
               Folge dann den Anweisungen des Installers.
             </p>
           </div>

--- a/en-US/install.html
+++ b/en-US/install.html
@@ -11,10 +11,20 @@ title: Installation &middot; The Rust Programming Language
           <pre>curl https://sh.rustup.rs -sSf | sh</pre>
         </div>
 
-        <div id="platform-instructions-win" class="instructions" style="display: none;">
+        <div id="platform-instructions-win32" class="instructions" style="display: none;">
           <p>
             To install Rust, download and run
-            <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+            <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
+            then follow the onscreen instructions.
+          </p>
+          <p>If you're a Windows Subsystem for Linux user run the following in your terminal, then follow the onscreen instructions to install Rust.</p>
+          <pre>curl https://sh.rustup.rs -sSf | sh</pre>
+        </div>
+
+        <div id="platform-instructions-win64" class="instructions" style="display: none;">
+          <p>
+            To install Rust, download and run
+            <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
             then follow the onscreen instructions.
           </p>
           <p>If you're a Windows Subsystem for Linux user run the following in your terminal, then follow the onscreen instructions to install Rust.</p>
@@ -49,8 +59,18 @@ title: Installation &middot; The Rust Programming Language
 
           <div>
             <p>
-              If you are running Windows,<br/>download and run
-              <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+              If you are running Windows 64-bit,<br/>download and run
+              <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
+              then follow the onscreen instructions.
+            </p>
+          </div>
+
+          <hr/>
+
+          <div>
+            <p>
+              If you are running Windows 32-bit,<br/>download and run
+              <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
               then follow the onscreen instructions.
             </p>
           </div>
@@ -67,8 +87,18 @@ title: Installation &middot; The Rust Programming Language
 
           <div>
             <p>
-              If you are running Windows,<br/>download and run
-              <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+              If you are running Windows 64-bit,<br/>download and run
+              <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
+              then follow the onscreen instructions.
+            </p>
+          </div>
+
+          <hr/>
+
+          <div>
+            <p>
+              If you are running Windows 32-bit,<br/>download and run
+              <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
               then follow the onscreen instructions.
             </p>
           </div>

--- a/es-ES/install.html
+++ b/es-ES/install.html
@@ -11,12 +11,24 @@ title: Instalación &middot; El lenguaje de programación Rust
           <pre>curl https://sh.rustup.rs -sSf | sh</pre>
         </div>
 
-        <div id="platform-instructions-win" class="instructions" style="display: none;">
+        <div id="platform-instructions-win32" class="instructions" style="display: none;">
           <p>
             Para instalar Rust, descarga y ejecuta
-            <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+            <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
             luego sigue las instrucciones en pantalla.
           </p>
+          <p>If you're a Windows Subsystem for Linux user run the following in your terminal, then follow the onscreen instructions to install Rust.</p>
+          <pre>curl https://sh.rustup.rs -sSf | sh</pre>
+        </div>
+
+        <div id="platform-instructions-win64" class="instructions" style="display: none;">
+          <p>
+            Para instalar Rust, descarga y ejecuta
+            <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
+            luego sigue las instrucciones en pantalla.
+          </p>
+          <p>If you're a Windows Subsystem for Linux user run the following in your terminal, then follow the onscreen instructions to install Rust.</p>
+          <pre>curl https://sh.rustup.rs -sSf | sh</pre>
         </div>
 
         <div id="platform-instructions-unknown" class="instructions" style="display: none;">
@@ -48,17 +60,21 @@ title: Instalación &middot; El lenguaje de programación Rust
 
           <div>
             <p>
-              If you are running Windows,<br/>download and run
-              <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
-              then follow the onscreen instructions.
-            </p>
-            <p>
-              Si estas en Windows,<br/>descarga y ejecuta
-              <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+              Si estas en Windows 64-bit,<br/>descarga y ejecuta
+              <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
               luego sigue las instrucciones en pantalla.
             </p>
           </div>
 
+          <hr/>
+
+          <div>
+            <p>
+              Si estas en Windows 32-bit,<br/>descarga y ejecuta
+              <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
+              luego sigue las instrucciones en pantalla.
+            </p>
+          </div>
         </div>
 
         <div id="platform-instructions-default" class="instructions">
@@ -72,13 +88,18 @@ title: Instalación &middot; El lenguaje de programación Rust
 
           <div>
             <p>
-              If you are running Windows,<br/>download and run
-              <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
-              then follow the onscreen instructions.
+              Si estas en Windows 64-bit,<br/>descarga y ejecuta
+              <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
+              luego sigue las instrucciones en pantalla.
             </p>
+          </div>
+
+          <hr/>
+
+          <div>
             <p>
-              Si estas en Windows,<br/>descarga y ejecuta
-              <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+              Si estas en Windows 32-bit,<br/>descarga y ejecuta
+              <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
               luego sigue las instrucciones en pantalla.
             </p>
           </div>

--- a/fr-FR/install.html
+++ b/fr-FR/install.html
@@ -11,12 +11,24 @@ title: Installation &middot; Rust, le langage de programmation
           <pre>curl https://sh.rustup.rs -sSf | sh</pre>
         </div>
 
-        <div id="platform-instructions-win" class="instructions" style="display: none;">
+        <div id="platform-instructions-win32" class="instructions" style="display: none;">
           <p>
             Pour installer Rust, téléchargez et exécutez
-            <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+            <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
             puis suivez les instructions affichées à l'écran.
           </p>
+          <p>If you're a Windows Subsystem for Linux user run the following in your terminal, then follow the onscreen instructions to install Rust.</p>
+          <pre>curl https://sh.rustup.rs -sSf | sh</pre>
+        </div>
+
+        <div id="platform-instructions-win64" class="instructions" style="display: none;">
+          <p>
+            Pour installer Rust, téléchargez et exécutez
+            <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
+            puis suivez les instructions affichées à l'écran.
+          </p>
+          <p>If you're a Windows Subsystem for Linux user run the following in your terminal, then follow the onscreen instructions to install Rust.</p>
+          <pre>curl https://sh.rustup.rs -sSf | sh</pre>
         </div>
 
         <div id="platform-instructions-unknown" class="instructions" style="display: none;">
@@ -47,12 +59,21 @@ title: Installation &middot; Rust, le langage de programmation
 
           <div>
             <p>
-              Si vous êtes sur Windows,<br/>téléchargez et exécutez
-              <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+              Si vous êtes sur Windows 64-bit,<br/>téléchargez et exécutez
+              <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
               et suivez les instructions affichées à l'écran.
             </p>
           </div>
 
+          <hr/>
+
+          <div>
+            <p>
+              Si vous êtes sur Windows 32-bit,<br/>téléchargez et exécutez
+              <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
+              et suivez les instructions affichées à l'écran.
+            </p>
+          </div>
         </div>
 
         <div id="platform-instructions-default" class="instructions">
@@ -66,8 +87,18 @@ title: Installation &middot; Rust, le langage de programmation
 
           <div>
             <p>
-              Si vous êtes sur Windows,<br/>téléchargez et exécutez
-              <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+              Si vous êtes sur Windows 64-bit,<br/>téléchargez et exécutez
+              <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
+              et suivez les instructions affichées à l'écran.
+            </p>
+          </div>
+
+          <hr/>
+
+          <div>
+            <p>
+              Si vous êtes sur Windows 32-bit,<br/>téléchargez et exécutez
+              <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
               et suivez les instructions affichées à l'écran.
             </p>
           </div>

--- a/id-ID/install.html
+++ b/id-ID/install.html
@@ -11,12 +11,24 @@ title: Instalasi &middot; Bahasa Pemrograman Rust
           <pre>curl https://sh.rustup.rs -sSf | sh</pre>
         </div>
 
-        <div id="platform-instructions-win" class="instructions" style="display: none;">
+        <div id="platform-instructions-win32" class="instructions" style="display: none;">
           <p>
             Untuk instalasi Rust, unduh dan jalankan
-            <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+            <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
             lalu ikuti instruksi yang muncul dilayar.
           </p>
+          <p>If you're a Windows Subsystem for Linux user run the following in your terminal, then follow the onscreen instructions to install Rust.</p>
+          <pre>curl https://sh.rustup.rs -sSf | sh</pre>
+        </div>
+
+        <div id="platform-instructions-win64" class="instructions" style="display: none;">
+          <p>
+            Untuk instalasi Rust, unduh dan jalankan
+            <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
+            lalu ikuti instruksi yang muncul dilayar.
+          </p>
+          <p>If you're a Windows Subsystem for Linux user run the following in your terminal, then follow the onscreen instructions to install Rust.</p>
+          <pre>curl https://sh.rustup.rs -sSf | sh</pre>
         </div>
 
         <div id="platform-instructions-unknown" class="instructions" style="display: none;">
@@ -47,8 +59,18 @@ title: Instalasi &middot; Bahasa Pemrograman Rust
 
           <div>
             <p>
-              Jika anda pengguna Windows,<br/>unduh dan jalankan
-              <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+              Jika anda pengguna Windows 64-bit,<br/>unduh dan jalankan
+              <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
+              lalu ikuti instruksi yang muncul dilayar.
+            </p>
+          </div>
+
+          <hr/>
+
+          <div>
+            <p>
+              Jika anda pengguna Windows 32-bit,<br/>unduh dan jalankan
+              <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
               lalu ikuti instruksi yang muncul dilayar.
             </p>
           </div>
@@ -65,8 +87,18 @@ title: Instalasi &middot; Bahasa Pemrograman Rust
 
           <div>
             <p>
-              Jika anda pengguna Windows,<br/>unduh dan jalankan
-              <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+              Jika anda pengguna Windows 64-bit,<br/>unduh dan jalankan
+              <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
+              lalu ikuti instruksi yang muncul dilayar.
+            </p>
+          </div>
+
+          <hr/>
+
+          <div>
+            <p>
+              Jika anda pengguna Windows 32-bit,<br/>unduh dan jalankan
+              <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
               lalu ikuti instruksi yang muncul dilayar.
             </p>
           </div>

--- a/it-IT/install.html
+++ b/it-IT/install.html
@@ -11,12 +11,24 @@ title: Installazione &middot; Linguaggio di programmazione Rust
           <pre>curl https://sh.rustup.rs -sSf | sh</pre>
         </div>
 
-        <div id="platform-instructions-win" class="instructions" style="display: none;">
+        <div id="platform-instructions-win32" class="instructions" style="display: none;">
           <p>
             Per installare Rust, scarica e esegui l'installer
-            <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+            <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
             e segui le istruzioni a schermo.
           </p>
+          <p>If you're a Windows Subsystem for Linux user run the following in your terminal, then follow the onscreen instructions to install Rust.</p>
+          <pre>curl https://sh.rustup.rs -sSf | sh</pre>
+        </div>
+
+        <div id="platform-instructions-win64" class="instructions" style="display: none;">
+          <p>
+            Per installare Rust, scarica e esegui l'installer
+            <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
+            e segui le istruzioni a schermo.
+          </p>
+          <p>If you're a Windows Subsystem for Linux user run the following in your terminal, then follow the onscreen instructions to install Rust.</p>
+          <pre>curl https://sh.rustup.rs -sSf | sh</pre>
         </div>
 
         <div id="platform-instructions-unknown" class="instructions" style="display: none;">
@@ -47,8 +59,18 @@ title: Installazione &middot; Linguaggio di programmazione Rust
 
           <div>
             <p>
-              Se sei su Windows,<br/>scarica e esegui
-              <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+              Se sei su Windows 64-bit,<br/>scarica e esegui
+              <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
+              poi segui le istruzioni a schermo.
+            </p>
+          </div>
+
+          <hr/>
+
+          <div>
+            <p>
+              Se sei su Windows 32-bit,<br/>scarica e esegui
+              <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
               poi segui le istruzioni a schermo.
             </p>
           </div>
@@ -65,8 +87,18 @@ title: Installazione &middot; Linguaggio di programmazione Rust
 
           <div>
             <p>
-              Se sei su Windows, <br/>esegui l'installer
-              <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+              Se sei su Windows 64-bit, <br/>esegui l'installer
+              <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
+              e segui le istruzioni a schermo.
+            </p>
+          </div>
+
+          <hr/>
+
+          <div>
+            <p>
+              Se sei su Windows 32-bit, <br/>esegui l'installer
+              <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
               e segui le istruzioni a schermo.
             </p>
           </div>

--- a/ja-JP/install.html
+++ b/ja-JP/install.html
@@ -11,12 +11,24 @@ title: インストール &middot; プログラミング言語Rust
           <pre>curl https://sh.rustup.rs -sSf | sh</pre>
         </div>
 
-        <div id="platform-instructions-win" class="instructions" style="display: none;">
+        <div id="platform-instructions-win32" class="instructions" style="display: none;">
           <p>
             Rustをインストールするには
-            <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+            <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
             をダウンロードして実行し画面の指示に従って下さい。
           </p>
+          <p>If you're a Windows Subsystem for Linux user run the following in your terminal, then follow the onscreen instructions to install Rust.</p>
+          <pre>curl https://sh.rustup.rs -sSf | sh</pre>
+        </div>
+
+        <div id="platform-instructions-win64" class="instructions" style="display: none;">
+          <p>
+            Rustをインストールするには
+            <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
+            をダウンロードして実行し画面の指示に従って下さい。
+          </p>
+          <p>If you're a Windows Subsystem for Linux user run the following in your terminal, then follow the onscreen instructions to install Rust.</p>
+          <pre>curl https://sh.rustup.rs -sSf | sh</pre>
         </div>
 
         <div id="platform-instructions-unknown" class="instructions" style="display: none;">
@@ -47,8 +59,18 @@ title: インストール &middot; プログラミング言語Rust
 
           <div>
               <p>
-                  Windowsをお使いなら、<br/>
-                  <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+                  Windows 64-bitをお使いなら、<br/>
+                  <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
+                  をダウンロードして実行し、画面の指示に従って下さい
+              </p>
+          </div>
+
+          <hr/>
+
+          <div>
+              <p>
+                  Windows 32-bitをお使いなら、<br/>
+                  <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
                   をダウンロードして実行し、画面の指示に従って下さい
               </p>
           </div>
@@ -65,8 +87,18 @@ title: インストール &middot; プログラミング言語Rust
 
           <div>
             <p>
-              Windowsをお使いなら、<br/>
-              <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+              Windows 64-bitをお使いなら、<br/>
+              <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
+              をダウンロードして実行し、画面の指示に従って下さい
+            </p>
+          </div>
+
+          <hr/>
+
+          <div>
+            <p>
+              Windows 32-bitをお使いなら、<br/>
+              <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
               をダウンロードして実行し、画面の指示に従って下さい
             </p>
           </div>

--- a/ko-KR/install.html
+++ b/ko-KR/install.html
@@ -11,12 +11,24 @@ title: 설치 &middot; Rust 프로그래밍 언어
           <pre>curl https://sh.rustup.rs -sSf | sh</pre>
         </div>
 
-        <div id="platform-instructions-win" class="instructions" style="display: none;">
+        <div id="platform-instructions-win32" class="instructions" style="display: none;">
           <p>
             Rust를 설치하려면
-            <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>을
+            <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
             받아 설치한 뒤 화면에 나오는 설명(영문)을 따르세요.
           </p>
+          <p>If you're a Windows Subsystem for Linux user run the following in your terminal, then follow the onscreen instructions to install Rust.</p>
+          <pre>curl https://sh.rustup.rs -sSf | sh</pre>
+        </div>
+
+        <div id="platform-instructions-win64" class="instructions" style="display: none;">
+          <p>
+            Rust를 설치하려면
+            <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
+            받아 설치한 뒤 화면에 나오는 설명(영문)을 따르세요.
+          </p>
+          <p>If you're a Windows Subsystem for Linux user run the following in your terminal, then follow the onscreen instructions to install Rust.</p>
+          <pre>curl https://sh.rustup.rs -sSf | sh</pre>
         </div>
 
         <div id="platform-instructions-unknown" class="instructions" style="display: none;">
@@ -46,8 +58,18 @@ title: 설치 &middot; Rust 프로그래밍 언어
 
           <div>
             <p>
-              윈도를 사용하고 있을 경우,<br/>
-              <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>를
+              윈도를64-bit 사용하고 있을 경우,<br/>
+              <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
+              받아 설치한 뒤 화면에 나오는 설명(영문)을 따르세요.
+            </p>
+          </div>
+
+          <hr/>
+
+          <div>
+            <p>
+              윈도를32-bit 사용하고 있을 경우,<br/>
+              <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
               받아 설치한 뒤 화면에 나오는 설명(영문)을 따르세요.
             </p>
           </div>
@@ -64,8 +86,18 @@ title: 설치 &middot; Rust 프로그래밍 언어
 
           <div>
             <p>
-              윈도를 사용하고 있을 경우,<br/>
-              <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>를
+              윈도를64-bit 사용하고 있을 경우,<br/>
+              <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
+              받아 설치한 뒤 화면에 나오는 설명(영문)을 따르세요.
+            </p>
+          </div>
+
+          <hr/>
+
+          <div>
+            <p>
+              윈도를32-bit 사용하고 있을 경우,<br/>
+              <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
               받아 설치한 뒤 화면에 나오는 설명(영문)을 따르세요.
             </p>
           </div>

--- a/pl-PL/install.html
+++ b/pl-PL/install.html
@@ -11,12 +11,24 @@ title: Instalacja &middot; Język programowania Rust
           <pre>curl https://sh.rustup.rs -sSf | sh</pre>
         </div>
 
-        <div id="platform-instructions-win" class="instructions" style="display: none;">
+        <div id="platform-instructions-win32" class="instructions" style="display: none;">
           <p>
-            Aby zainstalować Rusta, pobierz i uruchom
-            <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+            Aby zainstalować Rusta, pobierz i uruchom
+            <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
             oraz postępuj zgodnie z instrukcjami wyświetlanymi na ekranie.
           </p>
+          <p>If you're a Windows Subsystem for Linux user run the following in your terminal, then follow the onscreen instructions to install Rust.</p>
+          <pre>curl https://sh.rustup.rs -sSf | sh</pre>
+        </div>
+
+        <div id="platform-instructions-win64" class="instructions" style="display: none;">
+          <p>
+            Aby zainstalować Rusta, pobierz i uruchom
+            <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
+            oraz postępuj zgodnie z instrukcjami wyświetlanymi na ekranie.
+          </p>
+          <p>If you're a Windows Subsystem for Linux user run the following in your terminal, then follow the onscreen instructions to install Rust.</p>
+          <pre>curl https://sh.rustup.rs -sSf | sh</pre>
         </div>
 
         <div id="platform-instructions-unknown" class="instructions" style="display: none;">
@@ -26,13 +38,32 @@ title: Instalacja &middot; Język programowania Rust
             używasz jednego z tych systemów i to widzisz proszę
             <a href="https://github.com/rust-lang/rust-www/issues/new">złóż issue</a>,
             wraz z tymi wartościami:
-            <div>
-              <div>navigator.platform:</div>
-              <div id="nav-plat"></div>
-              <div>navigator.appVersion:</div>
-              <div id="nav-app"></div>
-            </div>
           </p>
+
+          <div>
+            <div>navigator.platform:</div>
+            <div id="nav-plat"></div>
+            <div>navigator.appVersion:</div>
+            <div id="nav-app"></div>
+          </div>
+
+          <hr/>
+
+          <div>
+            <p>
+              Jeżeli używasz systemu Windows 64-bit,<br/>pobierz i uruchom
+              <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
+              oraz postępuj zgodnie z instrukcjami wyświetlanymi na ekranie.
+          </div>
+
+          <hr/>
+
+          <div>
+            <p>
+              Jeżeli używasz systemu Windows 32-bit,<br/>pobierz i uruchom
+              <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
+              oraz postępuj zgodnie z instrukcjami wyświetlanymi na ekranie.
+          </div>
         </div>
 
         <div id="platform-instructions-default" class="instructions">
@@ -45,8 +76,17 @@ title: Instalacja &middot; Język programowania Rust
 
           <div>
             <p>
-              Jeżeli używasz systemu Windows,<br/>pobierz i uruchom
-              <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+              Jeżeli używasz systemu Windows 64-bit,<br/>pobierz i uruchom
+              <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
+              oraz postępuj zgodnie z instrukcjami wyświetlanymi na ekranie.
+          </div>
+
+          <hr/>
+
+          <div>
+            <p>
+              Jeżeli używasz systemu Windows 32-bit,<br/>pobierz i uruchom
+              <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
               oraz postępuj zgodnie z instrukcjami wyświetlanymi na ekranie.
           </div>
         </div>

--- a/pt-BR/install.html
+++ b/pt-BR/install.html
@@ -11,12 +11,24 @@ title: Instalação &middot; A Linguagem de Programação Rust
           <pre>curl https://sh.rustup.rs -sSf | sh</pre>
         </div>
 
-        <div id="platform-instructions-win" class="instructions" style="display: none;">
+        <div id="platform-instructions-win32" class="instructions" style="display: none;">
           <p>
             Para instalar Rust, baixe e rode
-            <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+            <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
             e então siga as instruções na tela.
           </p>
+          <p>If you're a Windows Subsystem for Linux user run the following in your terminal, then follow the onscreen instructions to install Rust.</p>
+          <pre>curl https://sh.rustup.rs -sSf | sh</pre>
+        </div>
+
+        <div id="platform-instructions-win64" class="instructions" style="display: none;">
+          <p>
+            Para instalar Rust, baixe e rode
+            <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
+            e então siga as instruções na tela.
+          </p>
+          <p>If you're a Windows Subsystem for Linux user run the following in your terminal, then follow the onscreen instructions to install Rust.</p>
+          <pre>curl https://sh.rustup.rs -sSf | sh</pre>
         </div>
 
         <div id="platform-instructions-unknown" class="instructions" style="display: none;">
@@ -47,8 +59,18 @@ title: Instalação &middot; A Linguagem de Programação Rust
 
           <div>
             <p>
-              Se você está rodando Windows,<br/>baixe e rode
-              <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+              Se você está rodando Windows 64-bit,<br/>baixe e rode
+              <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
+              e então siga as instruções na tela.
+            </p>
+          </div>
+
+          <hr/>
+
+          <div>
+            <p>
+              Se você está rodando Windows 32-bit,<br/>baixe e rode
+              <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
               e então siga as instruções na tela.
             </p>
           </div>
@@ -65,8 +87,18 @@ title: Instalação &middot; A Linguagem de Programação Rust
 
           <div>
             <p>
-              Se você está rodando Windows,<br/>baixe e rode
-              <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+              Se você está rodando Windows 64-bit,<br/>baixe e rode
+              <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
+              e então siga as instruções na tela.
+            </p>
+          </div>
+
+          <hr/>
+
+          <div>
+            <p>
+              Se você está rodando Windows 32-bit,<br/>baixe e rode
+              <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
               e então siga as instruções na tela.
             </p>
           </div>

--- a/ru-RU/install.html
+++ b/ru-RU/install.html
@@ -11,12 +11,24 @@ title: Установка &middot; The Rust Programming Language
           <pre>curl https://sh.rustup.rs -sSf | sh</pre>
         </div>
 
-        <div id="platform-instructions-win" class="instructions" style="display: none;">
+        <div id="platform-instructions-win32" class="instructions" style="display: none;">
           <p>
             Чтобы установить Rust, загрузите и запустите
-            <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+            <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
             и следуйте инструкциям на экране.
           </p>
+          <p>If you're a Windows Subsystem for Linux user run the following in your terminal, then follow the onscreen instructions to install Rust.</p>
+          <pre>curl https://sh.rustup.rs -sSf | sh</pre>
+        </div>
+
+        <div id="platform-instructions-win64" class="instructions" style="display: none;">
+          <p>
+            Чтобы установить Rust, загрузите и запустите
+            <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
+            и следуйте инструкциям на экране.
+          </p>
+          <p>If you're a Windows Subsystem for Linux user run the following in your terminal, then follow the onscreen instructions to install Rust.</p>
+          <pre>curl https://sh.rustup.rs -sSf | sh</pre>
         </div>
 
         <div id="platform-instructions-unknown" class="instructions" style="display: none;">
@@ -47,8 +59,18 @@ title: Установка &middot; The Rust Programming Language
 
           <div>
             <p>
-              Если вы используете Windows,<br/>загрузите и запустите
-              <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+              Если вы используете Windows 64-bit,<br/>загрузите и запустите
+              <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
+              и следуйте инструкциям на экране.
+            </p>
+          </div>
+
+          <hr/>
+
+          <div>
+            <p>
+              Если вы используете Windows 32-bit,<br/>загрузите и запустите
+              <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
               и следуйте инструкциям на экране.
             </p>
           </div>
@@ -65,8 +87,18 @@ title: Установка &middot; The Rust Programming Language
 
           <div>
             <p>
-              Если вы используете Windows,<br/>загрузите и запустите
-              <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+              Если вы используете Windows 64-bit,<br/>загрузите и запустите
+              <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
+              и следуйте инструкциям на экране.
+            </p>
+          </div>
+
+          <hr/>
+
+          <div>
+            <p>
+              Если вы используете Windows 32-bit,<br/>загрузите и запустите
+              <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
               и следуйте инструкциям на экране.
             </p>
           </div>

--- a/sv-SE/install.html
+++ b/sv-SE/install.html
@@ -11,12 +11,24 @@ title: Installation &middot; Programmeringsspråket Rust
           <pre>curl https://sh.rustup.rs -sSf | sh</pre>
         </div>
 
-        <div id="platform-instructions-win" class="instructions" style="display: none;">
+        <div id="platform-instructions-win32" class="instructions" style="display: none;">
           <p>
             För att installera rust, ladda ner och kör
-            <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+            <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
             följ sedan instruktionerna på skrämen.
           </p>
+          <p>If you're a Windows Subsystem for Linux user run the following in your terminal, then follow the onscreen instructions to install Rust.</p>
+          <pre>curl https://sh.rustup.rs -sSf | sh</pre>
+        </div>
+
+        <div id="platform-instructions-win64" class="instructions" style="display: none;">
+          <p>
+            För att installera rust, ladda ner och kör
+            <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
+            följ sedan instruktionerna på skrämen.
+          </p>
+          <p>If you're a Windows Subsystem for Linux user run the following in your terminal, then follow the onscreen instructions to install Rust.</p>
+          <pre>curl https://sh.rustup.rs -sSf | sh</pre>
         </div>
 
         <div id="platform-instructions-unknown" class="instructions" style="display: none;">
@@ -47,8 +59,18 @@ title: Installation &middot; Programmeringsspråket Rust
 
           <div>
             <p>
-              Om du använder Windows,<br/>ladda ner och kör
-              <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+              Om du använder Windows 64-bit,<br/>ladda ner och kör
+              <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
+              och följ sedan instruktionerna på skärmen.
+            </p>
+          </div>
+
+          <hr/>
+
+          <div>
+            <p>
+              Om du använder Windows 32-bit,<br/>ladda ner och kör
+              <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
               och följ sedan instruktionerna på skärmen.
             </p>
           </div>
@@ -65,8 +87,18 @@ title: Installation &middot; Programmeringsspråket Rust
 
           <div>
             <p>
-              Om du använder Windows,<br/>ladda ner och kör
-              <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+              Om du använder Windows 64-bit,<br/>ladda ner och kör
+              <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
+              och följ sedan instruktionerna på skärmen.
+            </p>
+          </div>
+
+          <hr/>
+
+          <div>
+            <p>
+              Om du använder Windows 32-bit,<br/>ladda ner och kör
+              <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
               och följ sedan instruktionerna på skärmen.
             </p>
           </div>

--- a/vi-VN/install.html
+++ b/vi-VN/install.html
@@ -11,12 +11,24 @@ title: Cài đặt Rust &middot; Ngôn ngữ lập trình Rust
           <pre>curl https://sh.rustup.rs -sSf | sh</pre>
         </div>
 
-        <div id="platform-instructions-win" class="instructions" style="display: none;">
+        <div id="platform-instructions-win32" class="instructions" style="display: none;">
           <p>
             Để cài đặt Rust, tải về và chạy file dưới đây
-            <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+            <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
             kế tiếp làm theo các hướng dẫn ở màn hình.
           </p>
+          <p>If you're a Windows Subsystem for Linux user run the following in your terminal, then follow the onscreen instructions to install Rust.</p>
+          <pre>curl https://sh.rustup.rs -sSf | sh</pre>
+        </div>
+
+        <div id="platform-instructions-win64" class="instructions" style="display: none;">
+          <p>
+            Để cài đặt Rust, tải về và chạy file dưới đây
+            <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
+            kế tiếp làm theo các hướng dẫn ở màn hình.
+          </p>
+          <p>If you're a Windows Subsystem for Linux user run the following in your terminal, then follow the onscreen instructions to install Rust.</p>
+          <pre>curl https://sh.rustup.rs -sSf | sh</pre>
         </div>
 
         <div id="platform-instructions-unknown" class="instructions" style="display: none;">
@@ -47,8 +59,18 @@ title: Cài đặt Rust &middot; Ngôn ngữ lập trình Rust
 
           <div>
             <p>
-              Nếu bạn dùng Windows,<br/>tải về và chạy file
-              <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+              Nếu bạn dùng Windows 64-bit,<br/>tải về và chạy file
+              <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
+              kế tiếp làm theo các hướng dẫn trên màn hình.
+            </p>
+          </div>
+
+          <hr/>
+
+          <div>
+            <p>
+              Nếu bạn dùng Windows 32-bit,<br/>tải về và chạy file
+              <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
               kế tiếp làm theo các hướng dẫn trên màn hình.
             </p>
           </div>
@@ -65,8 +87,18 @@ title: Cài đặt Rust &middot; Ngôn ngữ lập trình Rust
 
           <div>
             <p>
-              Nếu bạn dùng Windows,<br/>tải về và chạy file
-              <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+              Nếu bạn dùng Windows 64-bit,<br/>tải về và chạy file
+              <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
+              kế tiếp làm theo các hướng dẫn trên màn hình.
+            </p>
+          </div>
+
+          <hr/>
+
+          <div>
+            <p>
+              Nếu bạn dùng Windows 32-bit,<br/>tải về và chạy file
+              <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
               kế tiếp làm theo các hướng dẫn trên màn hình.
             </p>
           </div>

--- a/zh-CN/install.html
+++ b/zh-CN/install.html
@@ -11,12 +11,24 @@ title: 安装 &middot; Rust 程序设计语言
           <pre>curl https://sh.rustup.rs -sSf | sh</pre>
         </div>
 
-        <div id="platform-instructions-win" class="instructions" style="display: none;">
+        <div id="platform-instructions-win32" class="instructions" style="display: none;">
           <p>
             安装 Rust：下载并运行
-            <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+            <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
             然后按照屏幕上的说明进行操作
           </p>
+          <p>If you're a Windows Subsystem for Linux user run the following in your terminal, then follow the onscreen instructions to install Rust.</p>
+          <pre>curl https://sh.rustup.rs -sSf | sh</pre>
+        </div>
+
+        <div id="platform-instructions-win64" class="instructions" style="display: none;">
+          <p>
+            安装 Rust：下载并运行
+            <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
+            然后按照屏幕上的说明进行操作
+          </p>
+          <p>If you're a Windows Subsystem for Linux user run the following in your terminal, then follow the onscreen instructions to install Rust.</p>
+          <pre>curl https://sh.rustup.rs -sSf | sh</pre>
         </div>
 
         <div id="platform-instructions-unknown" class="instructions" style="display: none;">
@@ -47,8 +59,18 @@ title: 安装 &middot; Rust 程序设计语言
 
           <div>
             <p>
-              如果您正在使用 Windows 操作系统，<br/>下载并运行
-              <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+              如果您正在使用 Windows 64-bit 操作系统，<br/>下载并运行
+              <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
+              然后按照屏幕上的说明进行操作。
+            </p>
+          </div>
+
+          <hr/>
+
+          <div>
+            <p>
+              如果您正在使用 Windows 32-bit 操作系统，<br/>下载并运行
+              <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
               然后按照屏幕上的说明进行操作。
             </p>
           </div>
@@ -65,8 +87,18 @@ title: 安装 &middot; Rust 程序设计语言
 
           <div>
             <p>
-              如果您正在使用 Windows 操作系统，<br/>下载并运行
-              <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+              如果您正在使用 Windows 64-bit 操作系统，<br/>下载并运行
+              <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
+              然后按照屏幕上的说明进行操作。
+            </p>
+          </div>
+
+          <hr/>
+
+          <div>
+            <p>
+              如果您正在使用 Windows 32-bit 操作系统，<br/>下载并运行
+              <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
               然后按照屏幕上的说明进行操作。
             </p>
           </div>


### PR DESCRIPTION
This primarily makes the install page offer the 64-bit version
of rustup-init when appropriate, per rustup.rs.

Also

- Adjust the "unknown" and "default" cases to offer both
  64-bit and 32-bit windows installers
- rustup.rs and rust-www use the exact same rustup.js
- add the "If you are a WSL user..." language to all
  non-English pages
- fix style on vi-VN

Fixes #1049 