### PR TITLE
adding new Montpellier/France Rust Meetup info

### DIFF
--- a/_data/usergroups.yml
+++ b/_data/usergroups.yml
@@ -115,6 +115,10 @@
       city: Paris
       url: https://www.meetup.com/Rust-Paris/
 
+    - name: Rust Montpellier
+      city: Montpellier
+      url: https://www.meetup.com/Montpellier-Rust-Meetup/
+
 - country: Finland
   meetups:
 


### PR DESCRIPTION
There is a new Rust Meetup in France, hosted in Montpellier.

Here are the information related to it.
Is is possible to reference it to the User Groups list on the official website ?

Thanks.
Kind regards

Damien