### PR TITLE
Fix shuffle algorithm for friends page

### DIFF
--- a/_includes/friends.js
+++ b/_includes/friends.js
@@ -14,9 +14,8 @@ function swapDiv(e1, e2){
 function shuffle() {
     var friends = document.querySelectorAll(".friend");
     for (var i = 0; i < friends.length; i++) {
-        var r1 = Math.floor(Math.random() * friends.length);
-        var r2 = Math.floor(Math.random() * friends.length);
-        swapDiv(friends[r1], friends[r2]);
+        var r = Math.floor(Math.random() * (i + 1));
+        swapDiv(friends[r], friends[i]);
     }
 }
 


### PR DESCRIPTION
Implement [Fisher-Yates shuffle](https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle) to ensure that each random permutation is equally likely to be produced.

The algorithm "repeatedly pick two random indices i and j between 0 and N-1 and swap element i and j" is a simple, straightforward algorithm, but unfortunately it tends to produce some random orderings more frequently than others. There is an equally simple algorithm by Fischer and Yates that does not have the same problem: "for i = 0 to N-1, pick a random index j between 0 and i and swap element i and j".