### PR TITLE
Update Barcelona Meetup info

### DIFF
--- a/_data/usergroups.yml
+++ b/_data/usergroups.yml
@@ -361,9 +361,9 @@
       city: Madrid
       url: https://github.com/rustmadrid
 
-    - name: Rust Barcelona
+    - name: Bcn Rust
       city: Barcelona
-      url: https://www.meetup.com/Rust-Barcelona/
+      url: https://www.meetup.com/BcnRust/
 
 - country: South Korea
   meetups:


### PR DESCRIPTION
The old Barcelona Rust Meetup group is no longer active, as stated on its home page: https://www.meetup.com/es-ES/Rust-Barcelona/

We've recently launched BcnRust as a second try to ignite the Rust fire in the Barcelona area, which was inaugurated by Steve Klabnik and Ashley Williams last week.

So, rustaceans of the world, give us a ping if you happen to get by Barcelona!