### PR TITLE
Use T-rustdoc label instead of A-rustdoc label

### DIFF
--- a/de-DE/contribute-tools.md
+++ b/de-DE/contribute-tools.md
@@ -15,7 +15,7 @@ bis zu deiner Lieblings-IDE. Folge dem Link für mehr Information.
 Sowohl Cargo, der Paketmanager, als auch der Dokumentationsgenerator rustdoc
 sind zwar voll funktionsfähig, leiden aber an einem Entwicklermangel.
 Rustdoc hat viele offene Probleme, die im Main-Repository unter dem Label
-[A-rustdoc] gelistet sind. Es sind hauptsächlich Bugs, die lediglich einen
+[T-rustdoc] gelistet sind. Es sind hauptsächlich Bugs, die lediglich einen
 Bugfix und einen Pull Request erfordern.
 Cargo hat [sein eigenes Repository mit Issue-Tracker][Cargo], und
 wer beitragen möchte, kann sich gerne in [#cargo] melden.
@@ -36,7 +36,7 @@ Diese können mit anderen Tooling-Enthusiasten in
 [#cargo]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
 [#rust-tools]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-tools
 [A-debuginfo]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-debuginfo
-[A-rustdoc]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-rustdoc
+[T-rustdoc]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AT-rustdoc
 [Cargo]: https://github.com/rust-lang/cargo/issues
 [awesome-rust]: https://github.com/kud1ing/awesome-rust
 [ides]: https://forge.rust-lang.org/ides.html

--- a/en-US/contribute-tools.md
+++ b/en-US/contribute-tools.md
@@ -14,7 +14,7 @@ favorite IDE. Follow the link for more information.
 Both Cargo, the Rust package manager, and rustdoc,
 the Rust documentation generator, while full-featured and functional,
 suffer from a lack of developers. Rustdoc has many open issues, under
-the main repository's [A-rustdoc] label. They are mostly bugs and
+the main repository's [T-rustdoc] label. They are mostly bugs and
 contributing is a matter of fixing the bug and submitting a pull
 request. Cargo has [its own repository and issues][Cargo], and those
 interested in contributing might want to introduce themselves in
@@ -34,7 +34,7 @@ Rust tooling enthusiasts in [#rust-tools].
 [#cargo]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
 [#rust-tools]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-tools
 [A-debuginfo]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-debuginfo
-[A-rustdoc]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-rustdoc
+[T-rustdoc]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AT-rustdoc
 [Cargo]: https://github.com/rust-lang/cargo/issues
 [awesome-rust]: https://github.com/kud1ing/awesome-rust
 [ides]: https://forge.rust-lang.org/ides.html

--- a/es-ES/contribute-tools.md
+++ b/es-ES/contribute-tools.md
@@ -14,7 +14,7 @@ favorite IDE. Follow the link for more information.
 Both Cargo, the Rust package manager, and rustdoc,
 the Rust documentation generator, while full-featured and functional,
 suffer from a lack of developers. Rustdoc has many open issues, under
-the main repository's [A-rustdoc] label. They are mostly bugs and
+the main repository's [T-rustdoc] label. They are mostly bugs and
 contributing is a matter of fixing the bug and submitting a pull
 request. Cargo has [its own repository and issues][Cargo], and those
 interested in contributing might want to introduce themselves in
@@ -34,7 +34,7 @@ Rust tooling enthusiasts in [#rust-tools].
 [#cargo]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
 [#rust-tools]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-tools
 [A-debuginfo]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-debuginfo
-[A-rustdoc]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-rustdoc
+[T-rustdoc]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AT-rustdoc
 [Cargo]: https://github.com/rust-lang/cargo/issues
 [awesome-rust]: https://github.com/kud1ing/awesome-rust
 [ides]: https://forge.rust-lang.org/ides.html

--- a/fr-FR/contribute-tools.md
+++ b/fr-FR/contribute-tools.md
@@ -7,7 +7,7 @@ title: Contribuer à Rust &mdash; les outils, les EDI et l'infrastructure &middo
 
 Les outils sont un acteur majeur du succès d'un langage et il y a encore une bonne partie qui reste à implémenter. ***Un des axes principaux de développement de Rust est actuellement [l'amélioration de l'expérience avec les EDI][ides]***. Ce type de contribution implique de manipuler l'ensemble de la « pile » Rust : depuis le compilateur jusqu'à votre EDI préféré. Le lien ci-dessus vous fournira plus d'informations à ce sujet.
 
-Cargo (le gestionnaire de paquets Rust) ou rustdoc (le générateur de documentation Rust) sont fonctionnels et assez complets mais ils souffrent d'un manque de développeurs. De nombreux problèmes associés à Rustdoc sont étiquetés avec [A-rustdoc] dans le traqueur du dépôt principal. Pour la plupart, ces problèmes sont des bugs et il s'agira de corriger le(s) bug(s) et d'envoyer une *pull request* pour contribuer. Cargo possède [son propre dépôt et traqueur][Cargo] et les personnes intéressées par ce projet pourront se présenter sur le canal [#cargo] afin de contribuer.
+Cargo (le gestionnaire de paquets Rust) ou rustdoc (le générateur de documentation Rust) sont fonctionnels et assez complets mais ils souffrent d'un manque de développeurs. De nombreux problèmes associés à Rustdoc sont étiquetés avec [T-rustdoc] dans le traqueur du dépôt principal. Pour la plupart, ces problèmes sont des bugs et il s'agira de corriger le(s) bug(s) et d'envoyer une *pull request* pour contribuer. Cargo possède [son propre dépôt et traqueur][Cargo] et les personnes intéressées par ce projet pourront se présenter sur le canal [#cargo] afin de contribuer.
 
 Bien que Rust puisse être manipulé avec les débogueurs gdb et lldb, cela reste plutôt limité et de nombreux cas de débogage ne fonctionnent pas encore correctement. L'étiquette [A-debuginfo] permet de repérer ces problèmes dans le traqueur.
 
@@ -18,7 +18,7 @@ De nombreux projets autour d'outils attendent simplement les bonnes personnes po
 [#cargo]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
 [#rust-tools]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-tools
 [A-debuginfo]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-debuginfo
-[A-rustdoc]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-rustdoc
+[T-rustdoc]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AT-rustdoc
 [Cargo]: https://github.com/rust-lang/cargo/issues
 [awesome-rust]: https://github.com/kud1ing/awesome-rust
 [ides]: https://forge.rust-lang.org/ides.html

--- a/id-ID/contribute-tools.md
+++ b/id-ID/contribute-tools.md
@@ -14,7 +14,7 @@ favorite IDE. Follow the link for more information.
 Both Cargo, the Rust package manager, and rustdoc,
 the Rust documentation generator, while full-featured and functional,
 suffer from a lack of developers. Rustdoc has many open issues, under
-the main repository's [A-rustdoc] label. They are mostly bugs and
+the main repository's [T-rustdoc] label. They are mostly bugs and
 contributing is a matter of fixing the bug and submitting a pull
 request. Cargo has [its own repository and issues][Cargo], and those
 interested in contributing might want to introduce themselves in
@@ -34,7 +34,7 @@ Rust tooling enthusiasts in [#rust-tools].
 [#cargo]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
 [#rust-tools]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-tools
 [A-debuginfo]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-debuginfo
-[A-rustdoc]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-rustdoc
+[T-rustdoc]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AT-rustdoc
 [Cargo]: https://github.com/rust-lang/cargo/issues
 [awesome-rust]: https://github.com/kud1ing/awesome-rust
 [ides]: https://forge.rust-lang.org/ides.html

--- a/it-IT/contribute-tools.md
+++ b/it-IT/contribute-tools.md
@@ -18,7 +18,7 @@ il generatore di documentazione per Rust, sebbene
 siano in possesso di tutte le funzioni richieste e 
 validamente funzionanti, soffrono di una carenza di sviluppatori.
 Rustdoc ha molte problematiche aperte sotto l'etichetta
-[A-rustdoc] del repository principale.
+[T-rustdoc] del repository principale.
 Queste problematiche sono principalmente composte da
 errori e contribuire è semplicmente una questione di 
 risolverli e inviare una richiesta di unione.
@@ -42,7 +42,7 @@ Rust su [#rust-tools].
 [#cargo]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
 [#rust-tools]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-tools
 [A-debuginfo]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-debuginfo
-[A-rustdoc]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-rustdoc
+[T-rustdoc]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AT-rustdoc
 [Cargo]: https://github.com/rust-lang/cargo/issues
 [awesome-rust]: https://github.com/kud1ing/awesome-rust
 [ides]: https://forge.rust-lang.org/ides.html

--- a/ja-JP/contribute-tools.md
+++ b/ja-JP/contribute-tools.md
@@ -11,7 +11,7 @@ title: Rustへ貢献する &mdash; ツール、IDE、インフラ &middot; プ�
 さらなる情報へはリンク先へ飛んで下さい。
 
 パッケージマネージャのCargoとドキュメントジェネレータのrustdocは一通り機能を実装していますしきちんと使えますが開発者不足に苦しんでいます。
-Rustdocにはメインレポジトリに[A-rustdoc]ラベルのついたイシューがいくつもあります。
+Rustdocにはメインレポジトリに[T-rustdoc]ラベルのついたイシューがいくつもあります。
 そのほとんどがバグで、貢献するにはバグを直してプルリクエストを送ればよいでしょう。
 Cargoは[自身のレポジトリとイシューを持っており][Cargo]、貢献したいと思っている人は[#cargo]に入ると良いでしょう。
 
@@ -27,7 +27,7 @@ Rustはgdbとlldbの両方のデバッガの下である程度動きますが、
 [#cargo]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
 [#rust-tools]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-tools
 [A-debuginfo]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-debuginfo
-[A-rustdoc]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-rustdoc
+[T-rustdoc]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AT-rustdoc
 [Cargo]: https://github.com/rust-lang/cargo/issues
 [awesome-rust]: https://github.com/kud1ing/awesome-rust
 [ides]: https://forge.rust-lang.org/ides.html

--- a/ko-KR/contribute-tools.md
+++ b/ko-KR/contribute-tools.md
@@ -12,7 +12,7 @@ title: Rust에 기여하기 &mdash; 도구, IDE 및 인프라 &middot; Rust 프�
 
 Rust의 패키지 관리자인 Cargo와 문서 생성기인 rustdoc 둘 다,
 완전한 기능을 제공하고 잘 동작하긴 하지만 개발자들이 부족합니다.
-Rustdoc에는 주 저장소의 [A-rustdoc] 라벨 아래 이슈가 많이 열려 있습니다.
+Rustdoc에는 주 저장소의 [T-rustdoc] 라벨 아래 이슈가 많이 열려 있습니다.
 이 이슈는 대부분 버그이며 기여를 하려면 버그를 고쳐서
 풀 요청(pull request)을 보내는 것으로 충분합니다.
 Cargo는 [별도의 저장소와 이슈][Cargo]를 가지고 있으며,
@@ -31,7 +31,7 @@ Rust를 gdb와 lldb 디버거로 어느 정도까지는 성공적으로 실행�
 [#cargo]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
 [#rust-tools]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-tools
 [A-debuginfo]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-debuginfo
-[A-rustdoc]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-rustdoc
+[T-rustdoc]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AT-rustdoc
 [Cargo]: https://github.com/rust-lang/cargo/issues
 [awesome-rust]: https://github.com/kud1ing/awesome-rust
 [ides]: https://forge.rust-lang.org/ides.html

--- a/pt-BR/contribute-tools.md
+++ b/pt-BR/contribute-tools.md
@@ -13,7 +13,7 @@ no link para mais informações.
 
 Ambos Cargo, o gerenciador de pacotes do Rust, e o rustdoc, o gerador de Documentação
 do Rust, enquanto cheio de funcionalidades e funcional, sofre da falta de desenvolvedores.
-Rustdoc tem muitos problemas em aberto, no repositório principal no rótulo [A-rustdoc].
+Rustdoc tem muitos problemas em aberto, no repositório principal no rótulo [T-rustdoc].
 Eles são, na sua maioria, bugs e contribuir é apenas sanar o problema e mandar uma pull
 request. Cargo tem [seu próprio repositório e seção de problemas][Cargo], e interessados
 em contribuir talvez queiram se introduzir em [#cargo].
@@ -30,7 +30,7 @@ de ferramentas para Rust em [#rust-tools].
 [#cargo]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
 [#rust-tools]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-tools
 [A-debuginfo]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-debuginfo
-[A-rustdoc]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-rustdoc
+[T-rustdoc]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AT-rustdoc
 [Cargo]: https://github.com/rust-lang/cargo/issues
 [awesome-rust]: https://github.com/kud1ing/awesome-rust
 [ides]: https://forge.rust-lang.org/ides.html

--- a/ru-RU/contribute-tools.md
+++ b/ru-RU/contribute-tools.md
@@ -15,7 +15,7 @@ title: Участие в разработке Rust &mdash; IDE, инструме
 Cargo, менеджер пакетов Rust, и rustdoc, генератор документации Rust,
 хоть и реализованы в полной мере, но страдают от нехватки разработчиков. Для
 rustdoc сейчас имеется много открытых задач, которые находятся в 
-в главном репозитории с пометкой [A-rustdoc]. Большинство задач связаны 
+в главном репозитории с пометкой [T-rustdoc]. Большинство задач связаны 
 с багами в коде, и участие в разработке сводится к исправлению этих багов и 
 отправке pull request. У cargo есть [свой репозиторий с задачами][Cargo],
 и тем, кто заинтересовался в разработке, было бы неплохо написать в 
@@ -34,7 +34,7 @@ IRC-канале [#cargo].
 [#cargo]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
 [#rust-tools]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-tools
 [A-debuginfo]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-debuginfo
-[A-rustdoc]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-rustdoc
+[T-rustdoc]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AT-rustdoc
 [Cargo]: https://github.com/rust-lang/cargo/issues
 [awesome-rust]: https://github.com/kud1ing/awesome-rust
 [ides]: https://forge.rust-lang.org/ides.html

--- a/sv-SE/contribute-tools.md
+++ b/sv-SE/contribute-tools.md
@@ -13,7 +13,7 @@ favorit-IDE. Följ länken för mer information.
 
 Både Cargo, Rusts pakethanterare och Rustdoc,
 Rusts dokumentationsgenerator, saknar utvecklare trots att de är funktionella.
-Rustdoc har många öppna problem (issues) märkta med etiketten [A-rustdoc]
+Rustdoc har många öppna problem (issues) märkta med etiketten [T-rustdoc]
 i huvudrepot. De är för det mesta buggar och att bidra handlar om att fixa
 en bugg och att skicka in en pull request. Cargo har
 [sitt egna repo och problem/issues][Cargo]. De som är intresserade av att bidra
@@ -32,7 +32,7 @@ ska dyka upp och implementera dem. Diskutera med andra Rust-verktygsentusiaster 
 [#cargo]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
 [#rust-tools]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-tools
 [A-debuginfo]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-debuginfo
-[A-rustdoc]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-rustdoc
+[T-rustdoc]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AT-rustdoc
 [Cargo]: https://github.com/rust-lang/cargo/issues
 [awesome-rust]: https://github.com/kud1ing/awesome-rust
 [ides]: https://forge.rust-lang.org/ides.html

--- a/vi-VN/contribute-tools.md
+++ b/vi-VN/contribute-tools.md
@@ -14,7 +14,7 @@ favorite IDE. Follow the link for more information.
 Both Cargo, the Rust package manager, and rustdoc,
 the Rust documentation generator, while full-featured and functional,
 suffer from a lack of developers. Rustdoc has many open issues, under
-the main repository's [A-rustdoc] label. They are mostly bugs and
+the main repository's [T-rustdoc] label. They are mostly bugs and
 contributing is a matter of fixing the bug and submitting a pull
 request. Cargo has [its own repository and issues][Cargo], and those
 interested in contributing might want to introduce themselves in
@@ -34,7 +34,7 @@ Rust tooling enthusiasts in [#rust-tools].
 [#cargo]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
 [#rust-tools]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-tools
 [A-debuginfo]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-debuginfo
-[A-rustdoc]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-rustdoc
+[T-rustdoc]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AT-rustdoc
 [Cargo]: https://github.com/rust-lang/cargo/issues
 [awesome-rust]: https://github.com/kud1ing/awesome-rust
 [ides]: https://forge.rust-lang.org/ides.html

--- a/zh-CN/contribute-tools.md
+++ b/zh-CN/contribute-tools.md
@@ -7,7 +7,7 @@ title: 为 Rust 出力 &mdash; 工具、IDE 以及基础设施 &middot; Rust 程
 
 工具在一门语言的成功中扮演着重要的角色，还有许多工作要做。***Rust 开发的主要焦点是 [改进 IDE 的体验][ides]***。这涉及了整个 Rust 语言栈的工作，从编译器本身到你偏好的 IDE。点击链接了解更多信息。
 
-Rust 包管理器 Cargo，Rust 文档生成器 rustdoc，虽然功能齐全且实用，但缺乏开发者。Rustdoc 在主仓库里的 [A-rustdoc] 标签下有许多未决的 issue。它们大多是 bug，问题是需要修复 bug 和提交 PR 的关键是贡献。 Cargo 有 [它自己的仓库和 issue][Cargo]，有兴趣贡献的人可以在 [#cargo] 中介绍自己。
+Rust 包管理器 Cargo，Rust 文档生成器 rustdoc，虽然功能齐全且实用，但缺乏开发者。Rustdoc 在主仓库里的 [T-rustdoc] 标签下有许多未决的 issue。它们大多是 bug，问题是需要修复 bug 和提交 PR 的关键是贡献。 Cargo 有 [它自己的仓库和 issue][Cargo]，有兴趣贡献的人可以在 [#cargo] 中介绍自己。
 
 尽管 Rust 可以在 gdb 和 lldb 调试器下进行一些有限的调试，但是仍然有很多无法正常调试的情况。 [A-debuginfo] 这个 issue 跟踪这些问题。
 
@@ -18,7 +18,7 @@ Rust 包管理器 Cargo，Rust 文档生成器 rustdoc，虽然功能齐全且�
 [#cargo]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
 [#rust-tools]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-tools
 [A-debuginfo]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-debuginfo
-[A-rustdoc]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-rustdoc
+[T-rustdoc]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AT-rustdoc
 [Cargo]: https://github.com/rust-lang/cargo/issues
 [awesome-rust]: https://github.com/kud1ing/awesome-rust
 [ides]: https://forge.rust-lang.org/ides.html


### PR DESCRIPTION
The contribute to rust tools section uses A-rustdoc as the label to search for in github
but the label in github is T-rustdoc. This changes the documentation links to use
T-rustdoc per github label.