### PR TITLE
Replace mibbit links with kiwiirc links

### DIFF
--- a/de-DE/community.md
+++ b/de-DE/community.md
@@ -59,7 +59,7 @@ Das Entwicklerteam von Rust koordiniert sich in [#rust-internals][internals_irc]
 - [#rust-es][es_irc] es para una discusión general sobre Rust en español
 - [#rust-fr][fr_irc] est dédié à la programmation en Rust en français
 - [#rust-ru][ru_irc] для общих дискуссий о Rust на русском языке
-- [#rust-sv](https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-sv) är för allmän diskussion om Rust på svenska
+- [#rust-sv](https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-sv?nick=rustacean??) är för allmän diskussion om Rust på svenska
 - [Rust中文][cn_org] Rust 语言中文 Chat 社区(非IRC频道)
 
 ### Teamkanäle (Englisch)
@@ -102,45 +102,45 @@ Diese Kanäle sind für die weiter Rust-Community und nicht vom [Moderationsteam
 - [#xi][xi_irc] für Diskussionen um Xi, den Texteditior in Rust
 
 [IRC]: https://en.wikipedia.org/wiki/Internet_Relay_Chat
-[beginners_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-beginners
-[bots_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-bots
-[br_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-br
-[cargo_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23cargo
+[beginners_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-beginners?nick=rustacean??
+[bots_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-bots?nick=rustacean??
+[br_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-br?nick=rustacean??
+[cargo_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#cargo?nick=rustacean??
 [cn_org]: https://chat.rust-china.org/
-[community_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-community
-[crypto_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-crypto
-[de_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-de
-[es_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-es
-[embedded_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-embedded
-[fr_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-fr
-[gamedev_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-gamedev
-[internals_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
-[lang_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-lang
-[libs_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-libs
-[networking_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-networking
-[osdev_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-osdev
-[ru_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-ru
-[rust_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust
-[rustc_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
-[servo_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23servo
-[webdev_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-webdev
-[docs_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-docs
-[xi_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23xi
-[dev_tools_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-dev-tools
-[style_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23style
+[community_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-community?nick=rustacean??
+[crypto_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-crypto?nick=rustacean??
+[de_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-de?nick=rustacean??
+[es_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-es?nick=rustacean??
+[embedded_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-embedded?nick=rustacean??
+[fr_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-fr?nick=rustacean??
+[gamedev_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-gamedev?nick=rustacean??
+[internals_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-internals?nick=rustacean??
+[lang_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-lang?nick=rustacean??
+[libs_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-libs?nick=rustacean??
+[networking_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-networking?nick=rustacean??
+[osdev_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-osdev?nick=rustacean??
+[ru_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-ru?nick=rustacean??
+[rust_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust?nick=rustacean??
+[rustc_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rustc?nick=rustacean??
+[servo_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#servo?nick=rustacean??
+[webdev_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-webdev?nick=rustacean??
+[docs_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-docs?nick=rustacean??
+[xi_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#xi?nick=rustacean??
+[dev_tools_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-dev-tools?nick=rustacean??
+[style_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#style?nick=rustacean??
 [style_team]: team.html#Style-team
-[mod_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23mods
-[machine_learning_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-machine-learning
-[hyper_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23hyper
-[iron_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23iron
-[redox_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23redox
-[nom_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23nom
-[infra_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-infra
-[rustgeo_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-geo
-[rocket_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rocket
-[serde_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23serde
-[sci_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-sci
-[wasm_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-wasm
+[mod_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#mods?nick=rustacean??
+[machine_learning_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-machine-learning?nick=rustacean??
+[hyper_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#hyper?nick=rustacean??
+[iron_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#iron?nick=rustacean??
+[redox_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#redox?nick=rustacean??
+[nom_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#nom?nick=rustacean??
+[infra_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-infra?nick=rustacean??
+[rustgeo_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-geo?nick=rustacean??
+[rocket_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rocket?nick=rustacean??
+[serde_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#serde?nick=rustacean??
+[sci_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-sci?nick=rustacean??
+[wasm_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-wasm?nick=rustacean??
 
 
 ## Diskussionsforen

--- a/de-DE/contribute-community.md
+++ b/de-DE/contribute-community.md
@@ -33,8 +33,8 @@ conf talks
 Conduct training on Rust. (link to training material).
 -->
 
-[#rust-beginners]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-beginners
-[#rust-community]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-community
+[#rust-beginners]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-beginners?nick=rustacean??
+[#rust-community]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-community?nick=rustacean??
 [/r/rust]: https://reddit.com/r/rust
 [E-easy]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-easy
 [E-mentor]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-easy+label%3AE-mentor

--- a/de-DE/contribute-compiler.md
+++ b/de-DE/contribute-compiler.md
@@ -26,10 +26,10 @@ TODO: some of this RFC description could probably go in the RFC readme
 -->
 
 
-[#rust-internals]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
-[#rust-lang]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-lang
-[#rust-libs]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-libs
-[#rustc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
+[#rust-internals]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-internals?nick=rustacean??
+[#rust-lang]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-lang?nick=rustacean??
+[#rust-libs]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-libs?nick=rustacean??
+[#rustc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rustc?nick=rustacean??
 [A-codegen]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-codegen
 [A-debuginfo]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-debuginfo
 [A-diagnostics]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-diagnostics

--- a/de-DE/contribute-docs.md
+++ b/de-DE/contribute-docs.md
@@ -19,7 +19,7 @@ Andere Dokumentationsbegeisterte findest du immer in [#rust-docs].
 TODO: blogging, translation
 -->
 
-[#rust-docs]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-docs
+[#rust-docs]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-docs?nick=rustacean??
 [A-book]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-book
 [A-docs]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-docs
 [Rust By Example]: https://github.com/rust-lang/rust-by-example

--- a/de-DE/contribute-libs.md
+++ b/de-DE/contribute-libs.md
@@ -25,7 +25,7 @@ Andere Bibliotheksentwickler triffst du in [#rust-libs].
 TODO: Not sure #rust-libs is the place to direct people
 -->
 
-[#rust-libs]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-libs
+[#rust-libs]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-libs?nick=rustacean??
 [/r/rust]: https://reddit.com/r/rust
 [PistonDevelopers]: https://github.com/PistonDevelopers
 [Servo]: https://github.com/servo/servo

--- a/de-DE/contribute-tools.md
+++ b/de-DE/contribute-tools.md
@@ -33,8 +33,8 @@ die richtigen Leute warten, um implementiert zu werden.
 Diese können mit anderen Tooling-Enthusiasten in
 [#rust-tools] diskutiert werden.
 
-[#cargo]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
-[#rust-tools]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-tools
+[#cargo]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rustc?nick=rustacean??
+[#rust-tools]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-tools?nick=rustacean??
 [A-debuginfo]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-debuginfo
 [T-rustdoc]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AT-rustdoc
 [Cargo]: https://github.com/rust-lang/cargo/issues

--- a/de-DE/contribute.md
+++ b/de-DE/contribute.md
@@ -53,7 +53,7 @@ TODO: Write guide to advertising Rust projects to link from
 libs / community building
 -->
 
-[#rust-internals]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
+[#rust-internals]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-internals?nick=rustacean??
 [CONTRIBUTING.md]: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md
 [bugs]: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md#bug-reports
 [coc]: conduct.html

--- a/de-DE/faq.md
+++ b/de-DE/faq.md
@@ -115,7 +115,7 @@ Wie bekomme ich bei Problemen mit Rust Hilfe?
 Es gibt viele Wege. Du kannst:
 
 - Einen Forenpost im offiziellen Rust User Forum [users.rust-lang.org](https://nsers.rust-lang.org/) absetzen.
-- Im offiziellen [Rust-IRC-Kanal](https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust) (#rust on irc.mozilla.org) eine Frage stellen.
+- Im offiziellen [Rust-IRC-Kanal](https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust?nick=rustacean??) (#rust on irc.mozilla.org) eine Frage stellen.
 - Auf [Stack Overflow](https://stackoverflow.com/questions/tagged/rust) eine Frage stellen (denke daran, sie mit dem „rust“-Tag zu markieren!).
 - Im inoffiziellen Rust-Subreddit [/r/rust](https://www.reddit.com/r/rust) posten.
 

--- a/en-US/community.md
+++ b/en-US/community.md
@@ -81,7 +81,7 @@ to ask questions about contributing to Rust.
 - [#rust-es][es_irc] es para una discusión general sobre Rust en español
 - [#rust-fr][fr_irc] est dédié à la programmation en Rust en français
 - [#rust-ru][ru_irc] для общих дискуссий о Rust на русском языке
-- [#rust-sv](https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-sv) är för allmän diskussion om Rust på svenska
+- [#rust-sv](https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-sv?nick=rustacean??) är för allmän diskussion om Rust på svenska
 - [Rust中文][cn_org] Rust 语言中文 Chat 社区(非IRC频道)
 
 ### Team channels
@@ -123,46 +123,46 @@ These channels are of the wider Rust community, and are not moderated by the [mo
 - [#xi][xi_irc] is for discussion of Xi, the text editor written in Rust
 
 [IRC]: https://en.wikipedia.org/wiki/Internet_Relay_Chat
-[beginners_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-beginners
-[bots_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-bots
-[br_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-br
-[cargo_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23cargo
+[beginners_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-beginners?nick=rustacean??
+[bots_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-bots?nick=rustacean??
+[br_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-br?nick=rustacean??
+[cargo_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#cargo?nick=rustacean??
 [cn_org]: https://chat.rust-china.org/
-[community_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-community
-[crypto_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-crypto
-[de_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-de
-[es_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-es
-[embedded_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-embedded
-[fr_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-fr
-[gamedev_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-gamedev
-[internals_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
-[lang_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-lang
-[libs_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-libs
-[networking_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-networking
-[osdev_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-osdev
-[ru_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-ru
-[rust_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust
-[rustc_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
-[servo_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23servo
-[webdev_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-webdev
-[docs_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-docs
-[xi_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23xi
-[dev_tools_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-dev-tools
-[style_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23style
+[community_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-community?nick=rustacean??
+[crypto_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-crypto?nick=rustacean??
+[de_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-de?nick=rustacean??
+[es_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-es?nick=rustacean??
+[embedded_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-embedded?nick=rustacean??
+[fr_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-fr?nick=rustacean??
+[gamedev_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-gamedev?nick=rustacean??
+[internals_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-internals?nick=rustacean??
+[lang_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-lang?nick=rustacean??
+[libs_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-libs?nick=rustacean??
+[networking_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-networking?nick=rustacean??
+[osdev_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-osdev?nick=rustacean??
+[ru_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-ru?nick=rustacean??
+[rust_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust?nick=rustacean??
+[rustc_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rustc?nick=rustacean??
+[servo_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#servo?nick=rustacean??
+[webdev_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-webdev?nick=rustacean??
+[docs_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-docs?nick=rustacean??
+[xi_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#xi?nick=rustacean??
+[dev_tools_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-dev-tools?nick=rustacean??
+[style_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#style?nick=rustacean??
 [style_team]: team.html#Style-team
-[mod_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23mods
-[machine_learning_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-machine-learning
-[hyper_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23hyper
-[iron_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23iron
-[redox_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23redox
-[nom_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23nom
-[infra_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-infra
-[rustgeo_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-geo
-[rocket_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rocket
-[serde_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23serde
-[sci_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-sci
-[wasm_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-wasm
-[rustdoc_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustdoc
+[mod_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#mods?nick=rustacean??
+[machine_learning_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-machine-learning?nick=rustacean??
+[hyper_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#hyper?nick=rustacean??
+[iron_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#iron?nick=rustacean??
+[redox_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#redox?nick=rustacean??
+[nom_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#nom?nick=rustacean??
+[infra_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-infra?nick=rustacean??
+[rustgeo_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-geo?nick=rustacean??
+[rocket_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rocket?nick=rustacean??
+[serde_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#serde?nick=rustacean??
+[sci_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-sci?nick=rustacean??
+[wasm_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-wasm?nick=rustacean??
+[rustdoc_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rustdoc?nick=rustacean??
 
 ## Discussion Forums
 

--- a/en-US/contribute-community.md
+++ b/en-US/contribute-community.md
@@ -68,8 +68,8 @@ conf talks
 Conduct training on Rust. (link to training material).
 -->
 
-[#rust-beginners]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-beginners
-[#rust-community]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-community
+[#rust-beginners]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-beginners?nick=rustacean??
+[#rust-community]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-community?nick=rustacean??
 [/r/rust]: https://reddit.com/r/rust
 [E-easy]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-easy
 [E-mentor]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-easy+label%3AE-mentor

--- a/en-US/contribute-compiler.md
+++ b/en-US/contribute-compiler.md
@@ -79,10 +79,10 @@ TODO: some of this RFC description could probably go in the RFC readme
 -->
 
 
-[#rust-internals]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
-[#rust-lang]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-lang
-[#rust-libs]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-libs
-[#rustc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
+[#rust-internals]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-internals?nick=rustacean??
+[#rust-lang]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-lang?nick=rustacean??
+[#rust-libs]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-libs?nick=rustacean??
+[#rustc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rustc?nick=rustacean??
 [A-codegen]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-codegen
 [A-debuginfo]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-debuginfo
 [A-diagnostics]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-diagnostics

--- a/en-US/contribute-docs.md
+++ b/en-US/contribute-docs.md
@@ -49,7 +49,7 @@ Meet other Rust documentarians in [#rust-docs].
 TODO: blogging, translation
 -->
 
-[#rust-docs]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-docs
+[#rust-docs]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-docs?nick=rustacean??
 [A-book]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-book
 [A-docs]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-docs
 [Rust By Example]: https://github.com/rust-lang/rust-by-example

--- a/en-US/contribute-libs.md
+++ b/en-US/contribute-libs.md
@@ -45,7 +45,7 @@ Meet other Rust library designers in [#rust-libs].
 TODO: Not sure #rust-libs is the place to direct people
 -->
 
-[#rust-libs]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-libs
+[#rust-libs]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-libs?nick=rustacean??
 [/r/rust]: https://reddit.com/r/rust
 [PistonDevelopers]: https://github.com/PistonDevelopers
 [Servo]: https://github.com/servo/servo

--- a/en-US/contribute-tools.md
+++ b/en-US/contribute-tools.md
@@ -31,8 +31,8 @@ There are often other tooling projects of interest just waiting for
 the right people to come along and implement them. Discuss with other
 Rust tooling enthusiasts in [#rust-tools].
 
-[#cargo]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
-[#rust-tools]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-tools
+[#cargo]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rustc?nick=rustacean??
+[#rust-tools]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-tools?nick=rustacean??
 [A-debuginfo]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-debuginfo
 [T-rustdoc]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AT-rustdoc
 [Cargo]: https://github.com/rust-lang/cargo/issues

--- a/en-US/contribute.md
+++ b/en-US/contribute.md
@@ -53,7 +53,7 @@ TODO: Write guide to advertising Rust projects to link from
 libs / community building
 -->
 
-[#rust-internals]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
+[#rust-internals]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-internals?nick=rustacean??
 [CONTRIBUTING.md]: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md
 [bugs]: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md#bug-reports
 [coc]: https://www.rust-lang.org/conduct.html

--- a/en-US/faq.md
+++ b/en-US/faq.md
@@ -116,7 +116,7 @@ How do I get help with Rust issues?
 There are several ways. You can:
 
 - Post in [users.rust-lang.org](https://users.rust-lang.org/), the official Rust users forum
-- Ask in the official [Rust IRC channel](https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust) (#rust on irc.mozilla.org)
+- Ask in the official [Rust IRC channel](https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust?nick=rustacean??) (#rust on irc.mozilla.org)
 - Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/rust) with the "rust" tag
 - Post in [/r/rust](https://www.reddit.com/r/rust), the unofficial Rust subreddit
 

--- a/es-ES/community.md
+++ b/es-ES/community.md
@@ -85,7 +85,7 @@ adecuado para preguntas sobre como contribuir con Rust.
 - [#rust-de][de_irc] ist für die allgemeine Diskussion über Rust auf Deutsch
 - [#rust-es][es_irc] es para una discusión general sobre Rust en español
 - [#rust-fr][fr_irc] est dédié à la programmation en Rust en français
-- [#rust-sv](https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-sv) är för allmän diskussion om Rust på svenska
+- [#rust-sv](https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-sv?nick=rustacean??) är för allmän diskussion om Rust på svenska
 - [#rust-ru][ru_irc] для общих дискуссий о Rust на русском языке
 
 ### Canales de temas específicos
@@ -101,28 +101,28 @@ adecuado para preguntas sobre como contribuir con Rust.
 - [#servo][servo_irc] es para discutir sobre Servo, el motor de navegador web escrito en Rust
 
 [IRC]: https://en.wikipedia.org/wiki/Internet_Relay_Chat
-[beginners_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-beginners
-[bots_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-bots
-[br_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-br
-[cargo_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23cargo
-[community_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-community
-[crypto_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-crypto
-[de_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-de
-[es_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-es
-[fr_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-fr
-[gamedev_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-gamedev
-[internals_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
-[lang_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-lang
-[libs_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-libs
-[networking_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-networking
-[osdev_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-osdev
-[ru_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-ru
-[rust_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust
-[rustc_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
-[servo_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23servo
-[tools_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-tools
-[webdev_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-webdev
-[docs_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-docs
+[beginners_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-beginners?nick=rustacean??
+[bots_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-bots?nick=rustacean??
+[br_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-br?nick=rustacean??
+[cargo_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#cargo?nick=rustacean??
+[community_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-community?nick=rustacean??
+[crypto_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-crypto?nick=rustacean??
+[de_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-de?nick=rustacean??
+[es_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-es?nick=rustacean??
+[fr_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-fr?nick=rustacean??
+[gamedev_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-gamedev?nick=rustacean??
+[internals_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-internals?nick=rustacean??
+[lang_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-lang?nick=rustacean??
+[libs_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-libs?nick=rustacean??
+[networking_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-networking?nick=rustacean??
+[osdev_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-osdev?nick=rustacean??
+[ru_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-ru?nick=rustacean??
+[rust_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust?nick=rustacean??
+[rustc_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rustc?nick=rustacean??
+[servo_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#servo?nick=rustacean??
+[tools_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-tools?nick=rustacean??
+[webdev_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-webdev?nick=rustacean??
+[docs_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-docs?nick=rustacean??
 
 ## Foros de discusión
 

--- a/es-ES/contribute-community.md
+++ b/es-ES/contribute-community.md
@@ -68,8 +68,8 @@ conf talks
 Conduct training on Rust. (link to training material).
 -->
 
-[#rust-beginners]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-beginners
-[#rust-community]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-community
+[#rust-beginners]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-beginners?nick=rustacean??
+[#rust-community]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-community?nick=rustacean??
 [/r/rust]: https://reddit.com/r/rust
 [E-easy]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-easy
 [E-mentor]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-easy+label%3AE-mentor

--- a/es-ES/contribute-compiler.md
+++ b/es-ES/contribute-compiler.md
@@ -79,10 +79,10 @@ TODO: some of this RFC description could probably go in the RFC readme
 -->
 
 
-[#rust-internals]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
-[#rust-lang]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-lang
-[#rust-libs]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-libs
-[#rustc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
+[#rust-internals]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-internals?nick=rustacean??
+[#rust-lang]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-lang?nick=rustacean??
+[#rust-libs]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-libs?nick=rustacean??
+[#rustc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rustc?nick=rustacean??
 [A-codegen]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-codegen
 [A-debuginfo]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-debuginfo
 [A-diagnostics]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-diagnostics

--- a/es-ES/contribute-docs.md
+++ b/es-ES/contribute-docs.md
@@ -49,7 +49,7 @@ Meet other Rust documentarians in [#rust-docs].
 TODO: blogging, translation
 -->
 
-[#rust-docs]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-docs
+[#rust-docs]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-docs?nick=rustacean??
 [A-book]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-book
 [A-docs]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-docs
 [Rust By Example]: https://github.com/rust-lang/rust-by-example

--- a/es-ES/contribute-libs.md
+++ b/es-ES/contribute-libs.md
@@ -45,7 +45,7 @@ Meet other Rust library designers in [#rust-libs].
 TODO: Not sure #rust-libs is the place to direct people
 -->
 
-[#rust-libs]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-libs
+[#rust-libs]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-libs?nick=rustacean??
 [/r/rust]: https://reddit.com/r/rust
 [PistonDevelopers]: https://github.com/PistonDevelopers
 [Servo]: https://github.com/servo/servo

--- a/es-ES/contribute-tools.md
+++ b/es-ES/contribute-tools.md
@@ -31,8 +31,8 @@ There are often other tooling projects of interest just waiting for
 the right people to come along and implement them. Discuss with other
 Rust tooling enthusiasts in [#rust-tools].
 
-[#cargo]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
-[#rust-tools]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-tools
+[#cargo]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rustc?nick=rustacean??
+[#rust-tools]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-tools?nick=rustacean??
 [A-debuginfo]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-debuginfo
 [T-rustdoc]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AT-rustdoc
 [Cargo]: https://github.com/rust-lang/cargo/issues

--- a/es-ES/contribute.md
+++ b/es-ES/contribute.md
@@ -53,7 +53,7 @@ TODO: Write guide to advertising Rust projects to link from
 libs / community building
 -->
 
-[#rust-internals]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
+[#rust-internals]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-internals?nick=rustacean??
 [CONTRIBUTING.md]: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md
 [bugs]: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md#bug-reports
 [coc]: https://www.rust-lang.org/conduct.html

--- a/es-ES/faq.md
+++ b/es-ES/faq.md
@@ -116,7 +116,7 @@ How do I get help with Rust issues?
 There are several ways. You can:
 
 - Post in [users.rust-lang.org](https://users.rust-lang.org/), the official Rust users forum
-- Ask in the official [Rust IRC channel](https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust) (#rust on irc.mozilla.org)
+- Ask in the official [Rust IRC channel](https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust?nick=rustacean??) (#rust on irc.mozilla.org)
 - Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/rust) with the "rust" tag
 - Post in [/r/rust](https://www.reddit.com/r/rust), the unofficial Rust subreddit
 

--- a/fr-FR/community.md
+++ b/fr-FR/community.md
@@ -64,7 +64,7 @@ Les développeurs de Rust échangent sur [#rust-internals][internals_irc]. Ce ca
 - [#rust-de][de_irc] ist für die allgemeine Diskussion über Rust auf Deutsch
 - [#rust-es][es_irc] es para una discusión general sobre Rust en español
 - [#rust-fr][fr_irc] est dédié à la programmation en Rust en français
-- [#rust-sv](https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-sv) är för allmän diskussion om Rust på svenska
+- [#rust-sv](https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-sv?nick=rustacean??) är för allmän diskussion om Rust på svenska
 - [#rust-ru][ru_irc] для общих дискуссий о Rust на русском языке
 
 ### Les canaux thématiques
@@ -80,28 +80,28 @@ Les développeurs de Rust échangent sur [#rust-internals][internals_irc]. Ce ca
 - [#servo][servo_irc] pour les discussions sur Servo, le moteur de rendu écrit en Rust
 
 [IRC]: https://en.wikipedia.org/wiki/Internet_Relay_Chat
-[beginners_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-beginners
-[bots_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-bots
-[br_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-br
-[cargo_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23cargo
-[community_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-community
-[crypto_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-crypto
-[de_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-de
-[es_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-es
-[fr_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-fr
-[gamedev_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-gamedev
-[internals_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
-[lang_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-lang
-[libs_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-libs
-[networking_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-networking
-[osdev_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-osdev
-[ru_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-ru
-[rust_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust
-[rustc_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
-[servo_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23servo
-[tools_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-tools
-[webdev_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-webdev
-[docs_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-docs
+[beginners_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-beginners?nick=rustacean??
+[bots_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-bots?nick=rustacean??
+[br_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-br?nick=rustacean??
+[cargo_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#cargo?nick=rustacean??
+[community_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-community?nick=rustacean??
+[crypto_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-crypto?nick=rustacean??
+[de_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-de?nick=rustacean??
+[es_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-es?nick=rustacean??
+[fr_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-fr?nick=rustacean??
+[gamedev_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-gamedev?nick=rustacean??
+[internals_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-internals?nick=rustacean??
+[lang_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-lang?nick=rustacean??
+[libs_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-libs?nick=rustacean??
+[networking_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-networking?nick=rustacean??
+[osdev_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-osdev?nick=rustacean??
+[ru_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-ru?nick=rustacean??
+[rust_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust?nick=rustacean??
+[rustc_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rustc?nick=rustacean??
+[servo_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#servo?nick=rustacean??
+[tools_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-tools?nick=rustacean??
+[webdev_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-webdev?nick=rustacean??
+[docs_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-docs?nick=rustacean??
 
 ## Les forums de discussion
 

--- a/fr-FR/contribute-community.md
+++ b/fr-FR/contribute-community.md
@@ -34,8 +34,8 @@ conf talks
 Conduct training on Rust. (link to training material).
 -->
 
-[#rust-beginners]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-beginners
-[#rust-community]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-community
+[#rust-beginners]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-beginners?nick=rustacean??
+[#rust-community]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-community?nick=rustacean??
 [/r/rust]: https://reddit.com/r/rust
 [E-easy]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-easy
 [E-mentor]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-easy+label%3AE-mentor

--- a/fr-FR/contribute-compiler.md
+++ b/fr-FR/contribute-compiler.md
@@ -26,10 +26,10 @@ TODO: some of this RFC description could probably go in the RFC readme
 -->
 
 
-[#rust-internals]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
-[#rust-lang]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-lang
-[#rust-libs]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-libs
-[#rustc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
+[#rust-internals]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-internals?nick=rustacean??
+[#rust-lang]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-lang?nick=rustacean??
+[#rust-libs]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-libs?nick=rustacean??
+[#rustc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rustc?nick=rustacean??
 [A-codegen]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-codegen
 [A-debuginfo]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-debuginfo
 [A-diagnostics]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-diagnostics

--- a/fr-FR/contribute-docs.md
+++ b/fr-FR/contribute-docs.md
@@ -20,7 +20,7 @@ Vous pouvez discuter avec d'autres personnes contribuant à la documentation sur
 TODO: blogging, translation
 -->
 
-[#rust-docs]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-docs
+[#rust-docs]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-docs?nick=rustacean??
 [A-book]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-book
 [A-docs]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-docs
 [Rust By Example]: https://github.com/rust-lang/rust-by-example

--- a/fr-FR/contribute-libs.md
+++ b/fr-FR/contribute-libs.md
@@ -25,7 +25,7 @@ Vous pouvez discuter avec les concepteurs de la bibliothèque Rust sur [#rust-li
 TODO: Not sure #rust-libs is the place to direct people
 -->
 
-[#rust-libs]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-libs
+[#rust-libs]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-libs?nick=rustacean??
 [/r/rust]: https://reddit.com/r/rust
 [PistonDevelopers]: https://github.com/PistonDevelopers
 [Servo]: https://github.com/servo/servo

--- a/fr-FR/contribute-tools.md
+++ b/fr-FR/contribute-tools.md
@@ -15,8 +15,8 @@ Pour découvrir d'autres projets liés aux outils et auxquels contribuer, voir [
 
 De nombreux projets autour d'outils attendent simplement les bonnes personnes pour les implémenter. Vous pouvez discuter avec les autres personnes motivées par l'environnement Rust sur le canal [#rust-tools].
 
-[#cargo]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
-[#rust-tools]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-tools
+[#cargo]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rustc?nick=rustacean??
+[#rust-tools]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-tools?nick=rustacean??
 [A-debuginfo]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-debuginfo
 [T-rustdoc]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AT-rustdoc
 [Cargo]: https://github.com/rust-lang/cargo/issues

--- a/fr-FR/contribute.md
+++ b/fr-FR/contribute.md
@@ -32,7 +32,7 @@ TODO: Write guide to advertising Rust projects to link from
 libs / community building
 -->
 
-[#rust-internals]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
+[#rust-internals]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-internals?nick=rustacean??
 [CONTRIBUTING.md]: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md
 [bugs]: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md#bug-reports
 [coc]: https://www.rust-lang.org/conduct.html

--- a/fr-FR/faq.md
+++ b/fr-FR/faq.md
@@ -116,7 +116,7 @@ How do I get help with Rust issues?
 There are several ways. You can:
 
 - Post in [users.rust-lang.org](https://users.rust-lang.org/), the official Rust users forum
-- Ask in the official [Rust IRC channel](https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust) (#rust on irc.mozilla.org)
+- Ask in the official [Rust IRC channel](https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust?nick=rustacean??) (#rust on irc.mozilla.org)
 - Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/rust) with the "rust" tag
 - Post in [/r/rust](https://www.reddit.com/r/rust), the unofficial Rust subreddit
 

--- a/id-ID/community.md
+++ b/id-ID/community.md
@@ -71,7 +71,7 @@ mengajukan pertanyaan tentang berkontribusi pada Rust.
 - [#rust-es][es_irc] es para una discusión general sobre Rust en español
 - [#rust-fr][fr_irc] est dédié à la programmation en Rust en français
 - [#rust-ru][ru_irc] для общих дискуссий о Rust на русском языке
-- [#rust-sv](https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-sv) är för allmän diskussion om Rust på svenska
+- [#rust-sv](https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-sv?nick=rustacean??) är för allmän diskussion om Rust på svenska
 - [Rust中文][cn_org] Rust 语言中文 Chat 社区(非IRC频道)
 
 ### Saluran Tim
@@ -110,43 +110,43 @@ Saluran ini berasal dari komunitas Rust yang lebih luas, dan tidak dimoderatori 
 - [#xi][xi_irc] untuk diskusi tentang Xi, editor teks yang ditulis dengan Rust
 
 [IRC]: https://en.wikipedia.org/wiki/Internet_Relay_Chat
-[beginners_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-beginners
-[bots_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-bots
-[br_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-br
-[cargo_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23cargo
+[beginners_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-beginners?nick=rustacean??
+[bots_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-bots?nick=rustacean??
+[br_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-br?nick=rustacean??
+[cargo_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#cargo?nick=rustacean??
 [cn_org]: https://chat.rust-china.org/
-[community_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-community
-[crypto_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-crypto
-[de_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-de
-[es_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-es
-[embedded_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-embedded
-[fr_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-fr
-[gamedev_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-gamedev
-[internals_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
-[lang_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-lang
-[libs_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-libs
-[networking_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-networking
-[osdev_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-osdev
-[ru_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-ru
-[rust_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust
-[rustc_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
-[servo_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23servo
-[webdev_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-webdev
-[docs_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-docs
-[xi_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23xi
-[dev_tools_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-dev-tools
-[style_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23style
+[community_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-community?nick=rustacean??
+[crypto_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-crypto?nick=rustacean??
+[de_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-de?nick=rustacean??
+[es_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-es?nick=rustacean??
+[embedded_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-embedded?nick=rustacean??
+[fr_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-fr?nick=rustacean??
+[gamedev_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-gamedev?nick=rustacean??
+[internals_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-internals?nick=rustacean??
+[lang_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-lang?nick=rustacean??
+[libs_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-libs?nick=rustacean??
+[networking_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-networking?nick=rustacean??
+[osdev_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-osdev?nick=rustacean??
+[ru_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-ru?nick=rustacean??
+[rust_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust?nick=rustacean??
+[rustc_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rustc?nick=rustacean??
+[servo_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#servo?nick=rustacean??
+[webdev_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-webdev?nick=rustacean??
+[docs_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-docs?nick=rustacean??
+[xi_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#xi?nick=rustacean??
+[dev_tools_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-dev-tools?nick=rustacean??
+[style_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#style?nick=rustacean??
 [style_team]: team.html#Style-team
-[mod_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23mods
-[machine_learning_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-machine-learning
-[hyper_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23hyper
-[iron_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23iron
-[redox_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23redox
-[nom_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23nom
-[infra_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-infra
-[rustgeo_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-geo
-[rocket_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rocket
-[serde_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23serde
+[mod_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#mods?nick=rustacean??
+[machine_learning_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-machine-learning?nick=rustacean??
+[hyper_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#hyper?nick=rustacean??
+[iron_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#iron?nick=rustacean??
+[redox_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#redox?nick=rustacean??
+[nom_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#nom?nick=rustacean??
+[infra_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-infra?nick=rustacean??
+[rustgeo_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-geo?nick=rustacean??
+[rocket_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rocket?nick=rustacean??
+[serde_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#serde?nick=rustacean??
 
 ## Forum Diskusi
 

--- a/id-ID/contribute-community.md
+++ b/id-ID/contribute-community.md
@@ -68,8 +68,8 @@ conf talks
 Conduct training on Rust. (link to training material).
 -->
 
-[#rust-beginners]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-beginners
-[#rust-community]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-community
+[#rust-beginners]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-beginners?nick=rustacean??
+[#rust-community]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-community?nick=rustacean??
 [/r/rust]: https://reddit.com/r/rust
 [E-easy]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-easy
 [E-mentor]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-easy+label%3AE-mentor

--- a/id-ID/contribute-compiler.md
+++ b/id-ID/contribute-compiler.md
@@ -79,10 +79,10 @@ TODO: some of this RFC description could probably go in the RFC readme
 -->
 
 
-[#rust-internals]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
-[#rust-lang]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-lang
-[#rust-libs]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-libs
-[#rustc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
+[#rust-internals]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-internals?nick=rustacean??
+[#rust-lang]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-lang?nick=rustacean??
+[#rust-libs]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-libs?nick=rustacean??
+[#rustc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rustc?nick=rustacean??
 [A-codegen]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-codegen
 [A-debuginfo]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-debuginfo
 [A-diagnostics]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-diagnostics

--- a/id-ID/contribute-docs.md
+++ b/id-ID/contribute-docs.md
@@ -49,7 +49,7 @@ Meet other Rust documentarians in [#rust-docs].
 TODO: blogging, translation
 -->
 
-[#rust-docs]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-docs
+[#rust-docs]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-docs?nick=rustacean??
 [A-book]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-book
 [A-docs]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-docs
 [Rust By Example]: https://github.com/rust-lang/rust-by-example

--- a/id-ID/contribute-libs.md
+++ b/id-ID/contribute-libs.md
@@ -45,7 +45,7 @@ Meet other Rust library designers in [#rust-libs].
 TODO: Not sure #rust-libs is the place to direct people
 -->
 
-[#rust-libs]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-libs
+[#rust-libs]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-libs?nick=rustacean??
 [/r/rust]: https://reddit.com/r/rust
 [PistonDevelopers]: https://github.com/PistonDevelopers
 [Servo]: https://github.com/servo/servo

--- a/id-ID/contribute-tools.md
+++ b/id-ID/contribute-tools.md
@@ -31,8 +31,8 @@ There are often other tooling projects of interest just waiting for
 the right people to come along and implement them. Discuss with other
 Rust tooling enthusiasts in [#rust-tools].
 
-[#cargo]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
-[#rust-tools]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-tools
+[#cargo]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rustc?nick=rustacean??
+[#rust-tools]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-tools?nick=rustacean??
 [A-debuginfo]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-debuginfo
 [T-rustdoc]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AT-rustdoc
 [Cargo]: https://github.com/rust-lang/cargo/issues

--- a/id-ID/contribute.md
+++ b/id-ID/contribute.md
@@ -46,7 +46,7 @@ TODO: Write guide to advertising Rust projects to link from
 libs / community building
 -->
 
-[#rust-internals]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
+[#rust-internals]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-internals?nick=rustacean??
 [CONTRIBUTING.md]: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md
 [bugs]: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md#bug-reports
 [coc]: https://www.rust-lang.org/conduct.html

--- a/id-ID/faq.md
+++ b/id-ID/faq.md
@@ -116,7 +116,7 @@ How do I get help with Rust issues?
 There are several ways. You can:
 
 - Post in [users.rust-lang.org](https://users.rust-lang.org/), the official Rust users forum
-- Ask in the official [Rust IRC channel](https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust) (#rust on irc.mozilla.org)
+- Ask in the official [Rust IRC channel](https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust?nick=rustacean??) (#rust on irc.mozilla.org)
 - Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/rust) with the "rust" tag
 - Post in [/r/rust](https://www.reddit.com/r/rust), the unofficial Rust subreddit
 

--- a/it-IT/community.md
+++ b/it-IT/community.md
@@ -85,7 +85,7 @@ Gli sviluppatori di Rust si organizzano su [#rust-internals][internals_irc]. Ded
 - [#rust-es][es_irc] es para una discusión general sobre Rust en español
 - [#rust-fr][fr_irc] est dédié à la programmation en Rust en français
 - [#rust-ru][ru_irc] для общих дискуссий о Rust на русском языке
-- [#rust-sv](https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-sv) är för allmän diskussion om Rust på svenska
+- [#rust-sv](https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-sv?nick=rustacean??) är för allmän diskussion om Rust på svenska
 
 ### Canali specifici
 
@@ -100,28 +100,28 @@ Gli sviluppatori di Rust si organizzano su [#rust-internals][internals_irc]. Ded
 - [#servo][servo_irc] il canale di Servo, il motore di navigazione scritto in Rust
 
 [IRC]: https://en.wikipedia.org/wiki/Internet_Relay_Chat
-[beginners_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-beginners
-[bots_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-bots
-[br_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-br
-[cargo_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23cargo
-[community_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-community
-[crypto_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-crypto
-[de_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-de
-[es_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-es
-[fr_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-fr
-[gamedev_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-gamedev
-[internals_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
-[lang_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-lang
-[libs_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-libs
-[networking_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-networking
-[osdev_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-osdev
-[ru_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-ru
-[rust_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust
-[rustc_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
-[servo_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23servo
-[tools_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-tools
-[webdev_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-webdev
-[docs_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-docs
+[beginners_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-beginners?nick=rustacean??
+[bots_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-bots?nick=rustacean??
+[br_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-br?nick=rustacean??
+[cargo_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#cargo?nick=rustacean??
+[community_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-community?nick=rustacean??
+[crypto_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-crypto?nick=rustacean??
+[de_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-de?nick=rustacean??
+[es_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-es?nick=rustacean??
+[fr_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-fr?nick=rustacean??
+[gamedev_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-gamedev?nick=rustacean??
+[internals_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-internals?nick=rustacean??
+[lang_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-lang?nick=rustacean??
+[libs_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-libs?nick=rustacean??
+[networking_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-networking?nick=rustacean??
+[osdev_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-osdev?nick=rustacean??
+[ru_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-ru?nick=rustacean??
+[rust_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust?nick=rustacean??
+[rustc_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rustc?nick=rustacean??
+[servo_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#servo?nick=rustacean??
+[tools_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-tools?nick=rustacean??
+[webdev_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-webdev?nick=rustacean??
+[docs_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-docs?nick=rustacean??
 
 ## Forum di discussione
 

--- a/it-IT/contribute-community.md
+++ b/it-IT/contribute-community.md
@@ -72,8 +72,8 @@ conf talks
 Conduct training on Rust. (link to training material).
 -->
 
-[#rust-beginners]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-beginners
-[#rust-community]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-community
+[#rust-beginners]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-beginners?nick=rustacean??
+[#rust-community]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-community?nick=rustacean??
 [/r/rust]: https://reddit.com/r/rust
 [E-easy]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-easy
 [E-mentor]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-easy+label%3AE-mentor

--- a/it-IT/contribute-compiler.md
+++ b/it-IT/contribute-compiler.md
@@ -82,10 +82,10 @@ TODO: some of this RFC description could probably go in the RFC readme
 -->
 
 
-[#rust-internals]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
-[#rust-lang]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-lang
-[#rust-libs]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-libs
-[#rustc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
+[#rust-internals]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-internals?nick=rustacean??
+[#rust-lang]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-lang?nick=rustacean??
+[#rust-libs]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-libs?nick=rustacean??
+[#rustc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rustc?nick=rustacean??
 [A-codegen]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-codegen
 [A-debuginfo]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-debuginfo
 [A-diagnostics]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-diagnostics

--- a/it-IT/contribute-docs.md
+++ b/it-IT/contribute-docs.md
@@ -51,7 +51,7 @@ Incontra altri documentatori su [#rust-docs].
 TODO: blogging, translation
 -->
 
-[#rust-docs]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-docs
+[#rust-docs]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-docs?nick=rustacean??
 [A-book]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-book
 [A-docs]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-docs
 [Rust By Example]: https://github.com/rust-lang/rust-by-example

--- a/it-IT/contribute-libs.md
+++ b/it-IT/contribute-libs.md
@@ -41,7 +41,7 @@ Incontrati con gli altri progettisti di librerie su [#rust-libs].
 TODO: Not sure #rust-libs is the place to direct people
 -->
 
-[#rust-libs]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-libs
+[#rust-libs]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-libs?nick=rustacean??
 [/r/rust]: https://reddit.com/r/rust
 [PistonDevelopers]: https://github.com/PistonDevelopers
 [Servo]: https://github.com/servo/servo

--- a/it-IT/contribute-tools.md
+++ b/it-IT/contribute-tools.md
@@ -39,8 +39,8 @@ giusto di persone che possano venire ad implementarli.
 Vieni a discuterne con gli altri appassionati di questo aspetto di
 Rust su [#rust-tools].
 
-[#cargo]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
-[#rust-tools]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-tools
+[#cargo]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rustc?nick=rustacean??
+[#rust-tools]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-tools?nick=rustacean??
 [A-debuginfo]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-debuginfo
 [T-rustdoc]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AT-rustdoc
 [Cargo]: https://github.com/rust-lang/cargo/issues

--- a/it-IT/contribute.md
+++ b/it-IT/contribute.md
@@ -50,7 +50,7 @@ TODO: Write guide to advertising Rust projects to link from
 libs / community building
 -->
 
-[#rust-internals]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
+[#rust-internals]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-internals?nick=rustacean??
 [CONTRIBUTING.md]: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md
 [bugs]: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md#bug-reports
 [coc]: https://www.rust-lang.org/it-IT/conduct.html

--- a/it-IT/faq.md
+++ b/it-IT/faq.md
@@ -122,7 +122,7 @@ Come posso ricevere aiuto con Rust?
 Ci sono diversi modi. Puoi:
 
 - Scrivere su [users.rust-lang.org](https://users.rust-lang.org/), il forum ufficiale di Rust
-- Chiedere sul [canale IRC ufficiale di Rust](https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust) (#rust on irc.mozilla.org)
+- Chiedere sul [canale IRC ufficiale di Rust](https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust?nick=rustacean??) (#rust on irc.mozilla.org)
 - Chiedere su [Stack Overflow](https://stackoverflow.com/questions/tagged/rust) with the "rust" tag
 - Scrivere su [/r/rust](https://www.reddit.com/r/rust), il subreddit non ufficiale di Rust
 

--- a/ja-JP/community.md
+++ b/ja-JP/community.md
@@ -71,7 +71,7 @@ Rust自体の開発についてリアルタイムで議論するための場で�
 - [#rust-es][es_irc] es para una discusión general sobre Rust en español
 - [#rust-fr][fr_irc] est dédié à la programmation en Rust en français
 - [#rust-ru][ru_irc] для общих дискуссий о Rust на русском языке
-- [#rust-sv](https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-sv) är för allmän diskussion om Rust på svenska
+- [#rust-sv](https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-sv?nick=rustacean??) är för allmän diskussion om Rust på svenska
 
 ### トピック別チャネル
 
@@ -87,29 +87,29 @@ Rust自体の開発についてリアルタイムで議論するための場で�
 - [#servo][servo_irc] Rustで書かれたブラウザエンジンServoの議論をするために
 
 [IRC]: https://en.wikipedia.org/wiki/Internet_Relay_Chat
-[beginners_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-beginners
-[bots_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-bots
-[br_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-br
-[cargo_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23cargo
-[community_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-community
-[crypto_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-crypto
-[de_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-de
-[es_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-es
-[embedded_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-embedded
-[fr_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-fr
-[gamedev_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-gamedev
-[internals_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
-[lang_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-lang
-[libs_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-libs
-[networking_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-networking
-[osdev_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-osdev
-[ru_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-ru
-[rust_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust
-[rustc_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
-[servo_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23servo
-[tools_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-tools
-[webdev_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-webdev
-[docs_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-docs
+[beginners_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-beginners?nick=rustacean??
+[bots_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-bots?nick=rustacean??
+[br_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-br?nick=rustacean??
+[cargo_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#cargo?nick=rustacean??
+[community_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-community?nick=rustacean??
+[crypto_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-crypto?nick=rustacean??
+[de_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-de?nick=rustacean??
+[es_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-es?nick=rustacean??
+[embedded_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-embedded?nick=rustacean??
+[fr_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-fr?nick=rustacean??
+[gamedev_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-gamedev?nick=rustacean??
+[internals_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-internals?nick=rustacean??
+[lang_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-lang?nick=rustacean??
+[libs_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-libs?nick=rustacean??
+[networking_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-networking?nick=rustacean??
+[osdev_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-osdev?nick=rustacean??
+[ru_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-ru?nick=rustacean??
+[rust_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust?nick=rustacean??
+[rustc_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rustc?nick=rustacean??
+[servo_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#servo?nick=rustacean??
+[tools_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-tools?nick=rustacean??
+[webdev_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-webdev?nick=rustacean??
+[docs_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-docs?nick=rustacean??
 
 ## ディスカッションフォーラム
 

--- a/ja-JP/contribute-community.md
+++ b/ja-JP/contribute-community.md
@@ -50,8 +50,8 @@ conf talks
 Conduct training on Rust. (link to training material).
 -->
 
-[#rust-beginners]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-beginners
-[#rust-community]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-community
+[#rust-beginners]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-beginners?nick=rustacean??
+[#rust-community]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-community?nick=rustacean??
 [/r/rust]: https://reddit.com/r/rust
 [E-easy]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-easy
 [E-mentor]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-easy+label%3AE-mentor

--- a/ja-JP/contribute-compiler.md
+++ b/ja-JP/contribute-compiler.md
@@ -48,10 +48,10 @@ TODO: some of this RFC description could probably go in the RFC readme
 -->
 
 
-[#rust-internals]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
-[#rust-lang]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-lang
-[#rust-libs]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-libs
-[#rustc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
+[#rust-internals]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-internals?nick=rustacean??
+[#rust-lang]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-lang?nick=rustacean??
+[#rust-libs]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-libs?nick=rustacean??
+[#rustc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rustc?nick=rustacean??
 [A-codegen]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-codegen
 [A-debuginfo]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-debuginfo
 [A-diagnostics]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-diagnostics

--- a/ja-JP/contribute-docs.md
+++ b/ja-JP/contribute-docs.md
@@ -36,7 +36,7 @@ Rustの重要なドキュメントのうち、かなりの量がメインレポ�
 TODO: blogging, translation
 -->
 
-[#rust-docs]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-docs
+[#rust-docs]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-docs?nick=rustacean??
 [A-book]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-book
 [A-docs]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-docs
 [Rust By Example]: https://github.com/rust-lang/rust-by-example

--- a/ja-JP/contribute-libs.md
+++ b/ja-JP/contribute-libs.md
@@ -27,7 +27,7 @@ Rustライブラリの設計者に[#rust-libs]で会いましょう。
 TODO: Not sure #rust-libs is the place to direct people
 -->
 
-[#rust-libs]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-libs
+[#rust-libs]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-libs?nick=rustacean??
 [/r/rust]: https://reddit.com/r/rust
 [PistonDevelopers]: https://github.com/PistonDevelopers
 [Servo]: https://github.com/servo/servo

--- a/ja-JP/contribute-tools.md
+++ b/ja-JP/contribute-tools.md
@@ -24,8 +24,8 @@ Rustはgdbとlldbの両方のデバッガの下である程度動きますが、
 他のツール好きの人と[#rust-tools]で議論しましょう。
 
 
-[#cargo]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
-[#rust-tools]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-tools
+[#cargo]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rustc?nick=rustacean??
+[#rust-tools]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-tools?nick=rustacean??
 [A-debuginfo]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-debuginfo
 [T-rustdoc]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AT-rustdoc
 [Cargo]: https://github.com/rust-lang/cargo/issues

--- a/ja-JP/contribute.md
+++ b/ja-JP/contribute.md
@@ -36,7 +36,7 @@ Rustの成功へと貢献する方法はいくつもあります。
 私たちは良識ある論議を維持していることにプライドを持っており、そのためにコントリビュータは[行動規範][coc]に従うことが期待されています。
 これについて質問があれば、[コミュニティチーム][community team]に問い合わせてみてください。
 
-[#rust-internals]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
+[#rust-internals]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-internals?nick=rustacean??
 [CONTRIBUTING.md]: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md
 [bugs]: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md#bug-reports
 [coc]: https://www.rust-lang.org/conduct.html

--- a/ja-JP/faq.md
+++ b/ja-JP/faq.md
@@ -124,7 +124,7 @@ Rustで問題に遭遇したときにどうやって助けを求められます�
 いくつか方法があります。
 
 - 公式のユーザフォーラムの[users.rust-lang.org](https://users.rust-lang.org/)に投稿する
-- 公式の[Rust IRC チャネル](https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust)(#rust on irc.mozilla.org)で質問する
+- 公式の[Rust IRC チャネル](https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust?nick=rustacean??)(#rust on irc.mozilla.org)で質問する
 - 「rust」タグを付けて[Stack Overflow](https://stackoverflow.com/questions/tagged/rust)で質問する
 - 非公式のRustのサブredditの[/r/rust](https://www.reddit.com/r/rust)に投稿する
 

--- a/ko-KR/community.md
+++ b/ko-KR/community.md
@@ -68,7 +68,7 @@ Rust에 기여하는 데 대한 질문을 하는 데도 쓰입니다.
 - [#rust-es][es_irc] es para una discusión general sobre Rust en español
 - [#rust-fr][fr_irc] est dédié à la programmation en Rust en français
 - [#rust-ru][ru_irc] для общих дискуссий о Rust на русском языке
-- [#rust-sv](https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-sv) är för allmän diskussion om Rust på svenska
+- [#rust-sv](https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-sv?nick=rustacean??) är för allmän diskussion om Rust på svenska
 - [Rust中文][cn_org] Rust 语言中文 Chat 社区(非IRC频道)
 
 ### 팀 채널
@@ -107,44 +107,44 @@ Rust에 기여하는 데 대한 질문을 하는 데도 쓰입니다.
 - [#xi][xi_irc]는 Rust로 작성된 텍스트 편집기인 Xi를 다룹니다.
 
 [IRC]: https://en.wikipedia.org/wiki/Internet_Relay_Chat
-[beginners_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-beginners
-[bots_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-bots
-[br_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-br
-[cargo_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23cargo
+[beginners_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-beginners?nick=rustacean??
+[bots_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-bots?nick=rustacean??
+[br_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-br?nick=rustacean??
+[cargo_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#cargo?nick=rustacean??
 [cn_org]: https://chat.rust-china.org/
-[community_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-community
-[crypto_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-crypto
-[de_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-de
-[es_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-es
-[embedded_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-embedded
-[fr_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-fr
-[gamedev_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-gamedev
-[internals_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
-[lang_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-lang
-[libs_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-libs
-[networking_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-networking
-[osdev_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-osdev
-[ru_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-ru
-[rust_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust
-[rustc_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
-[servo_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23servo
-[tools_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-tools
-[webdev_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-webdev
-[docs_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-docs
-[xi_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23xi
-[dev_tools_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-dev-tools
-[style_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23style
+[community_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-community?nick=rustacean??
+[crypto_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-crypto?nick=rustacean??
+[de_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-de?nick=rustacean??
+[es_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-es?nick=rustacean??
+[embedded_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-embedded?nick=rustacean??
+[fr_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-fr?nick=rustacean??
+[gamedev_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-gamedev?nick=rustacean??
+[internals_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-internals?nick=rustacean??
+[lang_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-lang?nick=rustacean??
+[libs_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-libs?nick=rustacean??
+[networking_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-networking?nick=rustacean??
+[osdev_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-osdev?nick=rustacean??
+[ru_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-ru?nick=rustacean??
+[rust_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust?nick=rustacean??
+[rustc_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rustc?nick=rustacean??
+[servo_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#servo?nick=rustacean??
+[tools_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-tools?nick=rustacean??
+[webdev_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-webdev?nick=rustacean??
+[docs_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-docs?nick=rustacean??
+[xi_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#xi?nick=rustacean??
+[dev_tools_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-dev-tools?nick=rustacean??
+[style_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#style?nick=rustacean??
 [style_team]: team.html#Style-team
-[mod_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23mods
-[machine_learning_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-machine-learning
-[hyper_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23hyper
-[iron_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23iron
-[redox_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23redox
-[nom_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23nom
-[infra_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-infra
-[rustgeo_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-geo
-[rocket_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rocket
-[serde_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23serde
+[mod_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#mods?nick=rustacean??
+[machine_learning_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-machine-learning?nick=rustacean??
+[hyper_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#hyper?nick=rustacean??
+[iron_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#iron?nick=rustacean??
+[redox_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#redox?nick=rustacean??
+[nom_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#nom?nick=rustacean??
+[infra_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-infra?nick=rustacean??
+[rustgeo_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-geo?nick=rustacean??
+[rocket_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rocket?nick=rustacean??
+[serde_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#serde?nick=rustacean??
 
 ## 포럼
 

--- a/ko-KR/contribute-community.md
+++ b/ko-KR/contribute-community.md
@@ -65,8 +65,8 @@ conf talks
 Conduct training on Rust. (link to training material).
 -->
 
-[#rust-beginners]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-beginners
-[#rust-community]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-community
+[#rust-beginners]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-beginners?nick=rustacean??
+[#rust-community]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-community?nick=rustacean??
 [/r/rust]: https://reddit.com/r/rust
 [E-easy]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-easy
 [E-mentor]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-easy+label%3AE-mentor

--- a/ko-KR/contribute-compiler.md
+++ b/ko-KR/contribute-compiler.md
@@ -75,10 +75,10 @@ TODO: some of this RFC description could probably go in the RFC readme
 -->
 
 
-[#rust-internals]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
-[#rust-lang]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-lang
-[#rust-libs]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-libs
-[#rustc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
+[#rust-internals]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-internals?nick=rustacean??
+[#rust-lang]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-lang?nick=rustacean??
+[#rust-libs]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-libs?nick=rustacean??
+[#rustc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rustc?nick=rustacean??
 [A-codegen]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-codegen
 [A-debuginfo]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-debuginfo
 [A-diagnostics]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-diagnostics

--- a/ko-KR/contribute-docs.md
+++ b/ko-KR/contribute-docs.md
@@ -48,7 +48,7 @@ Rust 생태계를 이루는 크레이트의 문서입니다***.
 TODO: blogging, translation
 -->
 
-[#rust-docs]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-docs
+[#rust-docs]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-docs?nick=rustacean??
 [A-book]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-book
 [A-docs]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-docs
 [Rust By Example]: https://github.com/rust-lang/rust-by-example

--- a/ko-KR/contribute-libs.md
+++ b/ko-KR/contribute-libs.md
@@ -40,7 +40,7 @@ Rust는 어린 언어이므로, 아직 존재하지 않거나 불완전하여 �
 TODO: Not sure #rust-libs is the place to direct people
 -->
 
-[#rust-libs]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-libs
+[#rust-libs]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-libs?nick=rustacean??
 [/r/rust]: https://reddit.com/r/rust
 [PistonDevelopers]: https://github.com/PistonDevelopers
 [Servo]: https://github.com/servo/servo

--- a/ko-KR/contribute-tools.md
+++ b/ko-KR/contribute-tools.md
@@ -28,8 +28,8 @@ Rust를 gdb와 lldb 디버거로 어느 정도까지는 성공적으로 실행�
 올바른 사람들이 찾아 와서 구현될 때까지 기다리고 있기도 합니다.
 [#rust-tools]에서 도구에 관심이 있는 다른 분들과 상의해 보세요.
 
-[#cargo]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
-[#rust-tools]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-tools
+[#cargo]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rustc?nick=rustacean??
+[#rust-tools]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-tools?nick=rustacean??
 [A-debuginfo]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-debuginfo
 [T-rustdoc]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AT-rustdoc
 [Cargo]: https://github.com/rust-lang/cargo/issues

--- a/ko-KR/contribute.md
+++ b/ko-KR/contribute.md
@@ -45,7 +45,7 @@ TODO: Write guide to advertising Rust projects to link from
 libs / community building
 -->
 
-[#rust-internals]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
+[#rust-internals]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-internals?nick=rustacean??
 [CONTRIBUTING.md]: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md
 [bugs]: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md#bug-reports
 [coc]: https://www.rust-lang.org/conduct.html

--- a/ko-KR/faq.md
+++ b/ko-KR/faq.md
@@ -123,7 +123,7 @@ Rust 문제들에 도움을 받으려면 어떻게 해야 하나요?
 여러 방법이 있습니다:
 
 - 공식 Rust 사용자 포럼인 [users.rust-lang.org](https://users.rust-lang.org/)에 글을 올려 보세요.
-- 공식 [Rust IRC 채널](https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust)(#rust on irc.mozilla.org)에서 질문해 보세요.
+- 공식 [Rust IRC 채널](https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust?nick=rustacean??)(#rust on irc.mozilla.org)에서 질문해 보세요.
 - [Stack Overflow](https://stackoverflow.com/questions/tagged/rust)에 "rust" 태그를 붙이고 질문해 보세요.
 - 비공식 Rust 서브레딧인 [/r/rust](https://www.reddit.com/r/rust)에 글을 올려 보세요.
 

--- a/pl-PL/community.md
+++ b/pl-PL/community.md
@@ -85,7 +85,7 @@ Służy także do zadawania pytań o sposoby zaangażowania się w rozwój Rusta
 - [#rust-es][es_irc] es para una discusión general sobre Rust en español
 - [#rust-fr][fr_irc] est dédié à la programmation en Rust en français
 - [#rust-ru][ru_irc] для общих дискуссий о Rust на русском языке
-- [#rust-sv](https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-sv) är för allmän diskussion om Rust på svenska
+- [#rust-sv](https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-sv?nick=rustacean??) är för allmän diskussion om Rust på svenska
 
 ### Kanały tematyczne
 
@@ -100,28 +100,28 @@ Służy także do zadawania pytań o sposoby zaangażowania się w rozwój Rusta
 - [#servo][servo_irc] jest dla dyskusji o Servo, silniku przeglądarki napisanym w Ruście
 
 [IRC]: https://en.wikipedia.org/wiki/Internet_Relay_Chat
-[beginners_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-beginners
-[bots_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-bots
-[br_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-br
-[cargo_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23cargo
-[community_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-community
-[crypto_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-crypto
-[de_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-de
-[es_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-es
-[fr_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-fr
-[gamedev_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-gamedev
-[internals_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
-[lang_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-lang
-[libs_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-libs
-[networking_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-networking
-[osdev_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-osdev
-[ru_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-ru
-[rust_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust
-[rustc_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
-[servo_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23servo
-[tools_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-tools
-[webdev_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-webdev
-[docs_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-docs
+[beginners_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-beginners?nick=rustacean??
+[bots_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-bots?nick=rustacean??
+[br_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-br?nick=rustacean??
+[cargo_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#cargo?nick=rustacean??
+[community_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-community?nick=rustacean??
+[crypto_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-crypto?nick=rustacean??
+[de_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-de?nick=rustacean??
+[es_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-es?nick=rustacean??
+[fr_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-fr?nick=rustacean??
+[gamedev_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-gamedev?nick=rustacean??
+[internals_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-internals?nick=rustacean??
+[lang_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-lang?nick=rustacean??
+[libs_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-libs?nick=rustacean??
+[networking_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-networking?nick=rustacean??
+[osdev_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-osdev?nick=rustacean??
+[ru_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-ru?nick=rustacean??
+[rust_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust?nick=rustacean??
+[rustc_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rustc?nick=rustacean??
+[servo_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#servo?nick=rustacean??
+[tools_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-tools?nick=rustacean??
+[webdev_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-webdev?nick=rustacean??
+[docs_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-docs?nick=rustacean??
 
 ## Fora Dyskusyjne
 

--- a/pl-PL/contribute.md
+++ b/pl-PL/contribute.md
@@ -50,7 +50,7 @@ TODO: Write guide to advertising Rust projects to link from
 libs / community building
 -->
 
-[#rust-internals]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
+[#rust-internals]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-internals?nick=rustacean??
 [CONTRIBUTING.md]: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md
 [bugs]: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md#bug-reports
 [community team]: /en-US/team.html#Community

--- a/pt-BR/community.md
+++ b/pt-BR/community.md
@@ -78,7 +78,7 @@ perguntar questões sobre contribuir para o Rust.
 - [#rust-es][es_irc] es para una discusión general sobre Rust en español
 - [#rust-fr][fr_irc] est dédié à la programmation en Rust en français
 - [#rust-ru][ru_irc] для общих дискуссий о Rust на русском языке
-- [#rust-sv](https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-sv) är för allmän diskussion om Rust på svenska
+- [#rust-sv](https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-sv?nick=rustacean??) är för allmän diskussion om Rust på svenska
 - [Rust中文][cn_org] Rust 语言中文 Chat 社区(非IRC频道)
 
 ### Canais dos times
@@ -118,44 +118,44 @@ Esses canais são da ampla comunidade Rust e não são moderados pelo [time de m
 - [#xi][xi_irc] é para discussão sobre Xi, um editor de texto escrito em Rust
 
 [IRC]: https://en.wikipedia.org/wiki/Internet_Relay_Chat
-[beginners_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-beginners
-[bots_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-bots
-[br_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-br
-[cargo_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23cargo
+[beginners_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-beginners?nick=rustacean??
+[bots_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-bots?nick=rustacean??
+[br_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-br?nick=rustacean??
+[cargo_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#cargo?nick=rustacean??
 [cn_org]: https://chat.rust-china.org/
-[community_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-community
-[crypto_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-crypto
-[de_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-de
-[es_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-es
-[embedded_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-embedded
-[fr_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-fr
-[gamedev_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-gamedev
-[internals_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
-[lang_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-lang
-[libs_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-libs
-[networking_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-networking
-[osdev_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-osdev
-[ru_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-ru
-[rust_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust
-[rustc_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
-[servo_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23servo
-[webdev_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-webdev
-[docs_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-docs
-[xi_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23xi
-[dev_tools_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-dev-tools
-[style_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23style
-[mod_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23mods
-[machine_learning_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-machine-learning
-[hyper_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23hyper
-[iron_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23iron
-[redox_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23redox
-[nom_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23nom
-[infra_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-infra
-[rustgeo_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-geo
-[rocket_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rocket
-[serde_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23serde
-[sci_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-sci
-[wasm_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-wasm
+[community_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-community?nick=rustacean??
+[crypto_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-crypto?nick=rustacean??
+[de_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-de?nick=rustacean??
+[es_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-es?nick=rustacean??
+[embedded_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-embedded?nick=rustacean??
+[fr_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-fr?nick=rustacean??
+[gamedev_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-gamedev?nick=rustacean??
+[internals_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-internals?nick=rustacean??
+[lang_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-lang?nick=rustacean??
+[libs_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-libs?nick=rustacean??
+[networking_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-networking?nick=rustacean??
+[osdev_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-osdev?nick=rustacean??
+[ru_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-ru?nick=rustacean??
+[rust_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust?nick=rustacean??
+[rustc_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rustc?nick=rustacean??
+[servo_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#servo?nick=rustacean??
+[webdev_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-webdev?nick=rustacean??
+[docs_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-docs?nick=rustacean??
+[xi_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#xi?nick=rustacean??
+[dev_tools_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-dev-tools?nick=rustacean??
+[style_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#style?nick=rustacean??
+[mod_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#mods?nick=rustacean??
+[machine_learning_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-machine-learning?nick=rustacean??
+[hyper_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#hyper?nick=rustacean??
+[iron_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#iron?nick=rustacean??
+[redox_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#redox?nick=rustacean??
+[nom_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#nom?nick=rustacean??
+[infra_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-infra?nick=rustacean??
+[rustgeo_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-geo?nick=rustacean??
+[rocket_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rocket?nick=rustacean??
+[serde_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#serde?nick=rustacean??
+[sci_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-sci?nick=rustacean??
+[wasm_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-wasm?nick=rustacean??
 
 ## Fóruns de Discussão
 

--- a/pt-BR/contribute-community.md
+++ b/pt-BR/contribute-community.md
@@ -57,8 +57,8 @@ conf talks
 Conduct training on Rust. (link to training material).
 -->
 
-[#rust-beginners]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-beginners
-[#rust-community]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-community
+[#rust-beginners]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-beginners?nick=rustacean??
+[#rust-community]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-community?nick=rustacean??
 [/r/rust]: https://reddit.com/r/rust
 [E-easy]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-easy
 [E-mentor]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-easy+label%3AE-mentor

--- a/pt-BR/contribute-compiler.md
+++ b/pt-BR/contribute-compiler.md
@@ -67,10 +67,10 @@ TODO: some of this RFC description could probably go in the RFC readme
 -->
 
 
-[#rust-internals]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
-[#rust-lang]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-lang
-[#rust-libs]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-libs
-[#rustc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
+[#rust-internals]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-internals?nick=rustacean??
+[#rust-lang]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-lang?nick=rustacean??
+[#rust-libs]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-libs?nick=rustacean??
+[#rustc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rustc?nick=rustacean??
 [A-codegen]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-codegen
 [A-debuginfo]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-debuginfo
 [A-diagnostics]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-diagnostics

--- a/pt-BR/contribute-docs.md
+++ b/pt-BR/contribute-docs.md
@@ -44,7 +44,7 @@ Conheça outros documentaristas de Rust em [#rust-docs].
 TODO: blogging, translation
 -->
 
-[#rust-docs]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-docs
+[#rust-docs]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-docs?nick=rustacean??
 [A-book]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-book
 [A-docs]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-docs
 [Rust By Example]: https://github.com/rust-lang/rust-by-example

--- a/pt-BR/contribute-libs.md
+++ b/pt-BR/contribute-libs.md
@@ -39,7 +39,7 @@ Encontre outros designers de bibliotecas Rust em [#rust-libs].
 TODO: Not sure #rust-libs is the place to direct people
 -->
 
-[#rust-libs]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-libs
+[#rust-libs]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-libs?nick=rustacean??
 [/r/rust]: https://reddit.com/r/rust
 [PistonDevelopers]: https://github.com/PistonDevelopers
 [Servo]: https://github.com/servo/servo

--- a/pt-BR/contribute-tools.md
+++ b/pt-BR/contribute-tools.md
@@ -27,8 +27,8 @@ Esses são, muitas vezes, outros projetos de ferramentas de seu interesse, apena
 pelas pessoas certas para chegarem e implementarem eles. Discuta com outros entusiastas
 de ferramentas para Rust em [#rust-tools].
 
-[#cargo]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
-[#rust-tools]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-tools
+[#cargo]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rustc?nick=rustacean??
+[#rust-tools]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-tools?nick=rustacean??
 [A-debuginfo]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-debuginfo
 [T-rustdoc]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AT-rustdoc
 [Cargo]: https://github.com/rust-lang/cargo/issues

--- a/pt-BR/contribute.md
+++ b/pt-BR/contribute.md
@@ -46,7 +46,7 @@ TODO: Write guide to advertising Rust projects to link from
 libs / community building
 -->
 
-[#rust-internals]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
+[#rust-internals]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-internals?nick=rustacean??
 [CONTRIBUTING.md]: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md
 [bugs]: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md#bug-reports
 [coc]: https://www.rust-lang.org/conduct.html

--- a/pt-BR/faq.md
+++ b/pt-BR/faq.md
@@ -116,7 +116,7 @@ How do I get help with Rust issues?
 There are several ways. You can:
 
 - Post in [users.rust-lang.org](https://users.rust-lang.org/), the official Rust users forum
-- Ask in the official [Rust IRC channel](https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust) (#rust on irc.mozilla.org)
+- Ask in the official [Rust IRC channel](https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust?nick=rustacean??) (#rust on irc.mozilla.org)
 - Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/rust) with the "rust" tag
 - Post in [/r/rust](https://www.reddit.com/r/rust), the unofficial Rust subreddit
 

--- a/ru-RU/community.md
+++ b/ru-RU/community.md
@@ -81,7 +81,7 @@ title: Сообщество Rust &middot; Язык Программирован�
 - [#rust-es][es_irc] es para una discusión general sobre Rust en español
 - [#rust-fr][fr_irc] est dédié à la programmation en Rust en français
 - [#rust-ru][ru_irc] для общих дискуссий о Rust на русском языке
-- [#rust-sv](https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-sv) är för allmän diskussion om Rust på svenska
+- [#rust-sv](https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-sv?nick=rustacean??) är för allmän diskussion om Rust på svenska
 
 ### Тематические каналы (англ.)
 
@@ -96,28 +96,28 @@ title: Сообщество Rust &middot; Язык Программирован�
 - [#servo][servo_irc] обсуждение Servo, браузерного движка, написанного на Rust
 
 [IRC]: https://en.wikipedia.org/wiki/Internet_Relay_Chat
-[beginners_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-beginners
-[bots_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-bots
-[br_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-br
-[cargo_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23cargo
-[community_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-community
-[crypto_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-crypto
-[de_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-de
-[es_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-es
-[fr_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-fr
-[gamedev_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-gamedev
-[internals_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
-[lang_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-lang
-[libs_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-libs
-[networking_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-networking
-[osdev_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-osdev
-[ru_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-ru
-[rust_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust
-[rustc_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
-[servo_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23servo
-[tools_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-tools
-[webdev_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-webdev
-[docs_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-docs
+[beginners_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-beginners?nick=rustacean??
+[bots_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-bots?nick=rustacean??
+[br_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-br?nick=rustacean??
+[cargo_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#cargo?nick=rustacean??
+[community_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-community?nick=rustacean??
+[crypto_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-crypto?nick=rustacean??
+[de_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-de?nick=rustacean??
+[es_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-es?nick=rustacean??
+[fr_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-fr?nick=rustacean??
+[gamedev_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-gamedev?nick=rustacean??
+[internals_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-internals?nick=rustacean??
+[lang_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-lang?nick=rustacean??
+[libs_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-libs?nick=rustacean??
+[networking_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-networking?nick=rustacean??
+[osdev_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-osdev?nick=rustacean??
+[ru_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-ru?nick=rustacean??
+[rust_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust?nick=rustacean??
+[rustc_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rustc?nick=rustacean??
+[servo_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#servo?nick=rustacean??
+[tools_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-tools?nick=rustacean??
+[webdev_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-webdev?nick=rustacean??
+[docs_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-docs?nick=rustacean??
 
 ## Форумы для обсуждения
 

--- a/ru-RU/contribute-tools.md
+++ b/ru-RU/contribute-tools.md
@@ -31,8 +31,8 @@ IRC-канале [#cargo].
 разработать тот или иной инструмент. Обсудить такие проекты с другими энтузиастами
 можно в [#rust-tools].
 
-[#cargo]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
-[#rust-tools]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-tools
+[#cargo]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rustc?nick=rustacean??
+[#rust-tools]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-tools?nick=rustacean??
 [A-debuginfo]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-debuginfo
 [T-rustdoc]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AT-rustdoc
 [Cargo]: https://github.com/rust-lang/cargo/issues

--- a/ru-RU/contribute.md
+++ b/ru-RU/contribute.md
@@ -48,7 +48,7 @@ TODO: Write guide to advertising Rust projects to link from
 libs / community building
 -->
 
-[#rust-internals]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
+[#rust-internals]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-internals?nick=rustacean??
 [CONTRIBUTING.md]: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md
 [bugs]: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md#bug-reports
 [coc]: https://www.rust-lang.org/conduct.html

--- a/sv-SE/community.md
+++ b/sv-SE/community.md
@@ -84,7 +84,7 @@ Rust-projektet.
 - [#rust-es][es_irc] es para una discusión general sobre Rust en español
 - [#rust-fr][fr_irc] est dédié à la programmation en Rust en français
 - [#rust-ru][ru_irc] для общих дискуссий о Rust на русском языке
-- [#rust-sv](https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-sv) är för allmän diskussion om Rust på svenska
+- [#rust-sv](https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-sv?nick=rustacean??) är för allmän diskussion om Rust på svenska
 - [Rust中文][cn_org] Rust 语言中文 Chat 社区(非IRC频道)
 
 ### Team-kanaler
@@ -126,45 +126,45 @@ av [modereringsteamet][mod_team].
 - [#xi][xi_irc] är för diskussion om Xi, texteditorn skriven i Rust
 
 [IRC]: https://en.wikipedia.org/wiki/Internet_Relay_Chat
-[beginners_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-beginners
-[bots_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-bots
-[br_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-br
-[cargo_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23cargo
+[beginners_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-beginners?nick=rustacean??
+[bots_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-bots?nick=rustacean??
+[br_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-br?nick=rustacean??
+[cargo_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#cargo?nick=rustacean??
 [cn_org]: https://chat.rust-china.org/
-[community_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-community
-[crypto_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-crypto
-[de_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-de
-[es_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-es
-[embedded_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-embedded
-[fr_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-fr
-[gamedev_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-gamedev
-[internals_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
-[lang_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-lang
-[libs_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-libs
-[networking_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-networking
-[osdev_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-osdev
-[ru_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-ru
-[rust_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust
-[rustc_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
-[servo_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23servo
-[webdev_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-webdev
-[docs_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-docs
-[xi_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23xi
-[dev_tools_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-dev-tools
-[style_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23style
+[community_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-community?nick=rustacean??
+[crypto_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-crypto?nick=rustacean??
+[de_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-de?nick=rustacean??
+[es_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-es?nick=rustacean??
+[embedded_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-embedded?nick=rustacean??
+[fr_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-fr?nick=rustacean??
+[gamedev_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-gamedev?nick=rustacean??
+[internals_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-internals?nick=rustacean??
+[lang_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-lang?nick=rustacean??
+[libs_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-libs?nick=rustacean??
+[networking_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-networking?nick=rustacean??
+[osdev_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-osdev?nick=rustacean??
+[ru_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-ru?nick=rustacean??
+[rust_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust?nick=rustacean??
+[rustc_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rustc?nick=rustacean??
+[servo_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#servo?nick=rustacean??
+[webdev_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-webdev?nick=rustacean??
+[docs_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-docs?nick=rustacean??
+[xi_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#xi?nick=rustacean??
+[dev_tools_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-dev-tools?nick=rustacean??
+[style_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#style?nick=rustacean??
 [style_team]: team.html#Style-team
-[mod_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23mods
-[machine_learning_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-machine-learning
-[hyper_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23hyper
-[iron_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23iron
-[redox_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23redox
-[nom_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23nom
-[infra_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-infra
-[rustgeo_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-geo
-[rocket_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rocket
-[serde_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23serde
-[sci_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-sci
-[wasm_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-wasm
+[mod_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#mods?nick=rustacean??
+[machine_learning_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-machine-learning?nick=rustacean??
+[hyper_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#hyper?nick=rustacean??
+[iron_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#iron?nick=rustacean??
+[redox_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#redox?nick=rustacean??
+[nom_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#nom?nick=rustacean??
+[infra_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-infra?nick=rustacean??
+[rustgeo_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-geo?nick=rustacean??
+[rocket_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rocket?nick=rustacean??
+[serde_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#serde?nick=rustacean??
+[sci_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-sci?nick=rustacean??
+[wasm_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-wasm?nick=rustacean??
 
 ## Diskussionsforum
 

--- a/sv-SE/contribute-community.md
+++ b/sv-SE/contribute-community.md
@@ -62,8 +62,8 @@ conf talks
 Conduct training on Rust. (link to training material).
 -->
 
-[#rust-beginners]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-beginners
-[#rust-community]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-community
+[#rust-beginners]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-beginners?nick=rustacean??
+[#rust-community]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-community?nick=rustacean??
 [/r/rust]: https://reddit.com/r/rust
 [E-easy]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-easy
 [E-mentor]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-easy+label%3AE-mentor

--- a/sv-SE/contribute-compiler.md
+++ b/sv-SE/contribute-compiler.md
@@ -78,10 +78,10 @@ TODO: some of this RFC description could probably go in the RFC readme
 -->
 
 
-[#rust-internals]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
-[#rust-lang]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-lang
-[#rust-libs]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-libs
-[#rustc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
+[#rust-internals]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-internals?nick=rustacean??
+[#rust-lang]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-lang?nick=rustacean??
+[#rust-libs]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-libs?nick=rustacean??
+[#rustc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rustc?nick=rustacean??
 [A-codegen]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-codegen
 [A-debuginfo]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-debuginfo
 [A-diagnostics]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-diagnostics

--- a/sv-SE/contribute-docs.md
+++ b/sv-SE/contribute-docs.md
@@ -50,7 +50,7 @@ Träffa andra människor som dokumenterar Rust i [#rust-docs].
 TODO: blogging, translation
 -->
 
-[#rust-docs]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-docs
+[#rust-docs]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-docs?nick=rustacean??
 [A-book]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-book
 [A-docs]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-docs
 [Rust By Example]: https://github.com/rust-lang/rust-by-example

--- a/sv-SE/contribute-libs.md
+++ b/sv-SE/contribute-libs.md
@@ -42,7 +42,7 @@ Träffa andra Rust-bibliotekdesigners i [#rust-libs].
 TODO: Not sure #rust-libs is the place to direct people
 -->
 
-[#rust-libs]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-libs
+[#rust-libs]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-libs?nick=rustacean??
 [/r/rust]: https://reddit.com/r/rust
 [PistonDevelopers]: https://github.com/PistonDevelopers
 [Servo]: https://github.com/servo/servo

--- a/sv-SE/contribute-tools.md
+++ b/sv-SE/contribute-tools.md
@@ -29,8 +29,8 @@ Det finns ofta flera intressanta verktygsprojekt som bara väntar på att rätt 
 ska dyka upp och implementera dem. Diskutera med andra Rust-verktygsentusiaster i
 [#rust-tools].
 
-[#cargo]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
-[#rust-tools]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-tools
+[#cargo]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rustc?nick=rustacean??
+[#rust-tools]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-tools?nick=rustacean??
 [A-debuginfo]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-debuginfo
 [T-rustdoc]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AT-rustdoc
 [Cargo]: https://github.com/rust-lang/cargo/issues

--- a/sv-SE/contribute.md
+++ b/sv-SE/contribute.md
@@ -48,7 +48,7 @@ TODO: Write guide to advertising Rust projects to link from
 libs / community building
 -->
 
-[#rust-internals]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
+[#rust-internals]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-internals?nick=rustacean??
 [CONTRIBUTING.md]: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md
 [bugs]: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md#bug-reports
 [coc]: https://www.rust-lang.org/conduct.html

--- a/sv-SE/faq.md
+++ b/sv-SE/faq.md
@@ -116,7 +116,7 @@ How do I get help with Rust issues?
 There are several ways. You can:
 
 - Post in [users.rust-lang.org](https://users.rust-lang.org/), the official Rust users forum
-- Ask in the official [Rust IRC channel](https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust) (#rust on irc.mozilla.org)
+- Ask in the official [Rust IRC channel](https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust?nick=rustacean??) (#rust on irc.mozilla.org)
 - Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/rust) with the "rust" tag
 - Post in [/r/rust](https://www.reddit.com/r/rust), the unofficial Rust subreddit
 

--- a/vi-VN/community.md
+++ b/vi-VN/community.md
@@ -77,7 +77,7 @@ nếu bạn đủ tự tin gia nhập core team và muốn vượt lên chính m
 - [#rust-es][es_irc] Rust ở Tây ban nha
 - [#rust-fr][fr_irc] Rust ở Pháp
 - [#rust-ru][ru_irc] Rust ở Nga
-- [#rust-sv](https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-sv) är för allmän diskussion om Rust på svenska
+- [#rust-sv](https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-sv?nick=rustacean??) är för allmän diskussion om Rust på svenska
 
 ### Các kênh chuyên đề
 
@@ -92,28 +92,28 @@ nếu bạn đủ tự tin gia nhập core team và muốn vượt lên chính m
 - [#servo][servo_irc] thảo luận về Servo -  trình duyệt được viết bằng Rust
 
 [IRC]: https://en.wikipedia.org/wiki/Internet_Relay_Chat
-[beginners_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-beginners
-[bots_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-bots
-[br_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-br
-[cargo_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23cargo
-[community_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-community
-[crypto_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-crypto
-[de_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-de
-[es_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-es
-[fr_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-fr
-[gamedev_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-gamedev
-[internals_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
-[lang_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-lang
-[libs_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-libs
-[networking_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-networking
-[osdev_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-osdev
-[ru_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-ru
-[rust_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust
-[rustc_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
-[servo_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23servo
-[tools_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-tools
-[webdev_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-webdev
-[docs_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-docs
+[beginners_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-beginners?nick=rustacean??
+[bots_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-bots?nick=rustacean??
+[br_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-br?nick=rustacean??
+[cargo_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#cargo?nick=rustacean??
+[community_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-community?nick=rustacean??
+[crypto_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-crypto?nick=rustacean??
+[de_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-de?nick=rustacean??
+[es_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-es?nick=rustacean??
+[fr_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-fr?nick=rustacean??
+[gamedev_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-gamedev?nick=rustacean??
+[internals_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-internals?nick=rustacean??
+[lang_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-lang?nick=rustacean??
+[libs_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-libs?nick=rustacean??
+[networking_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-networking?nick=rustacean??
+[osdev_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-osdev?nick=rustacean??
+[ru_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-ru?nick=rustacean??
+[rust_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust?nick=rustacean??
+[rustc_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rustc?nick=rustacean??
+[servo_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#servo?nick=rustacean??
+[tools_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-tools?nick=rustacean??
+[webdev_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-webdev?nick=rustacean??
+[docs_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-docs?nick=rustacean??
 
 ## Diễn đàn
 

--- a/vi-VN/contribute-community.md
+++ b/vi-VN/contribute-community.md
@@ -68,8 +68,8 @@ conf talks
 Conduct training on Rust. (link to training material).
 -->
 
-[#rust-beginners]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-beginners
-[#rust-community]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-community
+[#rust-beginners]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-beginners?nick=rustacean??
+[#rust-community]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-community?nick=rustacean??
 [/r/rust]: https://reddit.com/r/rust
 [E-easy]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-easy
 [E-mentor]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-easy+label%3AE-mentor

--- a/vi-VN/contribute-compiler.md
+++ b/vi-VN/contribute-compiler.md
@@ -79,10 +79,10 @@ TODO: some of this RFC description could probably go in the RFC readme
 -->
 
 
-[#rust-internals]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
-[#rust-lang]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-lang
-[#rust-libs]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-libs
-[#rustc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
+[#rust-internals]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-internals?nick=rustacean??
+[#rust-lang]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-lang?nick=rustacean??
+[#rust-libs]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-libs?nick=rustacean??
+[#rustc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rustc?nick=rustacean??
 [A-codegen]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-codegen
 [A-debuginfo]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-debuginfo
 [A-diagnostics]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-diagnostics

--- a/vi-VN/contribute-docs.md
+++ b/vi-VN/contribute-docs.md
@@ -49,7 +49,7 @@ Meet other Rust documentarians in [#rust-docs].
 TODO: blogging, translation
 -->
 
-[#rust-docs]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-docs
+[#rust-docs]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-docs?nick=rustacean??
 [A-book]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-book
 [A-docs]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-docs
 [Rust By Example]: https://github.com/rust-lang/rust-by-example

--- a/vi-VN/contribute-libs.md
+++ b/vi-VN/contribute-libs.md
@@ -45,7 +45,7 @@ Meet other Rust library designers in [#rust-libs].
 TODO: Not sure #rust-libs is the place to direct people
 -->
 
-[#rust-libs]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-libs
+[#rust-libs]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-libs?nick=rustacean??
 [/r/rust]: https://reddit.com/r/rust
 [PistonDevelopers]: https://github.com/PistonDevelopers
 [Servo]: https://github.com/servo/servo

--- a/vi-VN/contribute-tools.md
+++ b/vi-VN/contribute-tools.md
@@ -31,8 +31,8 @@ There are often other tooling projects of interest just waiting for
 the right people to come along and implement them. Discuss with other
 Rust tooling enthusiasts in [#rust-tools].
 
-[#cargo]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
-[#rust-tools]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-tools
+[#cargo]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rustc?nick=rustacean??
+[#rust-tools]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-tools?nick=rustacean??
 [A-debuginfo]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-debuginfo
 [T-rustdoc]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AT-rustdoc
 [Cargo]: https://github.com/rust-lang/cargo/issues

--- a/vi-VN/contribute.md
+++ b/vi-VN/contribute.md
@@ -33,7 +33,7 @@ TODO: Write guide to advertising Rust projects to link from
 libs / community building
 -->
 
-[#rust-internals]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
+[#rust-internals]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-internals?nick=rustacean??
 [CONTRIBUTING.md]: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md
 [bugs]: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md#bug-reports
 [coc]: https://www.rust-lang.org/conduct.html

--- a/vi-VN/faq.md
+++ b/vi-VN/faq.md
@@ -116,7 +116,7 @@ How do I get help with Rust issues?
 There are several ways. You can:
 
 - Post in [users.rust-lang.org](https://users.rust-lang.org/), the official Rust users forum
-- Ask in the official [Rust IRC channel](https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust) (#rust on irc.mozilla.org)
+- Ask in the official [Rust IRC channel](https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust?nick=rustacean??) (#rust on irc.mozilla.org)
 - Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/rust) with the "rust" tag
 - Post in [/r/rust](https://www.reddit.com/r/rust), the unofficial Rust subreddit
 

--- a/zh-CN/community.md
+++ b/zh-CN/community.md
@@ -61,7 +61,7 @@ Rust 开发者们在 [#rust-internals][internals_irc] 上协作。此频道中�
 - [#rust-es][es_irc] es para una discusión general sobre Rust en español
 - [#rust-fr][fr_irc] est dédié à la programmation en Rust en français
 - [#rust-ru][ru_irc] для общих дискуссий о Rust на русском языке
-- [#rust-sv](https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-sv) är för allmän diskussion om Rust på svenska
+- [#rust-sv](https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-sv?nick=rustacean??) är för allmän diskussion om Rust på svenska
 - [Rust中文][cn_org] Rust 语言中文 Chat 社区(非IRC频道)
 
 ### 团队频道
@@ -101,45 +101,45 @@ Rust 开发者们在 [#rust-internals][internals_irc] 上协作。此频道中�
 - [#xi][xi_irc] 用于讨论 Xi，一个用 Rust 编写的文本编辑器
 
 [IRC]: https://en.wikipedia.org/wiki/Internet_Relay_Chat
-[beginners_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-beginners
-[bots_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-bots
-[br_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-br
-[cargo_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23cargo
+[beginners_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-beginners?nick=rustacean??
+[bots_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-bots?nick=rustacean??
+[br_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-br?nick=rustacean??
+[cargo_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#cargo?nick=rustacean??
 [cn_org]: https://chat.rust-china.org/
-[community_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-community
-[crypto_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-crypto
-[de_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-de
-[es_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-es
-[embedded_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-embedded
-[fr_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-fr
-[gamedev_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-gamedev
-[internals_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
-[lang_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-lang
-[libs_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-libs
-[networking_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-networking
-[osdev_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-osdev
-[ru_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-ru
-[rust_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust
-[rustc_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
-[servo_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23servo
-[webdev_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-webdev
-[docs_irc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-docs
-[xi_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23xi
-[dev_tools_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-dev-tools
-[style_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23style
+[community_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-community?nick=rustacean??
+[crypto_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-crypto?nick=rustacean??
+[de_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-de?nick=rustacean??
+[es_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-es?nick=rustacean??
+[embedded_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-embedded?nick=rustacean??
+[fr_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-fr?nick=rustacean??
+[gamedev_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-gamedev?nick=rustacean??
+[internals_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-internals?nick=rustacean??
+[lang_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-lang?nick=rustacean??
+[libs_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-libs?nick=rustacean??
+[networking_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-networking?nick=rustacean??
+[osdev_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-osdev?nick=rustacean??
+[ru_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-ru?nick=rustacean??
+[rust_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust?nick=rustacean??
+[rustc_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rustc?nick=rustacean??
+[servo_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#servo?nick=rustacean??
+[webdev_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-webdev?nick=rustacean??
+[docs_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-docs?nick=rustacean??
+[xi_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#xi?nick=rustacean??
+[dev_tools_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-dev-tools?nick=rustacean??
+[style_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#style?nick=rustacean??
 [style_team]: team.html#Style-team
-[mod_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23mods
-[machine_learning_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-machine-learning
-[hyper_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23hyper
-[iron_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23iron
-[redox_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23redox
-[nom_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23nom
-[infra_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-infra
-[rustgeo_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-geo
-[rocket_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rocket
-[serde_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23serde
-[sci_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-sci
-[wasm_irc]: https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-wasm
+[mod_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#mods?nick=rustacean??
+[machine_learning_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-machine-learning?nick=rustacean??
+[hyper_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#hyper?nick=rustacean??
+[iron_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#iron?nick=rustacean??
+[redox_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#redox?nick=rustacean??
+[nom_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#nom?nick=rustacean??
+[infra_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-infra?nick=rustacean??
+[rustgeo_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-geo?nick=rustacean??
+[rocket_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rocket?nick=rustacean??
+[serde_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#serde?nick=rustacean??
+[sci_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-sci?nick=rustacean??
+[wasm_irc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-wasm?nick=rustacean??
 
 ## 论坛
 

--- a/zh-CN/contribute-community.md
+++ b/zh-CN/contribute-community.md
@@ -63,8 +63,8 @@ conf talks
 Conduct training on Rust. (link to training material).
 -->
 
-[#rust-beginners]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-beginners
-[#rust-community]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-community
+[#rust-beginners]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-beginners?nick=rustacean??
+[#rust-community]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-community?nick=rustacean??
 [/r/rust]: https://reddit.com/r/rust
 [E-easy]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-easy
 [E-mentor]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-easy+label%3AE-mentor

--- a/zh-CN/contribute-compiler.md
+++ b/zh-CN/contribute-compiler.md
@@ -77,10 +77,10 @@ TODO: some of this RFC description could probably go in the RFC readme
 -->
 
 
-[#rust-internals]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
-[#rust-lang]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-lang
-[#rust-libs]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-libs
-[#rustc]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
+[#rust-internals]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-internals?nick=rustacean??
+[#rust-lang]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-lang?nick=rustacean??
+[#rust-libs]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-libs?nick=rustacean??
+[#rustc]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rustc?nick=rustacean??
 [A-codegen]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-codegen
 [A-debuginfo]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-debuginfo
 [A-diagnostics]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-diagnostics

--- a/zh-CN/contribute-docs.md
+++ b/zh-CN/contribute-docs.md
@@ -49,7 +49,7 @@ For other existing documentation projects to contribute to see [rust-learning].
 TODO: blogging, translation
 -->
 
-[#rust-docs]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-docs
+[#rust-docs]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-docs?nick=rustacean??
 [A-book]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-book
 [A-docs]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-docs
 [Rust By Example]: https://github.com/rust-lang/rust-by-example

--- a/zh-CN/contribute-libs.md
+++ b/zh-CN/contribute-libs.md
@@ -39,7 +39,7 @@ title: 为 Rust 出力 &mdash; 库 &middot; Rust 程序设计语言
 TODO: Not sure #rust-libs is the place to direct people
 -->
 
-[#rust-libs]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-libs
+[#rust-libs]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-libs?nick=rustacean??
 [/r/rust]: https://reddit.com/r/rust
 [PistonDevelopers]: https://github.com/PistonDevelopers
 [Servo]: https://github.com/servo/servo

--- a/zh-CN/contribute-tools.md
+++ b/zh-CN/contribute-tools.md
@@ -15,8 +15,8 @@ Rust 包管理器 Cargo，Rust 文档生成器 rustdoc，虽然功能齐全且�
 
 通常还有其它有意思的工具项目，只是在等待合适的人来实现。在 [#rust-tools] 与其它 Rust 工具爱好者讨论。
 
-[#cargo]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rustc
-[#rust-tools]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-tools
+[#cargo]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rustc?nick=rustacean??
+[#rust-tools]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-tools?nick=rustacean??
 [A-debuginfo]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-debuginfo
 [T-rustdoc]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AT-rustdoc
 [Cargo]: https://github.com/rust-lang/cargo/issues

--- a/zh-CN/contribute.md
+++ b/zh-CN/contribute.md
@@ -44,7 +44,7 @@ TODO: Write guide to advertising Rust projects to link from
 libs / community building
 -->
 
-[#rust-internals]: https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals
+[#rust-internals]: https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust-internals?nick=rustacean??
 [CONTRIBUTING.md]: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md
 [bugs]: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md#bug-reports
 [coc]: https://www.rust-lang.org/conduct.html

--- a/zh-CN/faq.md
+++ b/zh-CN/faq.md
@@ -117,7 +117,7 @@ TODO: Write this answer.
 那有很多种方式。你可以尝试：
 
 - 在 [users.rust-lang.org](https://users.rust-lang.org/) 发帖，这是官方的 Rust 用户论坛
-- 在官方的 [Rust IRC 频道](https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust)提问（irc.mozilla.org 上的 #rust）
+- 在官方的 [Rust IRC 频道](https://kiwiirc.com/nextclient/#ircs://irc.mozilla.org:6697/#rust?nick=rustacean??)提问（irc.mozilla.org 上的 #rust）
 - 在 [Stack Overflow](https://stackoverflow.com/questions/tagged/rust) 提问，加上「rust」tag
 - 在 [/r/rust](https://www.reddit.com/r/rust) 发帖，这是非官方的 Rust 板块
 


### PR DESCRIPTION
Mibbit is currently a pita for everyone:

- it serves ads
- is unusable on small screens
- it's broken (pastes)

Thus Kiwiirc seems to be a good alternative.