### PR TITLE
Fixing link to MS VS 2017 tools for Windows (in french translation)

### DIFF
--- a/fr-FR/install.html
+++ b/fr-FR/install.html
@@ -162,8 +162,8 @@ title: Installation &middot; Rust, le langage de programmation
 	    Sur Windows, Rust nécessite également les outils de développement C++
 	    pour Visual Studio 2013 ou plus récent. La manière la plus simple
 	    d'obtenir ces outils de développement est d'installer
-	    <a href="https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2017">
-	      Microsoft Visual C++ Build Tools 2017
+	    <a href="https://visualstudio.microsoft.com/fr/downloads/#outils-de-compilation-pour-visual-studio-2017">
+	      Outils de compilation pour Visual Studio 2017
             </a>
             qui fournit uniquement les outils de développement Visual C++. Sinon,
 	    vous pouvez


### PR DESCRIPTION
The french visitors of the *Microsoft Visual Studio website* are redirected on its french version, but when they are redirected, they are loosing the ID of the subsection of the tool they need to install for Microsoft Windows use (the `#build-tools-for-visual-studio-2017` part on the end of the URL). Furthermore, the name of the tool in french was wrong (or has changed since translated).

I've discovered the correct name of the software when I changed the name of the *Microsoft Visual Studio website* to English and click another time on the link.

r? @steveklabnik