### PR TITLE
Set z-index of flash message to fix #1246

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -236,6 +236,7 @@ ul.laundry-list {
 		top: 0;
 		right: 0;
 		border: 0;
+		z-index: 2;
     width: 149px;
     height: 149px;
 	}

--- a/css/style.css
+++ b/css/style.css
@@ -794,6 +794,7 @@ h1.rustup {
   top: 0;
   left: 0;
   padding: 20px 0;
+  z-index: 1;
 }
 
 .flash a {


### PR DESCRIPTION
The flash message box is positioned fix. A z-index > 0 need to be set to lift the box above the content when the page is scrolled.