### PR TITLE
Add MadRust meetup in Madrid and clean old one

### DIFF
--- a/_data/usergroups.yml
+++ b/_data/usergroups.yml
@@ -365,9 +365,9 @@
 - country: Spain
   meetups:
 
-    - name: Rust Madrid
+    - name: MadRust
       city: Madrid
-      url: https://github.com/rustmadrid
+      url: https://www.meetup.com/MadRust/
 
     - name: Rust Barcelona
       city: Barcelona


### PR DESCRIPTION
Hi :wave:  from Rustaceans in Madrid! We've already organized a few gatherings but forgot to add ourselves to this page :slightly_smiling_face: 

Re: the old Madrid meetup: as far as I can tell, the old meetup is no longer active (the [Meetup URL](http://meetup.com/Rust-Madrid) listed in the [Github profile](https://github.com/rustmadrid) does not exist anymore).