### PR TITLE
Add Auckland meetup

### DIFF
--- a/_data/usergroups.yml
+++ b/_data/usergroups.yml
@@ -292,6 +292,10 @@
     - name: Wellington Rust Meetup
       city: Wellington
       url: https://www.meetup.com/Wellington-Rust-Meetup/
+      
+    - name: Rust AKL
+      city: Auckland
+      url: https://www.meetup.com/rust-akl/
 
 - country: Norway
   meetups:


### PR DESCRIPTION
G'day,

After a successful Rust talk sneakily placed at a Go meetup here in Auckland, we've decided to start a brand new Rust meetup. Details are included in the PR.

Thanks!