### PR TITLE
Improve size-optimizing FAQ docs

### DIFF
--- a/en-US/faq.md
+++ b/en-US/faq.md
@@ -1324,9 +1324,15 @@ fn main() {
 
 Two distinct versions of `foo` will be in the final binary, one specialized to an `i32` input, one specialized to a `&str` input. This enables efficient static dispatch of the generic function, but at the cost of a larger binary.
 
+__Release Mode__
+
+By default, building Rust with `cargo build` builds a debug mode binary. Debug builds disable optimizations to allow for greater ease of debugging, but result in substantially larger binary sizes. To decrease binary size, it's imperative to first build in release mode using `cargo build --release`.
+
 __Debug symbols__
 
-Rust programs compile with some debug symbols retained, even when compiling in release mode. These are used for providing backtraces on panics, and can be removed with `strip`, or another debug symbol removal tool. It is also useful to note that compiling in release mode with Cargo is equivalent to setting optimization level 3 with rustc. An alternative optimization level (called `s` or `z`) [has recently landed](https://github.com/rust-lang/rust/pull/32386) and tells the compiler to optimize for size rather than performance.
+Rust programs compile with some debug symbols retained, even when compiling in release mode. These are used for providing backtraces on panics, and can be removed with `strip`, or another debug symbol removal tool.
+
+It is also useful to note that compiling in release mode with Cargo is equivalent to setting optimization level 3 with rustc. An alternative optimization level ([called `s` or `z`](https://doc.rust-lang.org/cargo/reference/manifest.html#the-profile-sections)) [has recently landed](https://github.com/rust-lang/rust/pull/32386) and tells the compiler to optimize for size rather than performance.
 
 __Jemalloc__
 
@@ -1334,7 +1340,7 @@ Rust uses jemalloc as the default allocator, which adds some size to compiled Ru
 
 __Link-time optimization__
 
-Rust does not do link-time optimization by default, but can be instructed to do so. This increases the amount of optimization that the Rust compiler can potentially do, and can have a small effect on binary size. This effect is likely larger in combination with the previously mentioned size optimizing mode.
+Rust does not do link-time optimization by default, but [can be instructed to do so](https://doc.rust-lang.org/cargo/reference/manifest.html#the-profile-sections). This increases the amount of optimization that the Rust compiler can potentially do, and can have a small effect on binary size. This effect is likely larger in combination with the previously mentioned size optimizing mode.
 
 __Standard library__
 

--- a/en-US/faq.md
+++ b/en-US/faq.md
@@ -1336,7 +1336,20 @@ It is also useful to note that compiling in release mode with Cargo is equivalen
 
 __Jemalloc__
 
-Rust uses jemalloc as the default allocator, which adds some size to compiled Rust binaries. Jemalloc is chosen because it is a consistent, quality allocator that has preferable performance characteristics compared to a number of common system-provided allocators. There is work being done to [make it easier to use custom allocators](https://github.com/rust-lang/rust/issues/32838), but that work is not yet finished.
+Rust uses jemalloc as the default allocator, which adds some size to compiled Rust binaries. Jemalloc is chosen because it is a consistent, quality allocator that has preferable performance characteristics compared to a number of common system-provided allocators. To remove jemalloc and instead use the system interpretter, add the following code to `main.rs`:
+
+```rust
+use std::alloc::System;
+
+#[global_allocator]
+static GLOBAL: System = System;
+
+fn main() {
+    let mut v = Vec::new();
+    // This will allocate memory using the system allocator.
+    v.push(1);
+}
+```
 
 __Link-time optimization__
 

--- a/en-US/faq.md
+++ b/en-US/faq.md
@@ -1355,6 +1355,10 @@ __Link-time optimization__
 
 Rust does not do link-time optimization by default, but [can be instructed to do so](https://doc.rust-lang.org/cargo/reference/manifest.html#the-profile-sections). This increases the amount of optimization that the Rust compiler can potentially do, and can have a small effect on binary size. This effect is likely larger in combination with the previously mentioned size optimizing mode.
 
+__Panic Strategy__
+
+By default, Rust supports unwinding when a panic occurs. This provides a helpful traceback, but requires additional generated code to support unwinding. The Rust compiler [can be instructed to abort on panic](https://doc.rust-lang.org/cargo/reference/manifest.html#the-profile-sections), instead, which reduces the size of the compiled binary.
+
 __Standard library__
 
 The Rust standard library includes libbacktrace and libunwind, which may be undesirable in some programs. Using `#![no_std]` can thus result in smaller binaries, but will also usually result in substantial changes to the sort of Rust code you're writing. Note that using Rust without the standard library is often functionally closer to the equivalent C code.


### PR DESCRIPTION
A question that comes up fairly often (for example, [recently on the User Forum](https://users.rust-lang.org/t/why-rust-executable-is-smaller-than-kotlin-native/21210)), is how to reduce Rust binary sizes. This PR attempts organize the FAQ on this section in a way that helps a user actually enable all of these options, as well as update some out-of-date information.